### PR TITLE
Configurable storage path

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -50,7 +50,7 @@ var Commands = []cli.Command{
 		Usage: "Get or set the active machine",
 		Action: func(c *cli.Context) {
 			name := c.Args().First()
-			store := NewStore()
+			store := NewStore(c.GlobalString("storage-path"))
 
 			if name == "" {
 				host, err := store.GetActive()
@@ -106,7 +106,7 @@ var Commands = []cli.Command{
 				log.Fatalf("Identity authentication public key doesn't exist at %q. Create your public key by running the \"docker\" command.", drivers.PublicKeyPath())
 			}
 
-			store := NewStore()
+			store := NewStore(c.GlobalString("storage-path"))
 
 			host, err := store.Create(name, driver, c)
 			if err != nil {
@@ -163,7 +163,7 @@ var Commands = []cli.Command{
 		Usage: "List machines",
 		Action: func(c *cli.Context) {
 			quiet := c.Bool("quiet")
-			store := NewStore()
+			store := NewStore(c.GlobalString("storage-path"))
 
 			hostList, err := store.List()
 			if err != nil {
@@ -263,7 +263,7 @@ var Commands = []cli.Command{
 
 			isError := false
 
-			store := NewStore()
+			store := NewStore(c.GlobalString("storage-path"))
 			for _, host := range c.Args() {
 				if err := store.Remove(host, force); err != nil {
 					log.Errorf("Error removing machine %s: %s", host, err)
@@ -287,7 +287,7 @@ var Commands = []cli.Command{
 		Usage: "Log into or run a command on a machine with SSH",
 		Action: func(c *cli.Context) {
 			name := c.Args().First()
-			store := NewStore()
+			store := NewStore(c.GlobalString("storage-path"))
 
 			if name == "" {
 				host, err := store.GetActive()
@@ -369,7 +369,7 @@ var Commands = []cli.Command{
 
 func getHost(c *cli.Context) *Host {
 	name := c.Args().First()
-	store := NewStore()
+	store := NewStore(c.GlobalString("storage-path"))
 
 	if name == "" {
 		host, err := store.GetActive()

--- a/main.go
+++ b/main.go
@@ -26,6 +26,11 @@ func main() {
 			Name:  "debug, D",
 			Usage: "Enable debug mode",
 		},
+		cli.StringFlag{
+			EnvVar: "MACHINE_STORAGE_PATH",
+			Name:   "storage-path",
+			Usage:  "Configures storage path",
+		},
 	}
 
 	app.Run(os.Args)

--- a/store.go
+++ b/store.go
@@ -15,8 +15,11 @@ type Store struct {
 	Path string
 }
 
-func NewStore() *Store {
-	rootPath := filepath.Join(drivers.GetHomeDir(), ".docker", "machines")
+func NewStore(rootPath string) *Store {
+	if rootPath == "" {
+		rootPath = filepath.Join(drivers.GetHomeDir(), ".docker", "machines")
+	}
+
 	return &Store{Path: rootPath}
 }
 

--- a/store_test.go
+++ b/store_test.go
@@ -41,7 +41,7 @@ func TestStoreCreate(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 
 	host, err := store.Create("test", "none", flags)
 	if err != nil {
@@ -67,7 +67,7 @@ func TestStoreRemove(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
@@ -96,7 +96,7 @@ func TestStoreList(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func TestStoreExists(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 	exists, err := store.Exists("test")
 	if exists {
 		t.Fatal("Exists returned true when it should have been false")
@@ -151,13 +151,13 @@ func TestStoreLoad(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	store = NewStore()
+	store = NewStore("")
 	host, err := store.Load("test")
 	if host.Name != "test" {
 		t.Fatal("Host name is incorrect")
@@ -182,7 +182,7 @@ func TestStoreGetSetActive(t *testing.T) {
 		},
 	}
 
-	store := NewStore()
+	store := NewStore("")
 
 	// No hosts set
 	host, err := store.GetActive()


### PR DESCRIPTION
As per #77, this PR adds `--storage-path`/`MACHINE_STORAGE_PATH` (env var)
to allow the user to specify where they want to store the machine db

Signed-off-by: Simon Thulbourn <simon+github@thulbourn.com>
