### PR TITLE
Listen on unix socket in addition to TCP for Digital Ocean hosts

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -167,7 +167,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("Updating /etc/default/docker to use identity auth...")
 
-	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376\"' >> /etc/default/docker")
+	cmd, err = d.GetSSHCommand("echo 'export DOCKER_OPTS=\"--auth=identity --host=tcp://0.0.0.0:2376 --host=unix:///var/run/docker.sock\"' >> /etc/default/docker")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On Digital Oean provisioned machines, you cannot use the local Docker client since it is not listening on the unix socket:

```console
$ machine ssh demo1
root@docker:~# docker ps
FATA[0000] Cannot connect to the Docker daemon. Is 'docker -d' running on this host?
```

This quick fix enabled the unix socket in addition to the TCP socket so that local Docker stuff works as well:

```console
$ machine ssh demo1 -c "docker info"
Containers: 0
Images: 0
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Dirs: 0
Execution Driver: native-0.2
Kernel Version: 3.13.0-40-generic
Operating System: Ubuntu 14.04.1 LTS
CPUs: 2
Total Memory: 1.955 GiB
Name: docker
ID: GLRE:XM26:DVF7:VU4U:XCXU:NZET:WIT6:K6VG:OSNF:BGBQ:WCIC:VZN6
```