### PR TITLE
Add machine shellinit, and use the real command path, so it works for pe...

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -143,6 +143,11 @@ var Commands = []cli.Command{
 		Usage:  "Get the URL of a machine",
 		Action: cmdUrl,
 	},
+	{
+		Name:   "shellinit",
+		Usage:  "Display the shell commands to set up the Docker client.",
+		Action: cmdShellInit,
+	},
 }
 
 func cmdActive(c *cli.Context) {
@@ -209,7 +214,16 @@ func cmdCreate(c *cli.Context) {
 		log.Fatalf("error setting active host: %v", err)
 	}
 
-	log.Infof("%q has been created and is now the active machine. To point Docker at this machine, run: export DOCKER_HOST=$(machine url) DOCKER_AUTH=identity", name)
+	log.Infof("%q has been created and is now the active machine. To point Docker at this machine, run:", name)
+	log.Infof("   $(%s shellinit %s)", os.Args[0], name)
+}
+
+func cmdShellInit(c *cli.Context) {
+	url, err := getHost(c).GetURL()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("export DOCKER_HOST=%s DOCKER_AUTH=identity\n", url)
 }
 
 func cmdInspect(c *cli.Context) {


### PR DESCRIPTION
...ople that may not have it in their path

using `$(./machine shellinit vmname)` means that it won't matter what the env vars might change to in the future (including TLS, or plain text socket)

and its much better if users start using this kind of thing from their `.bashrc` - as it'll continue working.

```
mini:machine sven$ ./machine create --driver=vmwarefusion vmtest3
INFO[0000] Downloading boot2docker...                   
INFO[0037] Creating SSH key...                          
INFO[0037] Creating VM...                               
INFO[0038] Waiting for VM to come online...             
INFO[0087] "vmtest3" has been created and is now the active machine. To point Docker at this machine, run: 
INFO[0087]    $(./machine shellinit vmtest3)            
mini:machine sven$ $(./machine shellinit vmtest3)
mini:machine sven$ ./docker-identity info
Containers: 0
Images: 0
Storage Driver: aufs
 Root Dir: /mnt/sda1/var/lib/docker/aufs
 Dirs: 0
Execution Driver: native-0.2
Kernel Version: 3.16.4-tinycore64
Operating System: Boot2Docker 1.3.1 (TCL 5.4); vmw-identity : 8ff8eb3 - Wed Dec 10 22:30:27 UTC 2014
CPUs: 1
```

Signed-off-by: Sven Dowideit <SvenDowideit@docker.com>