### PR TITLE
Use actual binary name instead of hardcoding it

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 
 	app := cli.NewApp()
-	app.Name = "machine"
+	app.Name = os.Args[0]
 	app.Commands = Commands
 	app.CommandNotFound = cmdNotFound
 	app.Usage = "Create and manage machines running Docker."


### PR DESCRIPTION
There's a few reasons to use proposed approach:

1. The usage simply may give wrong instructions i.e. "Run `machine`" when the binary may actually have different name and it by default has when building through `gox` and keeping the original filename.
2. Even advising user to move it anywhere under `machine` is not great as there's `/usr/bin/machine` built-in OSX (_yes, I know that not many people will actually use the original command, but the approach of covering a binary which comes with the OS is generally not nice_):

```
MACHINE(1)                BSD General Commands Manual               MACHINE(1)

NAME
     machine -- print machine type

SYNOPSIS
     machine

DESCRIPTION
     The machine command displays the machine type.

SEE ALSO
     arch(1), make(1)

BSD                              July 26, 1991                             BSD
```