### PR TITLE
A few additions to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 machine*
+.git


### PR DESCRIPTION
The most important of these is .git, which will eventually grow to
astronomical sizes as the repo chugs along.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
