### PR TITLE
Putting the export DOCKER_HOST... on a separate line makes it easier to see

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -209,7 +209,8 @@ func cmdCreate(c *cli.Context) {
 		log.Fatalf("error setting active host: %v", err)
 	}
 
-	log.Infof("%q has been created and is now the active machine. To point Docker at this machine, run: export DOCKER_HOST=$(machine url) DOCKER_AUTH=identity", name)
+	log.Infof("%q has been created and is now the active machine. To point Docker at this machine, run:", name)
+	log.Infof("    export DOCKER_HOST=$(%s url %s) DOCKER_AUTH=identity", os.Args[0], name)
 }
 
 func cmdInspect(c *cli.Context) {


### PR DESCRIPTION

and easier to copy. Also changed it to be explicit in the real exe path
and machine name, as the hint might be from an old terminal, and the
user may have created another since.

now looks like:

```
INFO[0070] Creating SSH key...                          
INFO[0071] Creating VM...                               
INFO[0074] Waiting for VM to come online...             
INFO[0122] "vmtest" has been created and is now the active machine. To point Docker at this machine, run: 
INFO[0122]     export DOCKER_HOST=$(./machine url vmtest) DOCKER_AUTH=identity 
mini:machine sven$ export DOCKER_HOST=$(./machine url vmtest) DOCKER_AUTH=identity
```

Signed-off-by: Sven Dowideit <SvenDowideit@docker.com>