### PR TITLE
use hostname for azure instead of generating

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Options:
  - `--azure-subscription-id`: Your Azure subscription ID.
  - `--azure-subscription-cert`: Your Azure subscription cert.
 
+Note: the machine name will be used as DNS name for the Cloud Service (e.g. machinename.cloudapp.net)
+
 ### Amazon EC2
 
 Create machines on [Amazon Web Services](http://aws.amazon.com).  You will need an Access Key ID, Secret Access Key and a VPC ID.  To find the VPC ID, login to the AWS console and go to Services -> VPC -> Your VPCs.  Select the one where you would like to launch the instance.

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -108,16 +108,7 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	t := time.Now().Format("20060102150405")
-	name := fmt.Sprintf("%s-%s", machineName, t)
-
-	// trim name to 24 chars due to the azure dns name limit
-	if len(name) > 24 {
-		name = name[0:24]
-
-	}
-
-	driver := &Driver{MachineName: name, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}
+	driver := &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}
 	return driver, nil
 }
 
@@ -173,6 +164,20 @@ func (driver *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (driver *Driver) PreCreateCheck() error {
+	if err := driver.setUserSubscription(); err != nil {
+		return err
+	}
+
+	// check azure DNS to make sure name is available
+	available, res, err := vmClient.CheckHostedServiceNameAvailability(driver.MachineName)
+	if err != nil {
+		return err
+	}
+
+	if !available {
+		return fmt.Errorf(res)
+	}
+
 	return nil
 }
 

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -169,13 +169,13 @@ func (driver *Driver) PreCreateCheck() error {
 	}
 
 	// check azure DNS to make sure name is available
-	available, res, err := vmClient.CheckHostedServiceNameAvailability(driver.MachineName)
+	available, response, err := vmClient.CheckHostedServiceNameAvailability(driver.MachineName)
 	if err != nil {
 		return err
 	}
 
 	if !available {
-		return fmt.Errorf(res)
+		return fmt.Errorf(response)
 	}
 
 	return nil


### PR DESCRIPTION
This removes the date append to the name of a machine in Azure.  Instead, the `PreCreateCheck` checks to see if the name is available and meets the Azure requirements.  If it doesn't an error will be reported and the machine will not be created.

Fixes #433 