### PR TITLE
use ubuntu for base image

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path"
 	"time"
@@ -262,7 +261,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("Installing Docker")
 
-	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sudo sh -; fi")
+	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
 	if err != nil {
 		return err
 
@@ -413,14 +412,19 @@ func (d *Driver) GetDockerConfigDir() string {
 }
 
 func (d *Driver) Upgrade() error {
-	sshCmd, err := d.GetSSHCommand("apt-get update && apt-get install -y lxc-docker")
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := d.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
 	if err != nil {
 		return err
+
 	}
-	sshCmd.Stdin = os.Stdin
-	sshCmd.Stdout = os.Stdout
-	sshCmd.Stderr = os.Stderr
-	return sshCmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+
+	}
+
+	return cmd.Run()
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -210,7 +210,7 @@ func (driver *Driver) Create() error {
 		return err
 	}
 
-	cmd, err := driver.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sh -; fi")
+	cmd, err := driver.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
 	if err != nil {
 		return err
 	}
@@ -459,7 +459,19 @@ func (driver *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 }
 
 func (driver *Driver) Upgrade() error {
-	return nil
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := driver.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
+	if err != nil {
+		return err
+
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+
+	}
+
+	return cmd.Run()
 }
 
 func generateVMName() string {

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -170,7 +169,7 @@ func (d *Driver) Create() error {
 
 	log.Debugf("Installing Docker")
 
-	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sudo sh -; fi")
+	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
 	if err != nil {
 		return err
 
@@ -309,17 +308,19 @@ func (d *Driver) GetDockerConfigDir() string {
 }
 
 func (d *Driver) Upgrade() error {
-	sshCmd, err := d.GetSSHCommand("apt-get update && apt-get install lxc-docker")
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := d.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
 	if err != nil {
 		return err
+
 	}
-	sshCmd.Stdin = os.Stdin
-	sshCmd.Stdout = os.Stdout
-	sshCmd.Stderr = os.Stderr
-	if err := sshCmd.Run(); err != nil {
-		return fmt.Errorf("%s", err)
+	if err := cmd.Run(); err != nil {
+		return err
+
 	}
-	return nil
+
+	return cmd.Run()
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -58,7 +58,7 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "DIGITALOCEAN_IMAGE",
 			Name:   "digitalocean-image",
 			Usage:  "Digital Ocean Image",
-			Value:  "docker",
+			Value:  "ubuntu-14-04-x64",
 		},
 		cli.StringFlag{
 			EnvVar: "DIGITALOCEAN_REGION",
@@ -166,6 +166,18 @@ func (d *Driver) Create() error {
 	}
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+
+	log.Debugf("Installing Docker")
+
+	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl get.docker.io | sudo sh -; fi")
+	if err != nil {
+		return err
+
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+
 	}
 
 	return nil

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -26,8 +26,9 @@ type ComputeUtil struct {
 }
 
 const (
-	apiURL             = "https://www.googleapis.com/compute/v1/projects/"
-	imageName          = "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20141016"
+	apiURL = "https://www.googleapis.com/compute/v1/projects/"
+	//imageName          = "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20141016"
+	imageName          = "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/ubuntu-1404"
 	firewallRule       = "docker-machines"
 	port               = "2376"
 	firewallTargetTag  = "docker-machine"
@@ -40,7 +41,7 @@ var (
 		`sudo mkdir -p /.docker/authorized-keys.d/
 sudo chown -R {{ .UserName }} /.docker
 while [ -e /var/run/docker.pid ]; do sleep 1; done
-sudo curl -s -L -o /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-latest
+curl -sL https://get.docker.com | sh
 `))
 )
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -404,7 +404,19 @@ func (d *Driver) Kill() error {
 }
 
 func (d *Driver) Upgrade() error {
-	return fmt.Errorf("unable to upgrade as we are using the custom docker binary with identity auth")
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := d.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
+	if err != nil {
+		return err
+
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+
+	}
+
+	return cmd.Run()
 }
 
 func (d *Driver) StartDocker() error {
@@ -740,7 +752,7 @@ func (d *Driver) installDocker() error {
 
 	if err := d.sshExec([]string{
 		`apt-get install -y curl`,
-		`curl -sSL https://get.docker.com | /bin/sh >/var/log/docker-install.log 2>&1`,
+		`curl -sSL https://get.docker.com | sh`,
 	}); err != nil {
 		log.Error("The docker installation failed.")
 		log.Error(

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -423,17 +423,19 @@ func (d *Driver) Stop() error {
 }
 
 func (d *Driver) Upgrade() error {
-	sshCmd, err := d.GetSSHCommand("curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-latest > /tmp/docker && chmod +x /tmp/docker && mv /tmp/docker $(which docker)")
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := d.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
 	if err != nil {
 		return err
+
 	}
-	sshCmd.Stdin = os.Stdin
-	sshCmd.Stdout = os.Stdout
-	sshCmd.Stderr = os.Stderr
-	if err := sshCmd.Run(); err != nil {
-		return fmt.Errorf("%s", err)
+	if err := cmd.Run(); err != nil {
+		return err
+
 	}
-	return nil
+
+	return cmd.Run()
 }
 
 func (d *Driver) setupHost() error {

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -7,7 +7,6 @@ package vmwarevcloudair
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -414,7 +413,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.Provision {
-		dockerInstall := "curl -sSL https://get.docker.com/ | sudo sh"
+		dockerInstall := "curl -sSL https://get.docker.com | sudo sh"
 
 		log.Infof("Installing Docker...")
 
@@ -742,19 +741,19 @@ func (d *Driver) GetDockerConfigDir() string {
 }
 
 func (d *Driver) Upgrade() error {
-	// Stolen from DigitalOcean ;-)
-	sshCmd, err := d.GetSSHCommand("apt-get update && apt-get install lxc-docker")
+	log.Debugf("Upgrading Docker")
+
+	cmd, err := d.GetSSHCommand("sudo apt-get update && apt-get install --upgrade lxc-docker")
 	if err != nil {
 		return err
-	}
-	sshCmd.Stdin = os.Stdin
-	sshCmd.Stdout = os.Stdout
-	sshCmd.Stderr = os.Stderr
-	if err := sshCmd.Run(); err != nil {
-		return fmt.Errorf("%s", err)
-	}
-	return nil
 
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+
+	}
+
+	return cmd.Run()
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {


### PR DESCRIPTION
We had originally started down this path with cloudinit but not all providers fully support it yet.  This consolidates the operating systems on the providers to give a consistent experience for machine.  In the future, we will improve this to be more performant and possibly move to "official" Docker images on the providers.  For now, this at least provides a consistent Docker experience in that Machines running on all providers now use the same version of Docker and the configuration with it (storage backends, TLS, etc).