### PR TITLE
listen on socket in addition to tls for amazon driver

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -255,7 +255,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("Updating /etc/default/docker to use identity auth...")
 
-	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376 --auth-authorized-dir=/root/.docker/authorized-keys.d\"' | sudo tee -a /etc/default/docker")
+	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376 --host=unix:///var/run/docker.sock --auth-authorized-dir=/root/.docker/authorized-keys.d\"' | sudo tee -a /etc/default/docker")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #202.  This will listen on the default socket as well as tls for amazon.