### PR TITLE
Quick PR : Change markdowns tags to not met git conflicts markers accidentaly

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ run:
 
 If you have any questions we're in #docker-machine on Freenode.
 
-=======
 ## Integration Tests
 There is a suite of integration tests that will run for the drivers.  In order
 to use these you must export the corresponding environment variables for each

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,13 @@
-Roadmap
-=======
+# Roadmap
 
-Machine 1.0
------------
+
+## Machine 1.0
 
 This will be a stable version of the current design with additional drivers and complete documentation.
 
 You can follow progress towards this release with the [GitHub milestone](https://github.com/docker/machine/milestones/1.0).
 
-Future
-------
+## Future
 
 There are two main areas for future development:
 

--- a/script/validate-git-marks
+++ b/script/validate-git-marks
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+IN_MARK=$(grep -r "^<<<<<<<" *)
+if [ $? -eq 0 ]; then
+	echo "-- Git conflict marks have been found, please correct them :"
+	echo "$IN_MARK"
+	exit 1
+fi
+
+OUT_MARK=$(grep -r "^>>>>>>>" *)
+if [ $? -eq 0 ]; then
+	echo "-- Git conflict marks have been found, please correct them :"
+	echo "$OUT_MARK"
+	exit 1
+fi
+
+SEPARATE_MARK=$(grep -r "^=======$" *)
+if [ $? -eq 0 ]; then
+	echo "-- Git conflict marks have been found, please correct them :"
+	echo "$SEPARATE_MARK"
+	exit 1
+fi
+
+echo "-- Congratulations : no git conflict marks have been found !"


### PR DESCRIPTION
Given that some contributors have long running PR (i'm in this case :) ) , and they use rebasing with rerere to not repeat themselves during master rebases (hey guys, you are very fast when developing @Docker ;) ), this PR just make sure that there is no git conflict marker inside the .md files.

Before that, trying to use git rerere ended in
```
error: Could not parse conflict hunks in README.md
```

I also added a little validation script which will check in, out and separate conflict markers.

Thanks !

Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>