### PR TITLE
Create / Re-use existing EC2 security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,17 @@ Create machines on [Amazon Web Services](http://aws.amazon.com).  You will need 
 
 Options:
 
- - `--amazonec2-access-key`: Your access key id for the Amazon Web Services API.
- - `--amazonec2-ami`: The AMI ID of the instance to use  Default: `ami-a00461c8`
+ - `--amazonec2-access-key`: **required** Your access key id for the Amazon Web Services API.
+ - `--amazonec2-ami`: The AMI ID of the instance to use  Default: `ami-4ae27e22`
  - `--amazonec2-instance-type`: The instance type to run.  Default: `t2.micro`
  - `--amazonec2-region`: The region to use when launching the instance.  Default: `us-east-1`
  - `--amazonec2-root-size`: The root disk size of the instance (in GB).  Default: `16`
- - `--amazonec2-secret-key`: Your secret access key for the Amazon Web Services API.
+ - `--amazonec2-secret-key`: **required** Your secret access key for the Amazon Web Services API.
+ - `--amazonec2-security-group-name`: AWS VPC security group name. Default: `docker-machine`
  - `--amazonec2-session-token`: Your session token for the Amazon Web Services API.
- - `--amazonec2-vpc-id`: Your VPC ID to launch the instance in.
- - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e).
+ - `--amazonec2-subnet-id`: AWS VPC subnet id
+ - `--amazonec2-vpc-id`: **required** Your VPC ID to launch the instance in.
+ - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e). Default: `a`
 
 ### Google Compute Engine
 

