### PR TITLE
Ensure `script/validate-gofmt` is executed with bash

### DIFF
--- a/script/validate-gofmt
+++ b/script/validate-gofmt
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source "$(dirname "$BASH_SOURCE")/.validate"
 
 IFS=$'\n'


### PR DESCRIPTION
While Travis does that, a user just running the script will get an
error.

Signed-off-by: Vincent Bernat Vincent.Bernat@exoscale.ch
