### PR TITLE
wip: Change AWS EC2 driver

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/machine/drivers"
 	_ "github.com/docker/machine/drivers/amazonec2"
+	_ "github.com/docker/machine/drivers/awsec2"
 	_ "github.com/docker/machine/drivers/azure"
 	_ "github.com/docker/machine/drivers/digitalocean"
 	_ "github.com/docker/machine/drivers/google"

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -299,7 +299,7 @@ func (d *Driver) GetIP() (string, error) {
 	}
 
 	if descInstResp.Reservations[0].Instances[0].PublicIPAddress == nil {
-		return "", errNoIP
+		return "unset", errNoIP
 	}
 
 	ip := *descInstResp.Reservations[0].Instances[0].PublicIPAddress

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -354,7 +354,7 @@ func (d *Driver) GetURL() (string, error) {
 	return fmt.Sprintf("tcp://%s:2376", ip), nil
 }
 func (d *Driver) Kill() error {
-	return nil
+	return d.Stop()
 }
 
 func (d *Driver) Remove() error {

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -62,6 +62,11 @@ func GetCreateFlags() []cli.Flag {
 			Name:  "aws-ec2-image-id",
 			Usage: "EC2 AMI ID",
 		},
+		cli.StringFlag{
+			Name:  "aws-ec2-disk-size",
+			Usage: "Size of the volume",
+			Value: 16,
+		},
 	}
 }
 
@@ -83,6 +88,7 @@ type Driver struct {
 
 	ImageID      string
 	InstanceType string
+	DiskSize     int
 
 	storePath string
 }
@@ -111,6 +117,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 
 	d.InstanceType = flags.String("aws-ec2-instance-type")
 	d.ImageID = image
+	d.DiskSize = flags.Int("aws-ec2-disk-size")
 
 	return nil
 }
@@ -179,7 +186,7 @@ func (d *Driver) Create() error {
 				DeviceName: aws.String("/dev/sda1"),
 				EBS: &ec2.EBSBlockDevice{
 					DeleteOnTermination: aws.Boolean(false),
-					VolumeSize:          aws.Integer(8),
+					VolumeSize:          aws.Integer(d.DiskSize),
 					VolumeType:          aws.String("gp2"),
 				},
 			},

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -62,7 +62,7 @@ func GetCreateFlags() []cli.Flag {
 			Name:  "aws-ec2-image-id",
 			Usage: "EC2 AMI ID",
 		},
