### PR TITLE
VirtualBox bailout

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -91,7 +91,7 @@ func (d *Driver) Create() error {
 		isoURL string
 	)
 
-	if err = vbm("--version"); err != nil {
+	if err = vbm(""); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
As per #27, I've set VirtualBox to bailout quicker if VBoxManage isn't available in the `$PATH`.
