### PR TITLE
Add test for flag order

### DIFF
--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -1,0 +1,43 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/codegangsta/cli"
+)
+
+func TestGetCreateFlags(t *testing.T) {
+	Register("foo", &RegisteredDriver{
+		New: func(storePath string) (Driver, error) { return nil, nil },
+		GetCreateFlags: func() []cli.Flag {
+			return []cli.Flag{
+				cli.StringFlag{"a", "", "", ""},
+				cli.StringFlag{"b", "", "", ""},
+				cli.StringFlag{"c", "", "", ""},
+			}
+		},
+	})
+	Register("bar", &RegisteredDriver{
+		New: func(storePath string) (Driver, error) { return nil, nil },
+		GetCreateFlags: func() []cli.Flag {
+			return []cli.Flag{
+				cli.StringFlag{"d", "", "", ""},
+				cli.StringFlag{"e", "", "", ""},
+				cli.StringFlag{"f", "", "", ""},
+			}
+		},
+	})
+
+	expected := []string{"-a \t", "-b \t", "-c \t", "-d \t", "-e \t", "-f \t"}
+
+	// test a few times to catch offset issue
+	// if it crops up again
+	for i := 0; i < 5; i++ {
+		flags := GetCreateFlags()
+		for j, e := range expected {
+			if flags[j].String() != e {
+				t.Fatal("Flags are out of order")
+			}
+		}
+	}
+}


### PR DESCRIPTION
cc @ehazlett @bfirsh 

Not a "critical path" by any stretch of the imagination but want to encourage good testing discipline on `machine`.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>