### PR TITLE
Update to TLS Certificates

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -342,7 +342,7 @@ func cmdShellinit(c *cli.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("export DOCKER_TLS_VERIFY=yes\nexport DOCKER_CERT_PATH=%s\nexport DOCKER_URL=%s\n",
+	fmt.Printf("export DOCKER_TLS_VERIFY=yes\nexport DOCKER_CERT_PATH=%s\nexport DOCKER_HOST=%s\n",
 		utils.GetMachineClientCertDir(), cfg.machineUrl)
 }
 

--- a/commands.go
+++ b/commands.go
@@ -208,7 +208,6 @@ func cmdCreate(c *cli.Context) {
 }
 
 func cmdConfig(c *cli.Context) {
-
 	name := c.Args().First()
 	if name == "" {
 		cli.ShowCommandHelp(c, "config")
@@ -222,9 +221,9 @@ func cmdConfig(c *cli.Context) {
 		log.Fatalf("Error loading machine config: %s", err)
 	}
 
-	caCert := filepath.Join(utils.GetMachineDir(), "ca.pem")
-	clientCert := filepath.Join(utils.GetMachineDir(), "client.pem")
-	clientKey := filepath.Join(utils.GetMachineDir(), "client-key.pem")
+	caCert := filepath.Join(utils.GetMachineClientCertDir(), "ca.pem")
+	clientCert := filepath.Join(utils.GetMachineClientCertDir(), "cert.pem")
+	clientKey := filepath.Join(utils.GetMachineClientCertDir(), "key.pem")
 	machineUrl, err := host.GetURL()
 	if err != nil {
 		log.Fatalf("Error getting machine url: %s", err)

--- a/commands.go
+++ b/commands.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/docker/machine/drivers/vmwarevcloudair"
 	_ "github.com/docker/machine/drivers/vmwarevsphere"
 	"github.com/docker/machine/state"
+	"github.com/docker/machine/utils"
 )
 
 type hostListItem struct {
@@ -156,7 +157,7 @@ var Commands = []cli.Command{
 
 func cmdActive(c *cli.Context) {
 	name := c.Args().First()
-	store := NewStore(c.GlobalString("storage-path"), c.GlobalString("auth-ca"), c.GlobalString("auth-key"))
+	store := NewStore(c.GlobalString("storage-path"), c.GlobalString("tls-ca-cert"), c.GlobalString("tls-ca-key"))
 
 	if name == "" {
 		host, err := store.GetActive()
@@ -221,10 +222,9 @@ func cmdConfig(c *cli.Context) {
 		log.Fatalf("Error loading machine config: %s", err)
 	}
 
-	storeDir := store.Path
-	caCert := filepath.Join(storeDir, name, "ca.pem")
-	clientCert := filepath.Join(storeDir, name, "cert.pem")
-	clientKey := filepath.Join(storeDir, name, "key.pem")
+	caCert := filepath.Join(utils.GetMachineDir(), "ca.pem")
+	clientCert := filepath.Join(utils.GetMachineDir(), "client.pem")
+	clientKey := filepath.Join(utils.GetMachineDir(), "client-key.pem")
 	machineUrl, err := host.GetURL()
 	if err != nil {
 		log.Fatalf("Error getting machine url: %s", err)

--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -4,22 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
+
+	"github.com/docker/machine/utils"
 )
 
-func GetHomeDir() string {
-	if runtime.GOOS == "windows" {
-		return os.Getenv("USERPROFILE")
-	}
-	return os.Getenv("HOME")
-}
-
-func GetDockerDir() string {
-	return fmt.Sprintf(filepath.Join(GetHomeDir(), ".docker"))
-}
-
 func PublicKeyPath() string {
-	return filepath.Join(GetHomeDir(), ".docker", "public-key.json")
+	return filepath.Join(utils.GetHomeDir(), ".docker", "public-key.json")
 }
 
 func AddPublicKeyToAuthorizedHosts(d Driver, authorizedKeysPath string) error {

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -143,7 +143,7 @@ func (d *Driver) Create() error {
 		}
 
 		// todo: use real constant for .docker
-		rootPath := filepath.Join(drivers.GetHomeDir(), ".docker")
+		rootPath := filepath.Join(utils.GetHomeDir(), ".docker")
 		imgPath := filepath.Join(rootPath, "images")
 		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -151,7 +151,7 @@ func (d *Driver) Create() error {
 		}
 
 		// todo: use real constant for .docker
-		rootPath := filepath.Join(drivers.GetHomeDir(), ".docker")
+		rootPath := filepath.Join(utils.GetHomeDir(), ".docker")
 		imgPath := filepath.Join(rootPath, "images")
 		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -244,8 +244,7 @@ func (d *Driver) Create() error {
 			return err
 		}
 
-		// todo: use real constant for .docker
-		rootPath := filepath.Join(drivers.GetHomeDir(), ".docker")
+		rootPath := utils.GetDockerDir()
 		imgPath := filepath.Join(rootPath, "images")
 		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {

--- a/host.go
+++ b/host.go
@@ -117,7 +117,8 @@ func (h *Host) ConfigureAuth() error {
 	caKeyPath := filepath.Join(utils.GetMachineDir(), "key.pem")
 	serverCertPath := filepath.Join(h.storePath, "server.pem")
 	serverKeyPath := filepath.Join(h.storePath, "server-key.pem")
-	org := "docker"
+
+	org := h.Name
 	bits := 2048
 
 	log.Debugf("generating server cert: %s", serverCertPath)

--- a/host.go
+++ b/host.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"time"
@@ -83,59 +84,15 @@ func ValidateHostName(name string) (string, error) {
 	return name, nil
 }
 
-func (h *Host) GenerateCertificates() error {
+func GenerateClientCertificate(caCertPath, privateKeyPath string) error {
 	var (
-		caPathExists     bool
-		privateKeyExists bool
-		org              = "docker-machine"
-		bits             = 2048
+		org  = "docker-machine"
+		bits = 2048
 	)
 
-	ip, err := h.Driver.GetIP()
-	if err != nil {
-		return err
-	}
+	clientCertPath := filepath.Join(utils.GetMachineDir(), "cert.pem")
+	clientKeyPath := filepath.Join(utils.GetMachineDir(), "key.pem")
 
-	caCertPath := filepath.Join(h.storePath, "ca.pem")
-	privateKeyPath := filepath.Join(h.storePath, "private.pem")
-
-	if _, err := os.Stat(h.CaCertPath); os.IsNotExist(err) {
-		caPathExists = false
-	} else {
-		caPathExists = true
-	}
-
-	if _, err := os.Stat(h.PrivateKeyPath); os.IsNotExist(err) {
-		privateKeyExists = false
-	} else {
-		privateKeyExists = true
-	}
-
-	if !caPathExists && !privateKeyExists {
-		log.Debugf("generating self-signed CA cert: %s", caCertPath)
-		if err := utils.GenerateCACert(caCertPath, privateKeyPath, org, bits); err != nil {
-			return fmt.Errorf("error generating self-signed CA cert: %s", err)
-		}
-	} else {
-		if err := utils.CopyFile(h.CaCertPath, caCertPath); err != nil {
-			return fmt.Errorf("unable to copy CA cert: %s", err)
-		}
-		if err := utils.CopyFile(h.PrivateKeyPath, privateKeyPath); err != nil {
-			return fmt.Errorf("unable to copy private key: %s", err)
-		}
-	}
-
-	serverCertPath := filepath.Join(h.storePath, "server.pem")
-	serverKeyPath := filepath.Join(h.storePath, "server-key.pem")
-
-	log.Debugf("generating server cert: %s", serverCertPath)
-
-	if err := utils.GenerateCert([]string{ip}, serverCertPath, serverKeyPath, caCertPath, privateKeyPath, org, bits); err != nil {
-		return fmt.Errorf("error generating server cert: %s", err)
-	}
-
-	clientCertPath := filepath.Join(h.storePath, "cert.pem")
-	clientKeyPath := filepath.Join(h.storePath, "key.pem")
 	log.Debugf("generating client cert: %s", clientCertPath)
 	if err := utils.GenerateCert([]string{""}, clientCertPath, clientKeyPath, caCertPath, privateKeyPath, org, bits); err != nil {
 		return fmt.Errorf("error generating client cert: %s", err)
@@ -151,14 +108,23 @@ func (h *Host) ConfigureAuth() error {
 		return nil
 	}
 
-	log.Debugf("generating certificates for %s", h.Name)
-	if err := h.GenerateCertificates(); err != nil {
+	ip, err := h.Driver.GetIP()
+	if err != nil {
 		return err
 	}
 
+	caCertPath := filepath.Join(utils.GetMachineDir(), "ca.pem")
+	caKeyPath := filepath.Join(utils.GetMachineDir(), "key.pem")
 	serverCertPath := filepath.Join(h.storePath, "server.pem")
-	caCertPath := filepath.Join(h.storePath, "ca.pem")
 	serverKeyPath := filepath.Join(h.storePath, "server-key.pem")
+	org := "docker"
+	bits := 2048
+
+	log.Debugf("generating server cert: %s", serverCertPath)
+
+	if err := utils.GenerateCert([]string{ip}, serverCertPath, serverKeyPath, caCertPath, caKeyPath, org, bits); err != nil {
+		return fmt.Errorf("error generating server cert: %s", err)
+	}
 
 	if err := d.StopDocker(); err != nil {
 		return err
@@ -180,19 +146,19 @@ func (h *Host) ConfigureAuth() error {
 
 	// due to windows clients, we cannot use filepath.Join as the paths
 	// will be mucked on the linux hosts
-	machineCaCertPath := fmt.Sprintf("%s/ca.pem", d.GetDockerConfigDir())
+	machineCaCertPath := path.Join(d.GetDockerConfigDir(), "ca.pem")
 
 	serverCert, err := ioutil.ReadFile(serverCertPath)
 	if err != nil {
 		return err
 	}
-	machineServerCertPath := fmt.Sprintf("%s/server.pem", d.GetDockerConfigDir())
+	machineServerCertPath := path.Join(d.GetDockerConfigDir(), "server.pem")
 
 	serverKey, err := ioutil.ReadFile(serverKeyPath)
 	if err != nil {
 		return err
 	}
-	machineServerKeyPath := fmt.Sprintf("%s/server-key.pem", d.GetDockerConfigDir())
+	machineServerKeyPath := path.Join(d.GetDockerConfigDir(), "server-key.pem")
 
 	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(caCert), machineCaCertPath))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,11 @@ func before(c *cli.Context) error {
 	caKeyPath := c.GlobalString("tls-ca-key")
 	clientCertPath := c.GlobalString("tls-client-cert")
 	clientKeyPath := c.GlobalString("tls-client-key")
-	org := "docker"
+
+	org, err := utils.GetUsername()
+	if err != nil {
+		return err
+	}
 	bits := 2048
 
 	if _, err := os.Stat(utils.GetMachineDir()); err != nil {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,16 @@ func before(c *cli.Context) error {
 	org := "docker"
 	bits := 2048
 
+	if _, err := os.Stat(utils.GetDockerDir()); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(utils.GetDockerDir(), 0700); err != nil {
+				log.Fatalf("Error creating docker config dir: %s", err)
+			}
+		} else {
+			log.Fatal(err)
+		}
+	}
+
 	if _, err := os.Stat(utils.GetMachineDir()); err != nil {
 		if os.IsNotExist(err) {
 			if err := os.Mkdir(utils.GetMachineDir(), 0700); err != nil {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func before(c *cli.Context) error {
 	}
 
 	if _, err := os.Stat(clientCertPath); os.IsNotExist(err) {
-		log.Debugf("Creating client certificate: %s", clientCertPath)
+		log.Infof("Creating client certificate: %s", clientCertPath)
 
 		if _, err := os.Stat(utils.GetMachineClientCertDir()); err != nil {
 			if os.IsNotExist(err) {

--- a/main.go
+++ b/main.go
@@ -19,19 +19,9 @@ func before(c *cli.Context) error {
 	org := "docker"
 	bits := 2048
 
-	if _, err := os.Stat(utils.GetDockerDir()); err != nil {
-		if os.IsNotExist(err) {
-			if err := os.Mkdir(utils.GetDockerDir(), 0700); err != nil {
-				log.Fatalf("Error creating docker config dir: %s", err)
-			}
-		} else {
-			log.Fatal(err)
-		}
-	}
-
 	if _, err := os.Stat(utils.GetMachineDir()); err != nil {
 		if os.IsNotExist(err) {
-			if err := os.Mkdir(utils.GetMachineDir(), 0700); err != nil {
+			if err := os.MkdirAll(utils.GetMachineDir(), 0700); err != nil {
 				log.Fatalf("Error creating machine config dir: %s", err)
 			}
 		} else {

--- a/store.go
+++ b/store.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/utils"
 )
 
 // Store persists hosts on the filesystem
@@ -19,7 +20,7 @@ type Store struct {
 
 func NewStore(rootPath string, caCert string, privateKey string) *Store {
 	if rootPath == "" {
-		rootPath = filepath.Join(drivers.GetHomeDir(), ".docker", "machines")
+		rootPath = utils.GetMachineDir()
 	}
 
 	return &Store{Path: rootPath, CaCertPath: caCert, PrivateKeyPath: privateKey}

--- a/store.go
+++ b/store.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/machine/drivers"
@@ -94,7 +95,8 @@ func (s *Store) List() ([]Host, error) {
 	hosts := []Host{}
 
 	for _, file := range dir {
-		if file.IsDir() {
+		// don't load hidden dirs; used for configs
+		if file.IsDir() && strings.Index(file.Name(), ".") != 0 {
 			host, err := s.Load(file.Name())
 			if err != nil {
 				log.Errorf("error loading host %q: %s", file.Name(), err)

--- a/store_test.go
+++ b/store_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/machine/drivers"
 	_ "github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/utils"
 )
 
 type DriverOptionsMock struct {
@@ -27,7 +27,7 @@ func (d DriverOptionsMock) Bool(key string) bool {
 }
 
 func clearHosts() error {
-	return os.RemoveAll(path.Join(drivers.GetHomeDir(), ".docker", "machines"))
+	return os.RemoveAll(path.Join(utils.GetHomeDir(), ".docker", "machines"))
 }
 
 func TestStoreCreate(t *testing.T) {
@@ -50,7 +50,7 @@ func TestStoreCreate(t *testing.T) {
 	if host.Name != "test" {
 		t.Fatal("Host name is incorrect")
 	}
-	path := filepath.Join(drivers.GetHomeDir(), ".docker", "machines", "test")
+	path := filepath.Join(utils.GetHomeDir(), ".docker", "machines", "test")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Fatalf("Host path doesn't exist: %s", path)
 	}
@@ -72,7 +72,7 @@ func TestStoreRemove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(drivers.GetHomeDir(), ".docker", "machines", "test")
+	path := filepath.Join(utils.GetHomeDir(), ".docker", "machines", "test")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Fatalf("Host path doesn't exist: %s", path)
 	}

--- a/utils/certs.go
+++ b/utils/certs.go
@@ -40,10 +40,10 @@ func newCertificate(org string) (*x509.Certificate, error) {
 
 }
 
-// GenerateCACert generates a new certificate authority from the specified org
+// GenerateCACertificate generates a new certificate authority from the specified org
 // and bit size and stores the resulting certificate and key file
 // in the arguments.
-func GenerateCACert(certFile, keyFile, org string, bits int) error {
+func GenerateCACertificate(certFile, keyFile, org string, bits int) error {
 	template, err := newCertificate(org)
 	if err != nil {
 		return err

--- a/utils/certs.go
+++ b/utils/certs.go
@@ -93,7 +93,7 @@ func GenerateCert(hosts []string, certFile, keyFile, caFile, caKeyFile, org stri
 	}
 	// client
 	if len(hosts) == 1 && hosts[0] == "" {
-		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
 		template.KeyUsage = x509.KeyUsageDigitalSignature
 	} else { // server
 		for _, h := range hosts {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,11 +15,15 @@ func GetHomeDir() string {
 }
 
 func GetDockerDir() string {
-	return fmt.Sprintf(filepath.Join(GetHomeDir(), ".docker"))
+	return filepath.Join(GetHomeDir(), ".docker")
 }
 
 func GetMachineDir() string {
-	return fmt.Sprintf(filepath.Join(GetDockerDir(), "machines"))
+	return filepath.Join(GetDockerDir(), "machines")
+}
+
+func GetMachineClientCertDir() string {
+	return filepath.Join(GetMachineDir(), ".client")
 }
 
 func CopyFile(src, dst string) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 )
@@ -24,6 +25,15 @@ func GetMachineDir() string {
 
 func GetMachineClientCertDir() string {
 	return filepath.Join(GetMachineDir(), ".client")
+}
+
+func GetUsername() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return u.Username, nil
 }
 
 func CopyFile(src, dst string) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,9 +1,27 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 )
+
+func GetHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	}
+	return os.Getenv("HOME")
+}
+
+func GetDockerDir() string {
+	return fmt.Sprintf(filepath.Join(GetHomeDir(), ".docker"))
+}
+
+func GetMachineDir() string {
+	return fmt.Sprintf(filepath.Join(GetDockerDir(), "machines"))
+}
 
 func CopyFile(src, dst string) error {
 	in, err := os.Open(src)


### PR DESCRIPTION
This PR does the following:

- adds ServerAuth to the ExtKeyUsage (needed for some servers and swarm)
- no longer generates new CA and client certs for each machine - creates a single for the client (allows for easier sharing and a better CA workflow)
- uses a separate directory for the client cert and key (this allows for the Docker client to work using env vars)
- adds a `shellinit` command (refs: #251) for an easier local development workflow and b2d compatibility

This now enables the following (like b2d):

```
$>  docker-machine create -d virtualbox dev

$>  docker-machine shellinit dev
export DOCKER_TLS_VERIFY=yes
export DOCKER_CERT_PATH=/Users/ehazlett/.docker/machines/.client
export DOCKER_URL=tcp://192.168.99.104:2376

$>  $(docker-machine shellinit dev)
$>  docker ps
NAME        ACTIVE   DRIVER       STATE     URL
dev         *        virtualbox   Running   tcp://192.168.99.104:2376
```
Closes #397