### PR TITLE
add PreCreateCheck; check for existing ec2 keypair

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -33,6 +33,10 @@ func (d *FakeDriver) GetState() (state.State, error) {
 	return d.MockState, nil
 }
 
+func (d *FakeDriver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *FakeDriver) Create() error {
 	return nil
 }

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -182,7 +182,28 @@ func (d *Driver) DriverName() string {
 	return driverName
 }
 
+func (d *Driver) checkPrereqs() error {
+	// check for existing keypair
+	key, err := d.getClient().GetKeyPair(d.MachineName)
+	if err != nil {
+		return err
+	}
+
+	if key != nil {
+		return fmt.Errorf("There is already a keypair with the name %s.  Please either remove that keypair or use a different machine name.", d.MachineName)
+	}
+	return nil
+}
+
+func (d *Driver) PreCreateCheck() error {
+	return d.checkPrereqs()
+}
+
 func (d *Driver) Create() error {
+	if err := d.checkPrereqs(); err != nil {
+		return err
+	}
+
 	log.Infof("Launching instance...")
 
 	if err := d.createKeyPair(); err != nil {

--- a/drivers/amazonec2/amz/describe_keypairs.go
+++ b/drivers/amazonec2/amz/describe_keypairs.go
@@ -1,0 +1,6 @@
+package amz
+
+type DescribeKeyPairsResponse struct {
+	RequestId string    `xml:"requestId"`
+	KeySet    []KeyPair `xml:"keySet>item"`
+}

--- a/drivers/amazonec2/amz/keypair.go
+++ b/drivers/amazonec2/amz/keypair.go
@@ -11,3 +11,8 @@ type ImportKeyPairResponse struct {
 	KeyFingerprint string `xml:"keyFingerprint"`
 	KeyMaterial    []byte `xml:"keyMaterial"`
 }
+
+type KeyPair struct {
+	KeyFingerprint string `xml:"keyFingerprint"`
+	KeyName        string `xml:"keyName"`
+}

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -171,6 +171,10 @@ func (driver *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
+func (driver *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (driver *Driver) Create() error {
 	if err := driver.setUserSubscription(); err != nil {
 		return err

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -95,6 +95,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	log.Infof("Creating SSH key...")
 

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -32,6 +32,9 @@ type Driver interface {
 	// GetState returns the state that the host is in (running, stopped, etc)
 	GetState() (state.State, error)
 
+	// PreCreate allows for pre-create operations to make sure a driver is ready for creation
+	PreCreateCheck() error
+
 	// Create a host using the driver's config
 	Create() error
 

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -110,6 +110,10 @@ func (driver *Driver) initApis() (*ComputeUtil, error) {
 	return newComputeUtil(driver)
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 // Create creates a GCE VM instance acting as a docker host.
 func (driver *Driver) Create() error {
 	c, err := newComputeUtil(driver)

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -69,6 +69,10 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.None, nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	return nil
 }

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -312,6 +312,10 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.None, nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	d.KeyPairName = fmt.Sprintf("%s-%s", d.MachineName, utils.GenerateRandomID())
 

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -289,6 +289,10 @@ func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 	return ssh.GetSSHCommand(d.IPAddress, 22, "root", d.sshKeyPath(), args...), nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	waitForStart := func() {
 		log.Infof("Waiting for host to become available")

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -112,6 +112,10 @@ func cpIso(src, dest string) error {
 	return nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	var (
 		err    error

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -129,6 +129,10 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.Stopped, nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 
 	var (

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -260,6 +260,10 @@ func (d *Driver) GetState() (state.State, error) {
 
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 
 	key, err := d.createSSHKey()

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -215,6 +215,10 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.None, nil
 }
 
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
 // the current implementation does the following:
 // 1. check whether the docker directory contains the boot2docker ISO
 // 2. generate an SSH keypair

--- a/store.go
+++ b/store.go
@@ -31,7 +31,7 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		return nil, err
 	}
 	if exists {
-		return nil, fmt.Errorf("Host %q already exists", name)
+		return nil, fmt.Errorf("Machine %s already exists", name)
 	}
 
 	hostPath := filepath.Join(s.Path, name)
@@ -44,6 +44,10 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		if err := host.Driver.SetConfigFromFlags(flags); err != nil {
 			return host, err
 		}
+	}
+
+	if err := host.Driver.PreCreateCheck(); err != nil {
+		return nil, err
 	}
 
 	if err := os.MkdirAll(hostPath, 0700); err != nil {


### PR DESCRIPTION
This adds a method to the Driver: PreCreateCheck.  This can be used where you want to run some prerequisite checks before attempting to create the machine.  In the case of EC2, this is a check for an existingkeypair.  This can be used in the other drivers in the future as well.

Fixes #385