### PR TITLE
WIP: Refactor code out of main package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	drivers "github.com/docker/machine/drivers"
+	"github.com/docker/machine/store"
+)
+
+type Api struct {
+	store *store.Store
+}
+
+func NewApi(rootPath string) *Api {
+	store := store.NewStore(rootPath)
+	return &Api{store: store}
+}
+
+func (a *Api) Create(name string, driverName string, flags drivers.DriverOptions) (*store.Host, error) {
+	return a.store.Create(name, driverName, flags)
+}
+
+func (a *Api) Remove(name string, force bool) error {
+	return a.store.Remove(name, force)
+}
+
+func (a *Api) List() ([]store.Host, error) {
+	return a.store.List()
+}
+
+func (a *Api) Load(name string) (*store.Host, error) {
+	return a.store.Load(name)
+}
+
+func (a *Api) GetActive() (*store.Host, error) {
+	return a.store.GetActive()
+}
+
+func (a *Api) IsActive(host *store.Host) (bool, error) {
+	return a.store.IsActive(host)
+}
+
+func (a *Api) SetActive(host *store.Host) error {
+	return a.store.SetActive(host)
+}
+
+// Kills the host specified by name. If name is empty, the
+// active host will be killed.
+func (a *Api) Kill(name string) error {
+	host, err := a.getHost(name)
+	if err != nil {
+		return err
+	}
+
+	return host.Driver.Restart()
+}
+
+// Restarts the host specified by name. If name is empty, the
+// active host will be restarted.
+func (a *Api) Restart(name string) error {
+	host, err := a.getHost(name)
+	if err != nil {
+		return err
+	}
+
+	return host.Driver.Restart()
+}
+
+// Starts the host specified by name. If name is empty, the
+// active host will be started.
+func (a *Api) Start(name string) error {
+	host, err := a.getHost(name)
+	if err != nil {
+		return err
+	}
+
+	return host.Driver.Start()
+}
+
+// Stops the host specified by name. If name is empty, the
+// active host will be stopped.
+func (a *Api) Stop(name string) error {
+	host, err := a.getHost(name)
+	if err != nil {
+		return err
+	}
+
+	return host.Driver.Stop()
+}
+
+// Upgrades the host specified by name. If name is empty, the
+// active host will be upgraded.
+func (a *Api) Upgrade(name string) error {
+	host, err := a.getHost(name)
+	if err != nil {
+		return err
+	}
+
+	return host.Driver.Upgrade()
+}
+
+func (a *Api) getHost(name string) (*store.Host, error) {
+	if name == "" {
+		host, err := a.GetActive()
+		if err != nil {
+			return nil, err
+		}
+		return host, nil
+	}
+
+	host, err := a.Load(name)
+	if err != nil {
+		return nil, err
+	}
+	return host, nil
+}

--- a/commands_test.go
+++ b/commands_test.go
@@ -5,8 +5,10 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/docker/machine/api"
 	drivers "github.com/docker/machine/drivers"
 	"github.com/docker/machine/state"
