### PR TITLE
use 1.4.1 identity build

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -245,7 +245,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("HACK: Downloading version of Docker with identity auth...")
 
-	cmd, err = d.GetSSHCommand("sudo curl -sS -o /usr/bin/docker https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.0-dev-identity")
+	cmd, err = d.GetSSHCommand("sudo curl -sS -o /usr/bin/docker https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity")
 	if err != nil {
 		return err
 	}

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -226,7 +226,7 @@ func (driver *Driver) hackForIdentityAuth() error {
 		return err
 	}
 
-	if err := driver.runSSHCommand("sudo bash -c \"curl -sS https://bfirsh.s3.amazonaws.com/docker/docker-1.3.1-dev-identity-auth > /usr/bin/docker\"", numberOfRetries); err != nil {
+	if err := driver.runSSHCommand("sudo bash -c \"curl -sS https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity > /usr/bin/docker\"", numberOfRetries); err != nil {
 		return err
 	}
 

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -157,7 +157,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	cmd, err = d.GetSSHCommand("curl -sS https://bfirsh.s3.amazonaws.com/docker/docker-1.3.1-dev-identity-auth > /usr/bin/docker")
+	cmd, err = d.GetSSHCommand("curl -sS https://ehazlett.s3.amazonaws.com/public/docker/linux/docker-1.4.1-136b351e-identity > /usr/bin/docker")
 	if err != nil {
 		return err
 	}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -132,8 +132,8 @@ func (d *Driver) Create() error {
 			return err
 		}
 	} else {
-		// HACK: Docker 1.3 boot2docker image with client/daemon auth
-		isoURL = "https://ehazlett.s3.amazonaws.com/public/boot2docker/boot2docker-machine-87e3813.iso"
+		// HACK: Docker 1.4.1 boot2docker image with client/daemon auth
+		isoURL = "https://ejhazlett.s3.amazonaws.com/public/boot2docker/machine-b2d-docker-1.4.1-identity.iso"
 
 		// todo: check latest release URL, download if it's new
 		// until then always use "latest"


### PR DESCRIPTION
This enables Docker 1.4.1 (with identity) for all drivers.
