### PR TITLE
remove name option from azure driver

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -29,7 +29,6 @@ type Driver struct {
 	SubscriptionID          string
 	SubscriptionCert        string
 	PublishSettingsFilePath string
-	Name                    string
 	Location                string
 	Size                    string
 	UserName                string
@@ -68,10 +67,6 @@ func GetCreateFlags() []cli.Flag {
 			Name:   "azure-location",
 			Usage:  "Azure location",
 			Value:  "West US",
-		},
-		cli.StringFlag{
-			Name:  "azure-name",
-			Usage: "Azure cloud service name",
 		},
 		cli.StringFlag{
 			Name:  "azure-password",


### PR DESCRIPTION
This removes the `name` option from the azure driver as it is automatically set to the machine name now.