-		cli.StringFlag{
+		cli.IntFlag{
 			Name:  "aws-ec2-disk-size",
 			Usage: "Size of the volume",
 			Value: 16,
@@ -212,7 +212,7 @@ func (d *Driver) Create() error {
 	d.getClient().CreateTags(&ec2.CreateTagsRequest{
 		DryRun:    aws.Boolean(false),
 		Resources: []string{d.InstanceID, d.SecurityGroupID},
-		Tags: []Tags{
+		Tags: []ec2.Tag{
 			{
 				Key:   aws.String("Name"),
 				Value: aws.String(d.MachineName),

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -153,7 +153,7 @@ func (d *Driver) Create() error {
 
 	instResp, err := d.getClient().RunInstances(&ec2.RunInstancesRequest{
 		BlockDeviceMappings: []ec2.BlockDeviceMapping{
-			ec2.BlockDeviceMapping{
+			{
 				DeviceName: aws.String("/dev/sda1"),
 				EBS: &ec2.EBSBlockDevice{
 					VolumeSize: aws.Integer(8),
@@ -484,7 +484,7 @@ func (d *Driver) getDefaultVpc() (string, error) {
 	resp, err := d.getClient().DescribeVPCs(&ec2.DescribeVPCsRequest{
 		DryRun: aws.Boolean(false),
 		Filters: []ec2.Filter{
-			ec2.Filter{
+			{
 				Name:   aws.String("isDefault"),
 				Values: []string{"true"},
 			},

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/state"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
 
@@ -21,7 +22,28 @@ func init() {
 }
 
 func GetCreateFlags() []cli.Flag {
-	return []cli.Flag{}
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   "aws-access-key-id",
+			Usage:  "AWS Access Key",
+			EnvVar: "AWS_ACCESS_KEY_ID",
+		},
+		cli.StringFlag{
+			Name:   "aws-secret-access-key",
+			Usage:  "AWS Secret Access Key",
+			EnvVar: "AWS_SECRET_ACCESS_KEY",
+		},
+		cli.StringFlag{
+			Name:   "aws-session-token",
+			Usage:  "AWS Session Token",
+			EnvVar: "AWS_SESSION_TOKEN",
+		},
+		cli.StringFlag{
+			Name:   "aws-region",
+			Usage:  "AWS Region",
+			EnvVar: "AWS_DEFAULT_REGION",
+		},
+	}
 }
 
 func NewDriver(machineName string, storePath string) (drivers.Driver, error) {
@@ -30,6 +52,11 @@ func NewDriver(machineName string, storePath string) (drivers.Driver, error) {
 
 type Driver struct {
 	MachineName string
+
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+	Region       string
 
 	storePath string
 }

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -385,6 +385,21 @@ func (d *Driver) Remove() error {
 		return err
 	}
 
+	for {
+		instState, err := d.GetState()
+		if err != nil {
+			return nil
+		}
+
+		if instState == state.Stopped {
+			break
+		}
+
+		if instState == state.Error {
+			return errMachineFailure
+		}
+	}
+
 	err = d.getClient().DeleteSecurityGroup(&ec2.DeleteSecurityGroupRequest{
 		DryRun:  aws.Boolean(false),
 		GroupID: aws.String(d.SecurityGroupID),

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -1,0 +1,86 @@
+package awsec2
+
+import (
+	"os/exec"
+
+	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/state"
+
+	"github.com/codegangsta/cli"
+)
+
+const (
+	driverName = "awsec2"
+)
+
+func init() {
+	drivers.Register(driverName, &drivers.RegisteredDriver{
+		New:            NewDriver,
+		GetCreateFlags: GetCreateFlags,
+	})
+}
+
+func GetCreateFlags() []cli.Flag {
+	return []cli.Flag{}
+}
+
+func NewDriver(machineName string, storePath string) (drivers.Driver, error) {
+	return &Driver{MachineName: machineName, storePath: storePath}, nil
+}
+
+type Driver struct {
+	MachineName string
+
+	storePath string
+}
+
+func (d *Driver) DriverName() string {
+	return driverName
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	return nil
+}
+
+func (d *Driver) Create() error {
+	return nil
+}
+
+func (d *Driver) GetIP() (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
+	return &exec.Cmd{}, nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	return state.None, nil
+}
+
+func (d *Driver) GetURL() (string, error) {
+	return "tcp://localhost:2376", nil
+}
+func (d *Driver) Kill() error {
+	return nil
+}
+
+func (d *Driver) Remove() error {
+	return nil
+}
+
+func (d *Driver) Restart() error {
+	return nil
+}
+
+func (d *Driver) Start() error {
+	return nil
+}
+
+func (d *Driver) Stop() error {
+	return nil
+}
+
+func (d *Driver) Upgrade() error {
+	return nil
+}

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -209,6 +209,17 @@ func (d *Driver) Create() error {
 	d.InstanceID = *instResp.Instances[0].InstanceID
 	d.SecurityGroupID = *secGroupResp.GroupID
 
+	d.getClient().CreateTags(&ec2.CreateTagsRequest{
+		DryRun:    aws.Boolean(false),
+		Resources: []string{d.InstanceID, d.SecurityGroupID},
+		Tags: []Tags{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(d.MachineName),
+			},
+		},
+	})
+
 	machineState, err := d.GetState()
 	if err != nil {
 		return err

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -156,8 +156,9 @@ func (d *Driver) Create() error {
 			{
 				DeviceName: aws.String("/dev/sda1"),
 				EBS: &ec2.EBSBlockDevice{
-					VolumeSize: aws.Integer(8),
-					VolumeType: aws.String("gp2"),
+					DeleteOnTermination: aws.Boolean(false),
+					VolumeSize:          aws.Integer(8),
+					VolumeType:          aws.String("gp2"),
 				},
 			},
 		},
@@ -330,13 +331,6 @@ func (d *Driver) GetState() (state.State, error) {
 		}
 
 		instance := resp.Reservations[0].Instances[0]
-
-		// // This typically means that the instance doesn't exist or isn't booted yet
-		// if insta.InstanceStatuses == nil {
-		// 	time.Sleep(1 * time.Second)
-		// 	continue
-		// }
-
 		instState := *instance.State.Name
 
 		log.Debugf("Instance: state: %s", instState)

--- a/drivers/awsec2/awsec2.go
+++ b/drivers/awsec2/awsec2.go
@@ -66,10 +66,24 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	log.Debug("Setting flags")
+	d.AccessKey = flags.String("aws-access-key-id")
+	d.SecretKey = flags.String("aws-secret-key")
+	d.SessionToken = flags.String("aws-session-token")
+
+	region, err := validateAwsRegion(flags.String("aws-region"))
+	if err != nil {
+		return err
+	}
+
+	d.Region = region
+
 	return nil
 }
 
 func (d *Driver) Create() error {
+	creds := aws.Creds(d.AccessKey, d.SecretKey, d.SessionToken)
+
 	return nil
 }
 

--- a/drivers/awsec2/utils.go
+++ b/drivers/awsec2/utils.go
@@ -8,6 +8,7 @@ var (
 	errInvalidRegion  = errors.New("invalid region specified")
 	errNoVpcs         = errors.New("No VPCs found in region")
 	errMachineFailure = errors.New("Machine failed to start")
+	errNoIP           = errors.New("No IP Address associated with the instance")
 	errComplete       = errors.New("Complete")
 )
 

--- a/drivers/awsec2/utils.go
+++ b/drivers/awsec2/utils.go
@@ -6,6 +6,8 @@ import (
 
 var (
 	errInvalidRegion = errors.New("invalid region specified")
+	errNoVpcs        = errors.New("No VPCs found in region")
+	errComplete      = errors.New("Complete")
 )
 
 type region struct {

--- a/drivers/awsec2/utils.go
+++ b/drivers/awsec2/utils.go
@@ -17,23 +17,23 @@ type region struct {
 }
 
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1": &region{"ami-44f1e245"},
-	"ap-southeast-1": &region{"ami-f95875ab"},
-	"ap-southeast-2": &region{"ami-890b62b3"},
-	"cn-north-1":     &region{"ami-fe7ae8c7"},
-	"eu-west-1":      &region{"ami-823686f5"},
-	"eu-central-1":   &region{"ami-ac1524b1"},
-	"sa-east-1":      &region{"ami-c770c1da"},
-	"us-east-1":      &region{"ami-4ae27e22"},
-	"us-west-1":      &region{"ami-d1180894"},
-	"us-west-2":      &region{"ami-898dd9b9"},
-	"us-gov-west-1":  &region{"ami-cf5630ec"},
+	"ap-northeast-1": {"ami-44f1e245"},
+	"ap-southeast-1": {"ami-f95875ab"},
+	"ap-southeast-2": {"ami-890b62b3"},
+	"cn-north-1":     {"ami-fe7ae8c7"},
+	"eu-west-1":      {"ami-823686f5"},
+	"eu-central-1":   {"ami-ac1524b1"},
+	"sa-east-1":      {"ami-c770c1da"},
+	"us-east-1":      {"ami-4ae27e22"},
+	"us-west-1":      {"ami-d1180894"},
+	"us-west-2":      {"ami-898dd9b9"},
+	"us-gov-west-1":  {"ami-cf5630ec"},
 }
 
 func awsRegionsList() []string {
 	var list []string
 
-	for k, _ := range regionDetails {
+	for k := range regionDetails {
 		list = append(list, k)
 	}
 

--- a/drivers/awsec2/utils.go
+++ b/drivers/awsec2/utils.go
@@ -1,0 +1,47 @@
+package awsec2
+
+import (
+	"errors"
+)
+
+var (
+	errInvalidRegion = errors.New("invalid region specified")
+)
+
+type region struct {
+	AmiId string
+}
+
+var regionDetails map[string]*region = map[string]*region{
+	"ap-northeast-1": &region{"ami-44f1e245"},
+	"ap-southeast-1": &region{"ami-f95875ab"},
+	"ap-southeast-2": &region{"ami-890b62b3"},
+	"cn-north-1":     &region{"ami-fe7ae8c7"},
+	"eu-west-1":      &region{"ami-823686f5"},
+	"eu-central-1":   &region{"ami-ac1524b1"},
+	"sa-east-1":      &region{"ami-c770c1da"},
+	"us-east-1":      &region{"ami-4ae27e22"},
+	"us-west-1":      &region{"ami-d1180894"},
+	"us-west-2":      &region{"ami-898dd9b9"},
+	"us-gov-west-1":  &region{"ami-cf5630ec"},
+}
+
+func awsRegionsList() []string {
+	var list []string
+
+	for k, _ := range regionDetails {
+		list = append(list, k)
+	}
+
+	return list
+}
+
+func validateAwsRegion(region string) (string, error) {
+	for _, v := range awsRegionsList() {
+		if v == region {
+			return region, nil
+		}
+	}
+
+	return "", errInvalidRegion
+}

--- a/drivers/awsec2/utils.go
+++ b/drivers/awsec2/utils.go
@@ -5,9 +5,10 @@ import (
 )
 
 var (
-	errInvalidRegion = errors.New("invalid region specified")
-	errNoVpcs        = errors.New("No VPCs found in region")
-	errComplete      = errors.New("Complete")
+	errInvalidRegion  = errors.New("invalid region specified")
+	errNoVpcs         = errors.New("No VPCs found in region")
+	errMachineFailure = errors.New("Machine failed to start")
+	errComplete       = errors.New("Complete")
 )
 
 type region struct {


### PR DESCRIPTION
The EC2 driver needs some robustness adding and a few other nice options adding.

I've decided to create an `awsec2` driver to keep my work separate. I have deliberately chosen to take some key args (`aws-access-key-id` and so on) since they're well known in other apps.

This implementation will use stripe/aws-go instead of the homebrewed solution that's currently being used in the `amazonec2` driver.