### PR TITLE
Allow optional override of OS and arch in build (speed up compilation)

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,5 +1,12 @@
 #!/bin/sh
 set -e
+
+if [ -z "$1" ]; then
+    OS_ARCH_ARG=(-os="darwin linux windows")
+else
+    OS_ARCH_ARG=($1)
+fi
+
 rm -f machine_*
 docker build -t docker-machine .
-exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox -os="darwin linux windows"
+exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_ARCH_ARG[@]}"


### PR DESCRIPTION
With this change machine will still cross-compile for all supported OSes
/ archs by default, but allows user to customize args to the build
script.

For instance, I am only interested in building for `darwin/amd64`, so I can speed up the build of a `machine` binary 5x using this method.  @bfirsh PTAL

Example:

```
$ time ./script/build
Sending build context to Docker daemon 4.068 MB
Sending build context to Docker daemon
Step 0 : FROM golang:1.3-cross
 ---> 1ac906b28604
Step 1 : RUN go get github.com/mitchellh/gox
 ---> Using cache
 ---> c690364e7e44
Step 2 : RUN go get github.com/aktau/github-release
 ---> Using cache
 ---> 18abdba658f0
Step 3 : ENV GOPATH /go/src/github.com/docker/machine/Godeps/_workspace:/go
 ---> Using cache
 ---> 945a70f68cdd
Step 4 : WORKDIR /go/src/github.com/docker/machine
 ---> Using cache
 ---> c1afadf9d069
Step 5 : ADD . /go/src/github.com/docker/machine
 ---> Using cache
 ---> 17c2bca442ed
Successfully built 17c2bca442ed
Number of parallel builds: 8

-->      darwin/386: github.com/docker/machine
-->    darwin/amd64: github.com/docker/machine
-->       linux/386: github.com/docker/machine
-->     linux/amd64: github.com/docker/machine
-->       linux/arm: github.com/docker/machine
-->     windows/386: github.com/docker/machine
-->   windows/amd64: github.com/docker/machine

real    0m26.952s
user    0m0.367s
sys     0m0.061s

$ time ./script/build -osarch="darwin/amd64"
Sending build context to Docker daemon 4.068 MB
Sending build context to Docker daemon
Step 0 : FROM golang:1.3-cross
 ---> 1ac906b28604
Step 1 : RUN go get github.com/mitchellh/gox
 ---> Using cache
 ---> c690364e7e44
Step 2 : RUN go get github.com/aktau/github-release
 ---> Using cache
 ---> 18abdba658f0
Step 3 : ENV GOPATH /go/src/github.com/docker/machine/Godeps/_workspace:/go
 ---> Using cache
 ---> 945a70f68cdd
Step 4 : WORKDIR /go/src/github.com/docker/machine
 ---> Using cache
 ---> c1afadf9d069
Step 5 : ADD . /go/src/github.com/docker/machine
 ---> Using cache
 ---> 17c2bca442ed
Successfully built 17c2bca442ed
Number of parallel builds: 8

-->    darwin/amd64: github.com/docker/machine

real    0m5.297s
user    0m0.368s
sys     0m0.062s
```

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
