### PR TITLE
Adds check for SSH keygen command

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -36,6 +36,10 @@ func GetSSHCommand(host string, port int, user string, sshKey string, args ...st
 }
 
 func GenerateSSHKey(path string) error {
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		return fmt.Errorf("ssh-keygen not found in the path, please install ssh-keygen")
+	}
+
 	if _, err := os.Stat(path); err != nil {
 		if !os.IsNotExist(err) {
 			return err


### PR DESCRIPTION
Adds a check to find ssh-keygen in the user's $PATH, in the event it
can't find it, return an error with a friendly message

Signed-off-by: Simon Thulbourn <simon+github@thulbourn.com>

Fix for #62