### PR TITLE
Fix bug SSH interactive mode

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -373,7 +374,12 @@ var Commands = []cli.Command{
 				os.Exit(1)
 			}
 
-			sshCmd, err := host.Driver.GetSSHCommand(c.String("command"))
+			var sshCmd *exec.Cmd
+			if c.String("command") == "" {
+				sshCmd, err = host.Driver.GetSSHCommand()
+			} else {
+				sshCmd, err = host.Driver.GetSSHCommand(c.String("command"))
+			}
 			if err != nil {
 				log.Errorf("%s", err)
 				os.Exit(1)


### PR DESCRIPTION
Commit b44db20 introduced a bug that broke the SSH interactive mode. If no command is provided, `Driver.GetSSHCommand` is called with an empty string instead of no parameter.
