### PR TITLE
add env vars for google driver; add google instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ Options:
  - `--amazonec2-vpc-id`: Your VPC ID to launch the instance in.
  - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e).
 
+### Google Compute
+
+Create machines on [Google Compute](https://cloud.google.com/compute/).  You will need a Google account and project name.  See https://cloud.google.com/compute/docs/projects for details on projects.
+
+The Google driver uses oAuth.  When creating the machine, you will have your browser opened to authorize.  Once authorized, paste the code given in the prompt to launch the instance.
+
+Options:
+
+ - `--google-zone`: The zone to launch the instance.  Default: `us-central1-a`
+ - `--google-machine-type`: The type of instance.  Default: `f1-micro`
+ - `--google-username`: The username to use for the instance.  Default: `docker-user`
+ - `--google-instance-name`: The name of the instance.  Default: `docker-machine`
+ - `--google-project`: The name of your project to use when launching the instance.
+
 ## Contributing
 
 [![GoDoc](https://godoc.org/github.com/docker/machine?status.png)](https://godoc.org/github.com/docker/machine)

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -47,28 +47,33 @@ func init() {
 func GetCreateFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  "google-zone",
-			Usage: "GCE Zone",
-			Value: "us-central1-a",
+			Name:   "google-zone",
+			Usage:  "GCE Zone",
+			Value:  "us-central1-a",
+			EnvVar: "GOOGLE_ZONE",
 		},
 		cli.StringFlag{
-			Name:  "google-machine-type",
-			Usage: "GCE Machine Type",
-			Value: "f1-micro",
+			Name:   "google-machine-type",
+			Usage:  "GCE Machine Type",
+			Value:  "f1-micro",
+			EnvVar: "GOOGLE_MACHINE_TYPE",
 		},
 		cli.StringFlag{
-			Name:  "google-username",
-			Usage: "User Name",
-			Value: "docker-user",
+			Name:   "google-username",
+			Usage:  "User Name",
+			Value:  "docker-user",
+			EnvVar: "GOOGLE_USERNAME",
 		},
 		cli.StringFlag{
-			Name:  "google-instance-name",
-			Usage: "GCE Instance Name",
-			Value: "docker-machine",
+			Name:   "google-instance-name",
+			Usage:  "GCE Instance Name",
+			Value:  "docker-machine",
+			EnvVar: "GOOGLE_INSTANCE_NAME",
 		},
 		cli.StringFlag{
-			Name:  "google-project",
-			Usage: "GCE Project",
+			Name:   "google-project",
+			Usage:  "GCE Project",
+			EnvVar: "GOOGLE_PROJECT",
 		},
 	}
 }


### PR DESCRIPTION
This enables env vars for the Google driver.  It also has basic usage instructions in the readme.
