### PR TITLE
Sort `machine ls` output by machine name

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/docker/machine/drivers/digitalocean"
 	_ "github.com/docker/machine/drivers/none"
 	_ "github.com/docker/machine/drivers/virtualbox"
+	"github.com/docker/machine/state"
 )
 
 type DockerCli struct{}
@@ -91,6 +92,28 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 	flag.Usage()
 
 	return nil
+}
+
+type HostListItem struct {
+	Name       string
+	Active     bool
+	DriverName string
+	State      state.State
+	URL        string
+}
+
+type HostListItemByName []HostListItem
+
+func (h HostListItemByName) Len() int {
+	return len(h)
+}
+
+func (h HostListItemByName) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h HostListItemByName) Less(i, j int) bool {
+	return strings.ToLower(h[i].Name) < strings.ToLower(h[j].Name)
 }
 
 func (cli *DockerCli) CmdLs(args ...string) error {

--- a/host.go
+++ b/host.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/machine/drivers"
-	"github.com/docker/machine/state"
 )
 
 var (
@@ -24,28 +22,6 @@ type Host struct {
 	DriverName string
 	Driver     drivers.Driver
 	storePath  string
-}
-
-type HostListItem struct {
-	Name       string
-	Active     bool
-	DriverName string
-	State      state.State
-	URL        string
-}
-
-type HostListItemByName []HostListItem
-
-func (h HostListItemByName) Len() int {
-	return len(h)
-}
-
-func (h HostListItemByName) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-}
-
-func (h HostListItemByName) Less(i, j int) bool {
-	return strings.ToLower(h[i].Name) < strings.ToLower(h[j].Name)
 }
 
 type hostConfig struct {


### PR DESCRIPTION
At the moment in the `machine ls` output, the order of appearance of the machines is not predictable due to go routine implementation.

This pull request fix this, sorting machine by names (case insensitive).
