### PR TITLE
[WIP] Support for exporting environment variables (e.g. HTTP_PROXY support)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -76,6 +76,11 @@ var Commands = []cli.Command{
 				),
 				Value: "none",
 			},
+			cli.StringSliceFlag{
+				Name:  "environment, e",
+				Usage: "Environment variables to export. e.g. -e HTTP_PROXY=http://example.org:8080 -e HTTPS_PROXY=http://example.org:8080",
+				Value: &cli.StringSlice{},
+			},
 		),
 		Name:   "create",
 		Usage:  "Create a machine",
@@ -196,6 +201,7 @@ func cmdActive(c *cli.Context) {
 func cmdCreate(c *cli.Context) {
 	driver := c.String("driver")
 	name := c.Args().First()
+	environment := c.StringSlice("environment")
 
 	if name == "" {
 		cli.ShowCommandHelp(c, "create")
@@ -204,7 +210,7 @@ func cmdCreate(c *cli.Context) {
 
 	store := NewStore(c.GlobalString("storage-path"), c.GlobalString("tls-ca-cert"), c.GlobalString("tls-ca-key"))
 
-	host, err := store.Create(name, driver, c)
+	host, err := store.Create(name, driver, c, &environment)
 	if err != nil {
 		log.Errorf("Error creating machine: %s", err)
 		log.Warn("You will want to check the provider to make sure the machine and associated resources were properly removed.")

--- a/store.go
+++ b/store.go
@@ -27,7 +27,7 @@ func NewStore(rootPath string, caCert string, privateKey string) *Store {
 	return &Store{Path: rootPath, CaCertPath: caCert, PrivateKeyPath: privateKey}
 }
 
-func (s *Store) Create(name string, driverName string, flags drivers.DriverOptions) (*Host, error) {
+func (s *Store) Create(name string, driverName string, flags drivers.DriverOptions, environment *[]string) (*Host, error) {
 	exists, err := s.Exists(name)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 
 	hostPath := filepath.Join(s.Path, name)
 
-	host, err := NewHost(name, driverName, hostPath, s.CaCertPath, s.PrivateKeyPath)
+	host, err := NewHost(name, driverName, hostPath, s.CaCertPath, s.PrivateKeyPath, environment)
 	if err != nil {
 		return host, err
 	}


### PR DESCRIPTION
On our corporate network, we're required to specify the HTTP_PROXY and HTTPS_PROXY environment variables in order to fetch the images we are attempting to deploy as containers on the provisioned machines.

This applies to both our local environments using the VirtualBox driver and our staging environments that use vSphere.