### PR TITLE
Fix url to install docker with identity for amazon ec2 install

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -245,7 +245,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("HACK: Downloading version of Docker with identity auth...")
 
-	cmd, err = d.GetSSHCommand("sudo curl -sS -o /usr/bin/docker https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.0-dev-identity")
+	cmd, err = d.GetSSHCommand("sudo curl -sS -o /usr/bin/docker https://bfirsh.s3.amazonaws.com/docker/linux/docker-1.3.1-dev-identity-auth")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix url to install docker with identity for amazon ec2 install, the url in the code wasn't working anymore.
