### PR TITLE
Fix test for VBoxManage

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -92,7 +92,7 @@ func (d *Driver) Create() error {
 	)
 
 	// Check that VBoxManage exists and works
-	if err = vbm(""); err != nil {
+	if err = vbm(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The test was failing with an error from vboxmanage `Syntax error: Invalid command ''`
