### PR TITLE
Sort flags in create output

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -112,6 +112,8 @@ func GetCreateFlags() []cli.Flag {
 		}
 	}
 
+	sort.Sort(ByFlagName(flags))
+
 	return flags
 }
 

--- a/drivers/flag_sort.go
+++ b/drivers/flag_sort.go
@@ -1,0 +1,17 @@
+package drivers
+
+import "github.com/codegangsta/cli"
+
+type ByFlagName []cli.Flag
+
+func (flags ByFlagName) Len() int {
+	return len(flags)
+}
+
+func (flags ByFlagName) Swap(i, j int) {
+	flags[i], flags[j] = flags[j], flags[i]
+}
+
+func (flags ByFlagName) Less(i, j int) bool {
+	return flags[i].String() < flags[j].String()
+}


### PR DESCRIPTION
Closes #214 

cc @bfirsh @ehazlett 

```console
$ machine create -h 2>&1 | head
NAME:
   create - Create a machine

USAGE:
   command create [command options] [arguments...]

OPTIONS:
   --amazonec2-access-key                       AWS Access Key [$AWS_ACCESS_KEY_ID]
   --amazonec2-ami 'ami-a00461c8'               AWS machine image [$AWS_AMI]
   --amazonec2-instance-type 't2.micro'         AWS instance type [$AWS_INSTANCE_TYPE]

$ machine create -h 2>&1 | head
NAME:
   create - Create a machine

USAGE:
   command create [command options] [arguments...]

OPTIONS:
   --amazonec2-access-key                       AWS Access Key [$AWS_ACCESS_KEY_ID]
   --amazonec2-ami 'ami-a00461c8'               AWS machine image [$AWS_AMI]
   --amazonec2-instance-type 't2.micro'         AWS instance type [$AWS_INSTANCE_TYPE]

$ machine create -h 2>&1 | head
NAME:
   create - Create a machine

USAGE:
   command create [command options] [arguments...]

OPTIONS:
   --amazonec2-access-key                       AWS Access Key [$AWS_ACCESS_KEY_ID]
   --amazonec2-ami 'ami-a00461c8'               AWS machine image [$AWS_AMI]
   --amazonec2-instance-type 't2.micro'         AWS instance type [$AWS_INSTANCE_TYPE]
```

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>