### PR TITLE
refs #180: add option to migrate from an existing b2d instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
  - `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
  - `--virtualbox-disk-size`: Size of disk for the host in MB. Default: `20000`
  - `--virtualbox-memory`: Size of memory for the host in MB. Default: `1024`
+ - `--virtualbox-migrate-boot2docker-instance`: The name of a boot2docker instance to migrate.  (optional)
 
 ### Digital Ocean
 

--- a/drivers/virtualbox/disk.go
+++ b/drivers/virtualbox/disk.go
@@ -1,0 +1,42 @@
+package virtualbox
+
+import (
+	"errors"
+	"regexp"
+)
+
+var (
+	reDiskUUID = regexp.MustCompile(`SATA-ImageUUID-1-0\"=\"(.*)\"`)
+)
+
+// Disk
+type vmDisk struct {
+	UUID string
+}
+
+func getDiskInfo(vmName string) (*vmDisk, error) {
+	out, err := vbmOut("showvminfo", vmName, "--details", "--machinereadable")
+	if err != nil {
+		return nil, err
+	}
+
+	res := reDiskUUID.FindStringSubmatch(string(out))
+	if res == nil {
+		return nil, errors.New("failed to parse disk info")
+	}
+
+	return &vmDisk{UUID: res[1]}, err
+}
+
+func cloneBoot2DockerVmDisk(vmName string, destPath string) error {
+	info, err := getDiskInfo(vmName)
+	if err != nil {
+		return err
+	}
+
+	if err := vbm("clonehd", info.UUID, destPath); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds a flag to import (copy) an existing boot2docker instance during creation of a virtualbox machine.  Perhaps later, we can add the additional "magic" to do a full sweep of existing b2d instances as mentioned in #180.