### PR TITLE
automatically add host fingerprint to known hosts

### DIFF
--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -14,6 +14,10 @@ func GetHomeDir() string {
 	return os.Getenv("HOME")
 }
 
+func GetDockerDir() string {
+	return fmt.Sprintf(filepath.Join(GetHomeDir(), ".docker"))
+}
+
 func PublicKeyPath() string {
 	return filepath.Join(GetHomeDir(), ".docker", "public-key.json")
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -493,6 +493,9 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
+	// reset to nil as if using from Host Stdout is already set when using DEBUG
+	cmd.Stdout = nil
+
 	b, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes #17. This was basically vendored from https://github.com/dmcgowan/docker/compare/tls_libtrust_auth#diff-085728486480676f7b89e9fcee68da74R19.