### PR TITLE
wip: standardize install and configuration of docker

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -9,8 +9,8 @@
 		},
 		{
 			"ImportPath": "github.com/MSOpenTech/azure-sdk-for-go",
-			"Comment": "v1.1-14-g814812a",
-			"Rev": "515f3ec74ce6a5b31e934cefae997c97bd0a1b1e"
+			"Comment": "v1.1-18-g04b7424",
+			"Rev": "04b7424287fb24e2c03315d7cce4dd4834e3c3b5"
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",

--- a/Godeps/_workspace/src/github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient/entities.go
+++ b/Godeps/_workspace/src/github.com/MSOpenTech/azure-sdk-for-go/clients/vmClient/entities.go
@@ -100,6 +100,7 @@ type ConfigurationSet struct {
 	DisableSshPasswordAuthentication bool
 	InputEndpoints                   InputEndpoints `xml:",omitempty"`
 	SSH                              SSH            `xml:",omitempty"`
+	CustomData                       string         `xml:",omitempty"`
 }
 
 type SSH struct {

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -23,7 +23,7 @@ import (
 const (
 	driverName          = "amazonec2"
 	defaultRegion       = "us-east-1"
-	defaultAMI          = "ami-a00461c8"
+	defaultAMI          = "ami-4ae27e22"
 	defaultInstanceType = "t2.micro"
 	defaultRootSize     = 16
 	ipRange             = "0.0.0.0/0"

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -376,7 +376,7 @@ func (d *Driver) Upgrade() error {
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
-	return ssh.GetSSHCommand(d.IPAddress, 22, d.GetSSHUser(), d.sshKeyPath(), args...), nil
+	return ssh.GetSSHCommand(d.IPAddress, d.GetSSHPort(), d.GetSSHUser(), d.sshKeyPath(), args...), nil
 }
 
 func (d *Driver) getClient() *amz.EC2 {
@@ -480,8 +480,8 @@ func (d *Driver) createSecurityGroup() (*amz.SecurityGroup, error) {
 	perms := []amz.IpPermission{
 		{
 			Protocol: "tcp",
-			FromPort: 22,
-			ToPort:   22,
+			FromPort: d.GetSSHPort(),
+			ToPort:   d.GetSSHPort(),
 			IpRange:  ipRange,
 		},
 		{

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -219,85 +218,9 @@ func (d *Driver) Create() error {
 		d.InstanceId,
 		d.IPAddress)
 
-	log.Infof("Waiting for SSH...")
-
-	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", d.IPAddress, 22)); err != nil {
+	if err := drivers.InstallDocker(d.IPAddress, 22, "ubuntu", d.sshKeyPath()); err != nil {
 		return err
 	}
-
-	log.Debugf("Installing Docker")
-
-	cmd, err := d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sudo sh -; fi")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	cmd, err = d.GetSSHCommand("sudo stop docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	log.Debugf("HACK: Downloading version of Docker with identity auth...")
-
-	cmd, err = d.GetSSHCommand("sudo curl -sS -o /usr/bin/docker https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	log.Debugf("Updating /etc/default/docker to use identity auth...")
-
-	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376 --host=unix:///var/run/docker.sock --auth-authorized-dir=/root/.docker/authorized-keys.d\"' | sudo tee -a /etc/default/docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	// HACK: create dir for ubuntu user to access
-	log.Debugf("Adding key to authorized-keys.d...")
-
-	cmd, err = d.GetSSHCommand("sudo mkdir -p /root/.docker && sudo chown -R ubuntu /root/.docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	f, err := os.Open(filepath.Join(os.Getenv("HOME"), ".docker/public-key.json"))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	cmdString := fmt.Sprintf("sudo mkdir -p %q && sudo tee -a %q", "/root/.docker/authorized-keys.d", "/root/.docker/authorized-keys.d/docker-host.json")
-	cmd, err = d.GetSSHCommand(cmdString)
-	if err != nil {
-		return err
-	}
-	cmd.Stdin = f
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	cmd, err = d.GetSSHCommand("sudo start docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -163,7 +163,7 @@ func (e *EC2) awsApiCall(v url.Values) (http.Response, error) {
 	return *resp, nil
 }
 
-func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping) (EC2Instance, error) {
+func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, userData string) (EC2Instance, error) {
 	instance := Instance{}
 	v := url.Values{}
 	v.Set("Action", "RunInstances")
@@ -173,6 +173,7 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 	v.Set("MaxCount", strconv.Itoa(maxCount))
 	v.Set("KeyName", keyName)
 	v.Set("InstanceType", instanceType)
+	v.Set("UserData", userData)
 	v.Set("NetworkInterface.0.DeviceIndex", "0")
 	v.Set("NetworkInterface.0.SecurityGroupId.0", securityGroup)
 	v.Set("NetworkInterface.0.SubnetId", subnetId)

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -141,51 +141,7 @@ func (d *Driver) Create() error {
 		newDroplet.Droplet.ID,
 		d.IPAddress)
 
-	log.Infof("Waiting for SSH...")
-
-	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", d.IPAddress, 22)); err != nil {
-		return err
-	}
-
-	log.Debugf("HACK: Downloading version of Docker with identity auth...")
-
-	cmd, err := d.GetSSHCommand("stop docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	cmd, err = d.GetSSHCommand("curl -sS https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity > /usr/bin/docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	log.Debugf("Updating /etc/default/docker to use identity auth...")
-
-	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376\"' >> /etc/default/docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	log.Debugf("Adding key to authorized-keys.d...")
-
-	if err := drivers.AddPublicKeyToAuthorizedHosts(d, "/.docker/authorized-keys.d"); err != nil {
-		return err
-	}
-
-	cmd, err = d.GetSSHCommand("start docker")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
+	if err := drivers.InstallDocker(d.IPAddress, 22, "root", d.sshKeyPath()); err != nil {
 		return err
 	}
 

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -50,7 +50,7 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "DIGITALOCEAN_IMAGE",
 			Name:   "digitalocean-image",
 			Usage:  "Digital Ocean Image",
-			Value:  "docker",
+			Value:  "ubuntu-14-04-x64",
 		},
 		cli.StringFlag{
 			EnvVar: "DIGITALOCEAN_REGION",

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -173,7 +173,7 @@ func GetCloudConfig(driver Driver) (string, error) {
 
 	encodedKey := base64.StdEncoding.EncodeToString(key)
 
-	dockerOpts := fmt.Sprintf("DOCKER_OPTS=\"--auth=%s --host=%s --auth-authorized-dir=%s\"",
+	dockerOpts := fmt.Sprintf("DOCKER_OPTS=\"--auth=%s --host unix:// --host=%s --auth-authorized-dir=%s\"",
 		machineOpts.Auth, machineOpts.Host, machineOpts.AuthorizedDir)
 
 	buf := bytes.NewBufferString(dockerOpts)

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -1,10 +1,16 @@
 package drivers
 
 import (
+	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
+	"text/template"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/state"
@@ -28,6 +34,15 @@ type Driver interface {
 	// GetIP returns an IP or hostname that this host is available at
 	// e.g. 1.2.3.4 or docker-host-d60b70a14d3a.cloudapp.net
 	GetIP() (string, error)
+
+	// GetSSHUser returns the user for ssh
+	GetSSHUser() string
+
+	// GetSSHPort returns the port for ssh
+	GetSSHPort() int
+
+	// GetMachineOptions returns the machine options for the driver
+	GetMachineOptions() (*MachineOptions, error)
 
 	// GetState returns the state that the host is in (running, stopped, etc)
 	GetState() (state.State, error)
@@ -58,6 +73,11 @@ type Driver interface {
 	// and keys for the host with args appended. If no args are passed, it will
 	// initiate an interactive SSH session as if SSH were passed no args.
 	GetSSHCommand(args ...string) (*exec.Cmd, error)
+}
+
+type CloudConfigOptions struct {
+	PublicKey  string
+	DockerOpts string
 }
 
 // RegisteredDriver is used to register a driver with the Register function.
@@ -131,4 +151,80 @@ type DriverOptions interface {
 	String(key string) string
 	Int(key string) int
 	Bool(key string) bool
+}
+
+// GetDefaultCloudConfig returns a default cloudconfig script
+func GetCloudConfig(driver Driver) (string, error) {
+	f, err := os.Open(filepath.Join(os.Getenv("HOME"), ".docker/public-key.json"))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	key, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	machineOpts, err := driver.GetMachineOptions()
+	if err != nil {
+		return "", err
+	}
+
+	encodedKey := base64.StdEncoding.EncodeToString(key)
+
+	dockerOpts := fmt.Sprintf("DOCKER_OPTS=\"--auth=%s --host=%s --auth-authorized-dir=%s\"",
+		machineOpts.Auth, machineOpts.Host, machineOpts.AuthorizedDir)
+
+	buf := bytes.NewBufferString(dockerOpts)
+
+	encodedDockerOpts := base64.StdEncoding.EncodeToString(buf.Bytes())
+
+	cloudConfigOpts := &CloudConfigOptions{
+		PublicKey:  encodedKey,
+		DockerOpts: encodedDockerOpts,
+	}
+
+	// so for the life of me I cannot get the following to work
+	// with cloud-init in DigitalOcean ubuntu 14.04.  therefore,
+	// I have to do it manually to add the keys.
+	//
+	var tmpl bytes.Buffer
+	t := template.Must(template.New("machine-cloud-config").Parse(`#cloud-config
+apt_update: true
+apt_sources:
+ - source: "deb https://get.docker.com/ubuntu docker main"
+   filename: docker.list
+   keyserver: keyserver.ubuntu.com
+   keyid: A88D21E9
+
+package_update: true
+
+packages:
+ - lxc-docker
+
+write_files:
+ - encoding: base64
+   content: {{.DockerOpts}}
+   path: /etc/default/docker
+   permissions: 0644
+
+ - encoding: base64
+   content: {{.PublicKey}}
+   path: /root/.docker/authorized-keys.d/docker-host.json
+   permissions: 0600
+
+runcmd:
+ - [ curl, -sS, "https://bfirsh.s3.amazonaws.com/docker/docker-1.3.1-dev-identity-auth", "-o", /usr/bin/docker ]
+ - [ stop, docker ]
+ - [ start, docker ]
+
+final_message: "Docker Machine provisioning complete"
+    `))
+
+	if err := t.Execute(&tmpl, cloudConfigOpts); err != nil {
+		return "", err
+	}
+
+	return tmpl.String(), nil
 }

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -57,12 +57,24 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
+func (d *Driver) GetMachineOptions() (*drivers.MachineOptions, error) {
+	return nil, nil
+}
+
 func (d *Driver) GetURL() (string, error) {
 	return d.URL, nil
 }
 
 func (d *Driver) GetIP() (string, error) {
 	return "", nil
+}
+
+func (d *Driver) GetSSHUser() string {
+	return ""
+}
+
+func (d *Driver) GetSSHPort() int {
+	return -1
 }
 
 func (d *Driver) GetState() (state.State, error) {

--- a/drivers/options.go
+++ b/drivers/options.go
@@ -1,0 +1,9 @@
+package drivers
+
+type MachineOptions struct {
+	Auth          string
+	Host          string
+	AuthorizedDir string
+	Labels        []string
+	PublicKey     string
+}

--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -3,8 +3,12 @@ package drivers
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/machine/ssh"
 )
 
 func GetHomeDir() string {
@@ -46,4 +50,74 @@ func PublicKeyExists() (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+func InstallDocker(host string, port int, user string, sshKey string) error {
+	sshCmd := func(args ...string) *exec.Cmd {
+		return ssh.GetSSHCommand(host, port, user, sshKey, args...)
+	}
+
+	log.Infof("Waiting for SSH...")
+
+	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", host, port)); err != nil {
+		return err
+	}
+
+	cmd := sshCmd("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sudo sh -; fi")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	cmd = sshCmd("sudo stop docker")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	log.Debugf("HACK: Downloading version of Docker with identity auth...")
+
+	cmd = sshCmd("sudo curl -sS -o /usr/bin/docker https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	log.Debugf("Updating /etc/default/docker to use identity auth...")
+
+	cmd = sshCmd("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376 --host=unix:///var/run/docker.sock --auth-authorized-dir=/root/.docker/authorized-keys.d\"' | sudo tee -a /etc/default/docker")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	log.Debugf("Adding key to authorized-keys.d...")
+
+	// HACK: temporarily chown to ssh user for providers using non-root accounts
+	cmd = sshCmd(fmt.Sprintf("sudo mkdir -p /root/.docker && sudo chown -R %s /root/.docker", user))
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	f, err := os.Open(filepath.Join(os.Getenv("HOME"), ".docker/public-key.json"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	cmdString := fmt.Sprintf("sudo mkdir -p %q && sudo tee -a %q", "/root/.docker/authorized-keys.d", "/root/.docker/authorized-keys.d/docker-host.json")
+	cmd = sshCmd(cmdString)
+	cmd.Stdin = f
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// HACK: change back ownership
+	cmd = sshCmd("sudo mkdir -p /root/.docker && sudo chown -R root /root/.docker")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	cmd = sshCmd("sudo start docker")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -29,6 +29,7 @@ import (
 type Driver struct {
 	MachineName    string
 	SSHPort        int
+	SSHUser        string
 	Memory         int
 	DiskSize       int
 	Boot2DockerURL string
@@ -75,6 +76,10 @@ func NewDriver(storePath string) (drivers.Driver, error) {
 	return &Driver{storePath: storePath}, nil
 }
 
+func (d *Driver) GetMachineOptions() (*drivers.MachineOptions, error) {
+	return nil, nil
+}
+
 func (d *Driver) DriverName() string {
 	return "virtualbox"
 }
@@ -94,6 +99,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Memory = flags.Int("virtualbox-memory")
 	d.DiskSize = flags.Int("virtualbox-disk-size")
 	d.Boot2DockerURL = flags.String("virtualbox-boot2docker-url")
+	d.SSHUser = "tcuser"
 	return nil
 }
 
@@ -512,6 +518,14 @@ func (d *Driver) GetIP() (string, error) {
 	}
 
 	return "", fmt.Errorf("No IP address found %s", out)
+}
+
+func (d *Driver) GetSSHUser() string {
+	return d.SSHUser
+}
+
+func (d *Driver) GetSSHPort() int {
+	return d.SSHPort
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -63,10 +63,11 @@ func WaitForTCP(addr string) error {
 		if err != nil {
 			continue
 		}
-		defer conn.Close()
 		if _, err = conn.Read(make([]byte, 1)); err != nil {
+			conn.Close()
 			continue
 		}
+		conn.Close()
 		break
 	}
 	return nil


### PR DESCRIPTION
This makes the default OS Ubuntu 14.04 amd64 and uses a "standard" method of installing and configuring Docker.  This will handle installing Docker as well as setting the default options to be unified across providers.  It also makes for an easier upgrade path as drivers simply need to call `InstallDocker`.

Drivers implemented and testing:

- [x] Amazon EC2
- [x] DigitalOcean
- [x] Azure
- [ ] Google
- [ ] vCloud Air
- [ ] Softlayer
- [ ] Rackspace