### PR TITLE
add cleanup for create failure

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -194,11 +194,12 @@ func cmdCreate(c *cli.Context) {
 		if c.GlobalBool("debug") {
 			log.Fatal(err)
 		} else {
-			log.Warnf("Removing provisioned machine.  Use --debug to prevent removal.")
+			log.Warnf("Removing created machine. You can run machine with the --debug flag to avoid this.")
 			// we know there was an error so do not check for the error on removal
 			// instead we will Fatal with a message to prevent spamming with error messages
-			store.Remove(name, true)
-			log.Fatalf("You will want to check the provider to make sure the machine and associated resources were properly removed.")
+			_ = store.Remove(name, true)
+			log.Warn("You will want to check the provider to make sure the machine and associated resources were properly removed.")
+			log.Fatal("Error creating machine")
 		}
 	}
 	if err := store.SetActive(host); err != nil {

--- a/commands.go
+++ b/commands.go
@@ -190,7 +190,16 @@ func cmdCreate(c *cli.Context) {
 
 	host, err := store.Create(name, driver, c)
 	if err != nil {
-		log.Fatal(err)
+		log.Errorf("Error creating host: %s", err)
+		if c.GlobalBool("debug") {
+			log.Fatal(err)
+		} else {
+			log.Warnf("Removing provisioned machine.  Use --debug to prevent removal.")
+			// we know there was an error so do not check for the error on removal
+			// instead we will Fatal with a message to prevent spamming with error messages
+			store.Remove(name, true)
+			log.Fatalf("You will want to check the provider to make sure the machine and associated resources were properly removed.")
+		}
 	}
 	if err := store.SetActive(host); err != nil {
 		log.Fatalf("error setting active host: %v", err)

--- a/host.go
+++ b/host.go
@@ -227,9 +227,7 @@ func (h *Host) Upgrade() error {
 
 func (h *Host) Remove(force bool) error {
 	if err := h.Driver.Remove(); err != nil {
-		if force {
-			log.Errorf("Error removing host, force removing anyway: %s", err)
-		} else {
+		if !force {
 			return err
 		}
 	}


### PR DESCRIPTION
Refs: #119 

This will automatically call Remove to cleanup a machine when Create fails if DEBUG is not specified and show an error message.  If DEBUG is specified, it behaves as normal:

Default

```
ehazlett@ejh-mbp ~/d/g/s/g/d/machine> machine create -d digitalocean test-do
INFO[0000] Creating SSH key...
ERRO[0000] Error creating host: POST https://api.digitalocean.com/v2/account/keys: 401 Unable to authenticate you.
WARN[0000] Removing provisioned machine.  Use --debug to prevent removal.
FATA[0001] You will want to check the provider to make sure the machine and associated resources were properly removed.
ehazlett@ejh-mbp ~/d/g/s/g/d/machine> machine ls
NAME   ACTIVE   DRIVER       STATE     URL
```

Debug

```
ehazlett@ejh-mbp ~/d/g/s/g/d/machine> ./machine -D create -d digitalocean test-do
INFO[0000] Creating SSH key...
DEBU[0000] executing: /usr/bin/ssh-keygen ssh-keygen -t rsa -N  -f /Users/ehazlett/.docker/machines/test-do/id_rsa

Generating public/private rsa key pair.
Your identification has been saved in /Users/ehazlett/.docker/machines/test-do/id_rsa.
Your public key has been saved in /Users/ehazlett/.docker/machines/test-do/id_rsa.pub.
The key fingerprint is:
dd:2a:e3:88:a2:e7:1d:9c:07:a4:57:ea:22:d1:92:a1 ehazlett@ejh-mbp.local
The key's randomart image is:
+--[ RSA 2048]----+
|                 |
|                 |
|.   . .          |
|.+ o o   . .     |
|E o +   S . .    |
| o + o     .     |
|. . = . o .      |
| .oo + o o       |
|.+..o . .        |
+-----------------+
ERRO[0000] Error creating host: POST https://api.digitalocean.com/v2/account/keys: 401 Unable to authenticate you.
FATA[0000] POST https://api.digitalocean.com/v2/account/keys: 401 Unable to authenticate you.
ehazlett@ejh-mbp ~/d/g/s/g/d/machine> machine ls
ERRO[0000] error getting state for host test-do: GET https://api.digitalocean.com/v2/droplets/0: 401 Unable to authenticate you.
ERRO[0000] error getting URL for host test-do: IP address is not set
NAME      ACTIVE   DRIVER         STATE     URL
test-do            digitalocean   Error
```