### PR TITLE
Use binary file name instead of full path

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -16,7 +17,7 @@ func main() {
 	}
 
 	app := cli.NewApp()
-	app.Name = os.Args[0]
+	app.Name = path.Base(os.Args[0])
 	app.Commands = Commands
 	app.CommandNotFound = cmdNotFound
 	app.Usage = "Create and manage machines running Docker."


### PR DESCRIPTION
@phemmer has fair point:
https://github.com/docker/swarm/pull/282#issuecomment-71190899

If the binary is called with absolute path, there's probably no point in printing the whole path.