### PR TITLE
enable specifying arch along with os when building

### DIFF
--- a/script/build
+++ b/script/build
@@ -2,11 +2,17 @@
 set -e
 
 if [ -z "$1" ]; then
-    OS_ARCH_ARG=(-os="darwin linux windows")
+    OS_PLATFORM_ARG=(-os="darwin linux windows")
 else
-    OS_ARCH_ARG=($1)
+    OS_PLATFORM_ARG=($1)
+fi
+
+if [ -z "$2" ]; then
+    OS_ARCH_ARG=(-arch="386 amd64")
+else
+    OS_ARCH_ARG=($2)
 fi
 
 rm -f docker-machine*
 docker build -t docker-machine .
-exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}"
+exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}"


### PR DESCRIPTION
This enables specifying the `-arch` flag to gox.

By default, it will build binaries for windows, darwin and linux for 32 and 64 bit.  With this PR, you can now specify what arch to build for:

Example with just linux on 64 bit:

`./script/build -os="linux" -arch="amd64"`
