### PR TITLE
Move VirtualBox configuration file to be inside the data store

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -181,6 +181,7 @@ func (d *Driver) Create() error {
 	}
 
 	if err := vbm("createvm",
+		"--basefolder", d.storePath,
 		"--name", d.MachineName,
 		"--register"); err != nil {
 		return err


### PR DESCRIPTION
It turns out, that we only stored the actual disk inside the data store,
this brings it back inline with vmware.