### PR TITLE
fixes #108: persist identity keys in b2d

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -281,11 +281,42 @@ func (d *Driver) Create() error {
 
 	log.Debugf("Adding key to authorized-keys.d...")
 
-	if err := drivers.AddPublicKeyToAuthorizedHosts(d, "/root/.docker/authorized-keys.d"); err != nil {
+	cmd, err := d.GetSSHCommand("sudo mkdir -p /var/lib/boot2docker/.docker && sudo chown -R docker /var/lib/boot2docker/.docker")
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 
-	cmd, err := d.GetSSHCommand("sudo /etc/init.d/docker restart")
+	if err := drivers.AddPublicKeyToAuthorizedHosts(d, "/var/lib/boot2docker/.docker/authorized-keys.d"); err != nil {
+		return err
+	}
+
+	// HACK: configure docker to use persisted auth
+	cmd, err = d.GetSSHCommand("echo DOCKER_TLS=no | sudo tee -a /var/lib/boot2docker/profile")
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	extraArgs := `EXTRA_ARGS='--auth=identity 
+        --auth-authorized-dir=/var/lib/boot2docker/.docker/authorized-keys.d 
+        --auth-known-hosts=/var/lib/boot2docker/.docker/known-hosts.json 
+        --identity=/var/lib/boot2docker/.docker/key.json
+        -H tcp://0.0.0.0:2376'`
+	sshCmd := fmt.Sprintf("echo \"%s\" | sudo tee -a /var/lib/boot2docker/profile", extraArgs)
+	cmd, err = d.GetSSHCommand(sshCmd)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	cmd, err = d.GetSSHCommand("sudo /etc/init.d/docker restart")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This changes where the identity keys are stored in b2d.  This persists through reboots and stop/starts.

Note: I also created a new b2d iso for testing as the current one had issues with TLS and ports.

ISO: https://ehazlett.s3.amazonaws.com/public/boot2docker/boot2docker-machine-87e3813.iso

```
machine create -d virtualbox
    --virtualbox-boot2docker-url https://ehazlett.s3.amazonaws.com/public/boot2docker/boot2docker-machine-87e3813.iso 
    machine-test
```
