### PR TITLE
Fix for panics when no active host is set

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -256,6 +256,15 @@ func cmdLs(c *cli.Context) {
 
 	for _, host := range hostList {
 		if !quiet {
+			tmpHost, err := store.GetActive()
+			if err != nil {
+				log.Errorf("There's a problem with the active host: %s", err)
+			}
+
+			if tmpHost == nil {
+				log.Errorf("There's a problem finding the active host")
+			}
+
 			go getHostState(host, *store, hostListItems)
 		} else {
 			fmt.Fprintf(w, "%s\n", host.Name)
@@ -399,6 +408,10 @@ func getHost(c *cli.Context) *Host {
 		if err != nil {
 			log.Fatalf("unable to get active host: %v", err)
 		}
+
+		if host == nil {
+			log.Fatal("unable to get active host, active file not found")
+		}
 		return host
 	}
 
@@ -426,7 +439,7 @@ func getHostState(host Host, store Store, hostListItems chan<- hostListItem) {
 
 	isActive, err := store.IsActive(&host)
 	if err != nil {
-		log.Errorf("error determining whether host %q is active: %s",
+		log.Debugf("error determining whether host %q is active: %s",
 			host.Name, err)
 	}
 

--- a/store.go
+++ b/store.go
@@ -64,6 +64,7 @@ func (s *Store) Remove(name string, force bool) error {
 	if err != nil {
 		return err
 	}
+
 	if active != nil && active.Name == name {
 		if err := s.RemoveActive(); err != nil {
 			return err

--- a/store_test.go
+++ b/store_test.go
@@ -189,6 +189,7 @@ func TestStoreGetSetActive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if host != nil {
 		t.Fatalf("GetActive: Active host should not exist")
 	}
@@ -227,6 +228,7 @@ func TestStoreGetSetActive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if host != nil {
 		t.Fatalf("Active host %s is not nil", host.Name)
 	}


### PR DESCRIPTION
By adding some better error checking on `store.GetActive`, we can stop
getting panics on some commands

As a part of this PR, we no longer care about `store.GetActive` failing. 

Refs: #256, #222