+	"github.com/docker/machine/store"
 )
 
 type FakeDriver struct {
@@ -71,15 +73,15 @@ func TestGetHostState(t *testing.T) {
 		t.Fatal("Error creating tmp dir:", err)
 	}
 	hostListItems := make(chan hostListItem)
-	store := NewStore(storePath)
-	hosts := []Host{
+	api := api.NewApi(storePath)
+	hosts := []store.Host{
 		{
 			Name:       "foo",
 			DriverName: "fakedriver",
 			Driver: &FakeDriver{
 				MockState: state.Running,
 			},
-			storePath: storePath,
+			StorePath: storePath,
 		},
 		{
 			Name:       "bar",
@@ -87,7 +89,7 @@ func TestGetHostState(t *testing.T) {
 			Driver: &FakeDriver{
 				MockState: state.Stopped,
 			},
-			storePath: storePath,
+			StorePath: storePath,
 		},
 		{
 			Name:       "baz",
@@ -95,7 +97,7 @@ func TestGetHostState(t *testing.T) {
 			Driver: &FakeDriver{
 				MockState: state.Running,
 			},
-			storePath: storePath,
+			StorePath: storePath,
 		},
 	}
 	expected := map[string]state.State{
@@ -105,7 +107,7 @@ func TestGetHostState(t *testing.T) {
 	}
 	items := []hostListItem{}
 	for _, host := range hosts {
-		go getHostState(host, *store, hostListItems)
+		go getHostState(host, *api, hostListItems)
 	}
 	for i := 0; i < len(hosts); i++ {
 		items = append(items, <-hostListItems)

--- a/store/store.go
+++ b/store/store.go
@@ -1,4 +1,4 @@
-package main
+package store
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ func NewStore(rootPath string) *Store {
 }
 
 func (s *Store) Create(name string, driverName string, flags drivers.DriverOptions) (*Host, error) {
-	exists, err := s.Exists(name)
+	exists, err := s.exists(name)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 
 	hostPath := filepath.Join(s.Path, name)
 
-	host, err := NewHost(name, driverName, hostPath)
+	host, err := newHost(name, driverName, hostPath)
 	if err != nil {
 		return host, err
 	}
@@ -48,11 +48,11 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		return nil, err
 	}
 
-	if err := host.SaveConfig(); err != nil {
+	if err := host.saveConfig(); err != nil {
 		return host, err
 	}
 
-	if err := host.Create(name); err != nil {
+	if err := host.create(name); err != nil {
 		return host, err
 	}
 
@@ -74,7 +74,7 @@ func (s *Store) Remove(name string, force bool) error {
 	if err != nil {
 		return err
 	}
-	return host.Remove(force)
+	return host.remove(force)
 }
 
 func (s *Store) List() ([]Host, error) {
@@ -98,7 +98,7 @@ func (s *Store) List() ([]Host, error) {
 	return hosts, nil
 }
 
-func (s *Store) Exists(name string) (bool, error) {
+func (s *Store) exists(name string) (bool, error) {
 	_, err := os.Stat(filepath.Join(s.Path, name))
 	if os.IsNotExist(err) {
 		return false, nil
@@ -110,7 +110,7 @@ func (s *Store) Exists(name string) (bool, error) {
 
 func (s *Store) Load(name string) (*Host, error) {
 	hostPath := filepath.Join(s.Path, name)
-	return LoadHost(name, hostPath)
+	return loadHost(name, hostPath)
 }
 
 func (s *Store) GetActive() (*Host, error) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,4 +1,4 @@
-package main
+package store
 
 import (
 	"os"
@@ -122,7 +122,7 @@ func TestStoreExists(t *testing.T) {
 	}
 
 	store := NewStore("")
-	exists, err := store.Exists("test")
+	exists, err := store.exists("test")
 	if exists {
 		t.Fatal("Exists returned true when it should have been false")
 	}
@@ -130,7 +130,7 @@ func TestStoreExists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	exists, err = store.Exists("test")
+	exists, err = store.exists("test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR does the following:
* Moves the ```store.go``` and ```host.go``` code out of the main package and into a package called ```store```
* Introduces an ```api``` package to provide a single entry point for all operations on hosts

## Motivation and benefits
First, hopefully this will better organize business logic and separate concerns in the machine code base. It should give future developers better guidance on where business logic should go and force them to think through how it can be cleanly exposed. This should make machine more maintainable in the long run. 

It should allow ```commands.go``` to be concerned only with interpreting CLI requests and passing them to the API.  With the code in it's current state, it isn't clear where new functionality should drop. Here's a few examples where it seems the current model is falling short:
* We've seen some PRs where important store-specific logic is dropped directly into ```commands.go`` #29 is a possible example of this.
* The way one performs state changing operations is inconsistent. For example, to start a host you call ```host.Start()```, to restart it you call ```host.DriverRestart()```, and to remove it you call ```store.Remove()```, but there is also a ```host.Remove()``` function exposed.

Second, this provides access to machine as a library so that integrators don't have to exec out to it. This is a good stop-gap measure while we work towards building a REST API for machine. 

As @shykes and @ehazlett mentioned in an IRC conversation, a risk is that introducing a public api at this point means being forced to maintain it. It should be understood that the ```api``` provides no stability or backwards compatibility guarantees with regards to public consumption. It is first and foremost an internal API for better separating concerns within the machine code base. Users calling machine as a library would do so at their own risk. Would calling this out explicitly as a comment in the ```api ``` package be sufficient for conveying this?

## Current deficencies or concerns
There a few deficencies with the PR as-is:

The SSH command code has note been refactored. This was just done for time savings. I wanted to get some feedback on the concept before spending the time to refactor it.

The abstraction is a little leaky. All state changing functions on the ```host``` struct have been unexposed, but  the ```Driver``` field is still exposed and it exposes state changing operations. The reason for this is that the ```machine inspect``` command marshals the Driver field to json. I couldn't simply hide the Driver field because it would cause inspect to be much less useful. Suggests on how to address this are welcome.

There is some logic in ```store.go``` and ```host.go``` that perhaps now should be moved directly into the ```api``` package. This was done intentionally to minimize the impact of the PR. Future PRs could be address further refactoring made possible by this PR.

Some more testing may be needed