--- a/docs/dockermachine.md
+++ b/docs/dockermachine.md
@@ -454,15 +454,17 @@ Create machines on [Amazon Web Services](http://aws.amazon.com).  You will need 
 
 Options:
 
- - `--amazonec2-access-key`: Your access key id for the Amazon Web Services API.
- - `--amazonec2-ami`: The AMI ID of the instance to use  Default: `ami-a00461c8`
+ - `--amazonec2-access-key`: **required** Your access key id for the Amazon Web Services API.
+ - `--amazonec2-ami`: The AMI ID of the instance to use  Default: `ami-4ae27e22`
  - `--amazonec2-instance-type`: The instance type to run.  Default: `t2.micro`
  - `--amazonec2-region`: The region to use when launching the instance.  Default: `us-east-1`
  - `--amazonec2-root-size`: The root disk size of the instance (in GB).  Default: `16`
- - `--amazonec2-secret-key`: Your secret access key for the Amazon Web Services API.
+ - `--amazonec2-secret-key`: **required** Your secret access key for the Amazon Web Services API.
+ - `--amazonec2-security-group`: AWS VPC security group name. Default: `docker-machine`
  - `--amazonec2-session-token`: Your session token for the Amazon Web Services API.
- - `--amazonec2-vpc-id`: Your VPC ID to launch the instance in.
- - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e).
+ - `--amazonec2-subnet-id`: AWS VPC subnet id
+ - `--amazonec2-vpc-id`: **required** Your VPC ID to launch the instance in.
+ - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e). Default: `a`
 
 #### Digital Ocean
 Creates machines on [Digital Ocean](https://www.digitalocean.com/). You need to create a personal access token under "Apps & API" in the Digital Ocean Control Panel and pass that to `docker-machine create` with the `--digitalocean-access-token` option.

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -125,10 +125,10 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "AWS_SUBNET_ID",
 		},
 		cli.StringFlag{
-			Name:   "amazonec2-security-group-name",
-			Usage:  "AWS VPC security group name",
+			Name:   "amazonec2-security-group",
+			Usage:  "AWS VPC security group",
 			Value:  "docker-machine",
-			EnvVar: "AWS_SECURITY_GROUP_NAME",
+			EnvVar: "AWS_SECURITY_GROUP",
 		},
 		cli.StringFlag{
 			Name:   "amazonec2-instance-type",
@@ -159,7 +159,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.InstanceType = flags.String("amazonec2-instance-type")
 	d.VpcId = flags.String("amazonec2-vpc-id")
 	d.SubnetId = flags.String("amazonec2-subnet-id")
-	d.SecurityGroupName = flags.String("amazonec2-security-group-name")
+	d.SecurityGroupName = flags.String("amazonec2-security-group")
 	zone := flags.String("amazonec2-zone")
 	d.Zone = zone[:]
 	d.RootSize = int64(flags.Int("amazonec2-root-size"))

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -32,9 +32,9 @@ func TestConfigureSecurityGroupPermissionsSshOnly(t *testing.T) {
 
 	group.IpPermissions = []amz.IpPermission{
 		{
-			Protocol: "tcp",
-			FromPort: testSshPort,
-			ToPort:   testSshPort,
+			IpProtocol: "tcp",
+			FromPort:   testSshPort,
+			ToPort:     testSshPort,
 		},
 	}
 
@@ -54,9 +54,9 @@ func TestConfigureSecurityGroupPermissionsDockerOnly(t *testing.T) {
 
 	group.IpPermissions = []amz.IpPermission{
 		{
-			Protocol: "tcp",
-			FromPort: testDockerPort,
-			ToPort:   testDockerPort,
+			IpProtocol: "tcp",
+			FromPort:   testDockerPort,
+			ToPort:     testDockerPort,
 		},
 	}
 
@@ -76,14 +76,14 @@ func TestConfigureSecurityGroupPermissionsDockerAndSsh(t *testing.T) {
 
 	group.IpPermissions = []amz.IpPermission{
 		{
-			Protocol: "tcp",
-			FromPort: testSshPort,
-			ToPort:   testSshPort,
+			IpProtocol: "tcp",
+			FromPort:   testSshPort,
+			ToPort:     testSshPort,
 		},
 		{
-			Protocol: "tcp",
-			FromPort: testDockerPort,
-			ToPort:   testDockerPort,
+			IpProtocol: "tcp",
+			FromPort:   testDockerPort,
+			ToPort:     testDockerPort,
 		},
 	}
 

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -1,0 +1,94 @@
+package amazonec2
+
+import (
+	"testing"
+
+	"github.com/docker/machine/drivers/amazonec2/amz"
+)
+
+var (
+	securityGroup = amz.SecurityGroup{
+		GroupName: "test-group",
+		GroupId:   "12345",
+		VpcId:     "12345",
+	}
+)
+
+const (
+	testSshPort    = 22
+	testDockerPort = 2376
+)
+
+func TestConfigureSecurityGroupPermissionsEmpty(t *testing.T) {
+	group := securityGroup
+	perms := configureSecurityGroupPermissions(&group)
+	if len(perms) != 2 {
+		t.Fatalf("expected 2 permissions; received %d", len(perms))
+	}
+}
+
+func TestConfigureSecurityGroupPermissionsSshOnly(t *testing.T) {
+	group := securityGroup
+
+	group.IpPermissions = []amz.IpPermission{
+		{
+			Protocol: "tcp",
+			FromPort: testSshPort,
+			ToPort:   testSshPort,
+		},
+	}
+
+	perms := configureSecurityGroupPermissions(&group)
+	if len(perms) != 1 {
+		t.Fatalf("expected 1 permission; received %d", len(perms))
+	}
+
+	receivedPort := perms[0].FromPort
+	if receivedPort != testDockerPort {
+		t.Fatalf("expected permission on port %d; received port %d", testDockerPort, receivedPort)
+	}
+}
+
+func TestConfigureSecurityGroupPermissionsDockerOnly(t *testing.T) {
+	group := securityGroup
+
+	group.IpPermissions = []amz.IpPermission{
+		{
+			Protocol: "tcp",
+			FromPort: testDockerPort,
+			ToPort:   testDockerPort,
+		},
+	}
+
+	perms := configureSecurityGroupPermissions(&group)
+	if len(perms) != 1 {
+		t.Fatalf("expected 1 permission; received %d", len(perms))
+	}
+
+	receivedPort := perms[0].FromPort
+	if receivedPort != testSshPort {
+		t.Fatalf("expected permission on port %d; received port %d", testSshPort, receivedPort)
+	}
+}
+
+func TestConfigureSecurityGroupPermissionsDockerAndSsh(t *testing.T) {
+	group := securityGroup
+
+	group.IpPermissions = []amz.IpPermission{
+		{
+			Protocol: "tcp",
+			FromPort: testSshPort,
+			ToPort:   testSshPort,
+		},
+		{
+			Protocol: "tcp",
+			FromPort: testDockerPort,
+			ToPort:   testDockerPort,
+		},
+	}
+
+	perms := configureSecurityGroupPermissions(&group)
+	if len(perms) != 0 {
+		t.Fatalf("expected 0 permissions; received %d", len(perms))
+	}
+}

--- a/drivers/amazonec2/amz/describe_security_groups.go
+++ b/drivers/amazonec2/amz/describe_security_groups.go
@@ -1,7 +1,6 @@
 package amz
 
 type DescribeSecurityGroupsResponse struct {
-	RequestId         string `xml:"requestId"`
-	SecurityGroupInfo []struct {
-	} `xml:"securityGroupInfo>item"`
+	RequestId         string          `xml:"requestId"`
+	SecurityGroupInfo []SecurityGroup `xml:"securityGroupInfo>item"`
 }

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -347,7 +347,7 @@ func (e *EC2) AuthorizeSecurityGroup(groupId string, permissions []IpPermission)
 
 	for index, perm := range permissions {
 		n := index + 1 // amazon starts counting from 1 not 0
-		v.Set(fmt.Sprintf("IpPermissions.%d.IpProtocol", n), perm.Protocol)
+		v.Set(fmt.Sprintf("IpPermissions.%d.IpProtocol", n), perm.IpProtocol)
 		v.Set(fmt.Sprintf("IpPermissions.%d.FromPort", n), strconv.Itoa(perm.FromPort))
 		v.Set(fmt.Sprintf("IpPermissions.%d.ToPort", n), strconv.Itoa(perm.ToPort))
 		v.Set(fmt.Sprintf("IpPermissions.%d.IpRanges.1.CidrIp", n), perm.IpRange)
@@ -401,6 +401,21 @@ func (e *EC2) GetSecurityGroups() ([]SecurityGroup, error) {
 
 	return sgs, nil
 }
+
+func (e *EC2) GetSecurityGroupById(id string) (*SecurityGroup, error) {
+	groups, err := e.GetSecurityGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, g := range groups {
+		if g.GroupId == id {
+			return &g, nil
+		}
+	}
+	return nil, nil
+}
+
 func (e *EC2) GetSubnets() ([]Subnet, error) {
 	subnets := []Subnet{}
 	resp, err := e.performStandardAction("DescribeSubnets")

--- a/drivers/amazonec2/amz/ip_permission.go
+++ b/drivers/amazonec2/amz/ip_permission.go
@@ -1,8 +1,8 @@
 package amz
 
 type IpPermission struct {
-	Protocol string
-	FromPort int
-	ToPort   int
-	IpRange  string
+	IpProtocol string `xml:"ipProtocol"`
+	FromPort   int    `xml:"fromPort"`
+	ToPort     int    `xml:"toPort"`
+	IpRange    string `xml:"ipRanges"`
 }

--- a/drivers/amazonec2/amz/security_group.go
+++ b/drivers/amazonec2/amz/security_group.go
@@ -12,7 +12,9 @@ type DeleteSecurityGroupResponse struct {
 }
 
 type SecurityGroup struct {
-	GroupName string `xml:"groupName"`
-	GroupId   string `xml:"groupId"`
-	VpcId     string `xml:"vpcId"`
+	GroupName           string         `xml:"groupName"`
+	GroupId             string         `xml:"groupId"`
+	VpcId               string         `xml:"vpcId"`
+	IpPermissions       []IpPermission `xml:"ipPermissions,omitempty"`
+	IpPermissionsEgress []IpPermission `xml:"ipPermissionsEgress,omitempty"`
 }

--- a/drivers/amazonec2/amz/security_group.go
+++ b/drivers/amazonec2/amz/security_group.go
@@ -15,6 +15,7 @@ type SecurityGroup struct {
 	GroupName           string         `xml:"groupName"`
 	GroupId             string         `xml:"groupId"`
 	VpcId               string         `xml:"vpcId"`
-	IpPermissions       []IpPermission `xml:"ipPermissions,omitempty"`
-	IpPermissionsEgress []IpPermission `xml:"ipPermissionsEgress,omitempty"`
+	OwnerId             string         `xml:"ownerId"`
+	IpPermissions       []IpPermission `xml:"ipPermissions>item,omitempty"`
+	IpPermissionsEgress []IpPermission `xml:"ipPermissionsEgress>item,omitempty"`
 }

--- a/drivers/amazonec2/amz/security_group.go
+++ b/drivers/amazonec2/amz/security_group.go
@@ -12,6 +12,7 @@ type DeleteSecurityGroupResponse struct {
 }
 
 type SecurityGroup struct {
-	GroupId string
-	VpcId   string
+	GroupName string `xml:"groupName"`
+	GroupId   string `xml:"groupId"`
+	VpcId     string `xml:"vpcId"`
 }


### PR DESCRIPTION
This PR changes the way security groups are used in EC2.  Previously, a security group with the name of the machine would be created on each run.  This will use a default security group of `docker-machine` allowing for an optional name to be specified.  If the `docker-machine` or specified group does not exist, machine will create it.  Machine will then confirm (and update if necessary) the port authorizations needed (currently `22` for SSH and whatever the docker port is for the driver: default `2376`).

This PR also fixes a couple of race conditions in the EC2 driver found while testing: IP assigning and security group creation.

Refs: #387 