### PR TITLE
Change message to use machine env.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -215,8 +215,7 @@ func cmdCreate(c *cli.Context) {
 	}
 
 	log.Infof("%q has been created and is now the active machine", name)
-	// TODO @ehazlett: this will likely change but at least show how to connect for now
-	log.Infof("To connect: docker $(%s config %s) ps", c.App.Name, name)
+	log.Infof("Configure docker client with: $(%s env %s)", c.App.Name, name)
 }
 
 func cmdConfig(c *cli.Context) {


### PR DESCRIPTION
So basically this is just a UI fix that informs users to use machine env, instead of docker $(machine config) to configure their docker client to connect to the machine.

This is my suggestion, the comments section is for discussion if there is a better way to say it.