### PR TITLE
Ensure server cert generation uses env variables

### DIFF
--- a/host.go
+++ b/host.go
@@ -123,8 +123,6 @@ func (h *Host) ConfigureAuth() error {
 		return err
 	}
 
-	caCertPath := filepath.Join(utils.GetMachineDir(), "ca.pem")
-	caKeyPath := filepath.Join(utils.GetMachineDir(), "key.pem")
 	serverCertPath := filepath.Join(h.storePath, "server.pem")
 	serverKeyPath := filepath.Join(h.storePath, "server-key.pem")
 

--- a/main.go
+++ b/main.go
@@ -10,10 +10,14 @@ import (
 	"github.com/docker/machine/utils"
 )
 
+var (
+	caCertPath, caKeyPath string
+)
+
 func before(c *cli.Context) error {
 
-	caCertPath := c.GlobalString("tls-ca-cert")
-	caKeyPath := c.GlobalString("tls-ca-key")
+	caCertPath = c.GlobalString("tls-ca-cert")
+	caKeyPath = c.GlobalString("tls-ca-key")
 	clientCertPath := c.GlobalString("tls-client-cert")
 	clientKeyPath := c.GlobalString("tls-client-key")
 


### PR DESCRIPTION
If env variables exist for the CA and CA key paths we need to use these to
generate the server certificates instead of the defaults.

This should fix #411.