### PR TITLE
Add unknown command help

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -380,6 +380,16 @@ func cmdUrl(c *cli.Context) {
 	fmt.Println(url)
 }
 
+func cmdNotFound(c *cli.Context, command string) {
+	log.Fatalf(
+		"%s: '%s' is not a %s command. See '%s --help'.",
+		c.App.Name,
+		command,
+		c.App.Name,
+		c.App.Name,
+	)
+}
+
 func getHost(c *cli.Context) *Host {
 	name := c.Args().First()
 	store := NewStore(c.GlobalString("storage-path"))

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "machine"
 	app.Commands = Commands
+	app.CommandNotFound = cmdNotFound
 	app.Usage = "Create and manage machines running Docker."
 	app.Version = VERSION
 


### PR DESCRIPTION
Spits out "machine: '<command>' is not a machine command see 'machine --help'" to be inline with Docker

Refs: #231 