### PR TITLE
Add shell function recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ You can also get the commands to export environment variables to use with the Do
 
 Machine is still in its early stages. If you'd like to try out a preview build, [download it here](https://github.com/docker/machine/releases/latest).
 
+For information about getting started and an overview of all the Machine
+commands available to you, [please refer to the
+documentation](https://github.com/docker/machine/blob/master/docs/dockermachine.md).
+Note that the documentation in its current state is an incomplete "rough draft".
+
 ## Drivers
 
 ### VirtualBox

--- a/docs/dockermachine.md
+++ b/docs/dockermachine.md
@@ -262,6 +262,81 @@ NAME        ACTIVE   DRIVER    STATE     URL
 custombox   *        none      Running   tcp://50.134.234.20:2376
 ```
 
+## Shell Function Shortcut
+
+When you start using Machine, it is likely that you will want to create a few
+different hosts and run Docker commands against them using the subshell method
+suggested by Machine's console output, i.e. `docker $(docker-machine config dev)
+ps`.  However, that is a fair bit of typing and it can be difficult to remember
+which host is considered "active" by Machine.
+
+Therefore, we suggest that you may want to use a shell function such as
+the following to make switching machines and running commands against them
+easier and more fluid:
+
+```
+dkr () {
+    if [[ "$1" == "which" ]]; then
+        echo $(docker-machine active)
+        return
+    fi
+    if [[ "$1" == "use" ]]; then
+        docker-machine active "$2"
+        return
+    fi
+    docker $(docker-machine config $(docker-machine active)) "$@"
+}
+```
+
+To make this function available to you at all times, simply add it to your
+`.bashrc` or `.zshrc` file. This has been tested on `bash` and `zsh` and should
+work well with both (assuming there is no existing alias or function for `dkr`).
+
+With this function, you can run Docker commands as you normally would, except
+that you simply type `dkr` instead of `docker` and they will automatically run
+against the active machine.  For example:
+
+```
+$ dkr version
+Client version: 1.4.1
+Client API version: 1.16
+Go version (client): go1.3.3
+Git commit (client): 5bc2ff8
+OS/Arch (client): darwin/amd64
+Server version: 1.4.1
+Server API version: 1.16
+Go version (server): go1.3.3
+Git commit (server): 136b351
+
+$ dkr run busybox echo hello world
+Unable to find image 'busybox:latest' locally
+busybox:latest: The image you are pulling has been verified
+
+511136ea3c5a: Pull complete
+df7546f9f060: Pull complete
+ea13149945cb: Pull complete
+4986bf8c1536: Pull complete
+Status: Downloaded newer image for busybox:latest
+hello world
+```
+
+To see the active machine you simply run `dkr which`:
+
+```
+$ dkr which
+dev
+```
+
+To switch the active machine, you can run `dkr use $MACHINE`:
+
+```
+$ dkr which
+dev
+$ dkr use staging
+$ dkr which
+staging
+```
+
 ## Subcommands
 
 #### active


### PR DESCRIPTION
cc @bfirsh @ehazlett @sthulb 

I find this a lot easier and more pleasant to use than the other
currently supported methods (`env` and `config`) and may serve us well
as a stopgap until/if we can get true config files for Docker.  It's
definitely worth bringing up to users since the workflow is so nice (I
find that I forget the active machine often and want a way to access it
through the same interface I use to run Docker commands against it).

@bfirsh hopefully doesn't think I am trying to sneak in the "use" syntax I originally mentioned wanting :smile: .  I am not wildly attached to that part if you guys decide it is not best judgment (although I do find it _really_ nice to use as I forget my active machine quite often and want a quick way to see it) - the most important is to have something like `docker $(docker-machine config $(docker-machine active)) "$@"` in the function.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>