### PR TITLE
Issue #435 added new parameters --virtualbox-skip-update --vmwarevsphere-skip-update --vmwarefusion-skip-update

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -38,7 +38,6 @@ type Driver struct {
 	PrivateKeyPath string
 	storePath      string
 	SkipUpdate     bool
-
 }
 
 type CreateFlags struct {
@@ -110,14 +109,13 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
-
 func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
 func (d *Driver) Create() error {
 	var (
-		err    error
+		err error
 	)
 
 	// Check that VBoxManage exists and works

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -37,12 +37,15 @@ type Driver struct {
 	CaCertPath     string
 	PrivateKeyPath string
 	storePath      string
+	SkipUpdate     bool
+
 }
 
 type CreateFlags struct {
 	Memory         *int
 	DiskSize       *int
 	Boot2DockerURL *string
+	SkipUpdate     *bool
 }
 
 func init() {
@@ -65,6 +68,10 @@ func GetCreateFlags() []cli.Flag {
 			Name:  "virtualbox-disk-size",
 			Usage: "Size of disk for host in MB",
 			Value: 20000,
+		},
+		cli.BoolFlag{
+			Name:  "virtualbox-skip-update",
+			Usage: "Skip check for ISO updates, uses cached ISO file",
 		},
 		cli.StringFlag{
 			EnvVar: "VIRTUALBOX_BOOT2DOCKER_URL",
@@ -98,19 +105,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Memory = flags.Int("virtualbox-memory")
 	d.DiskSize = flags.Int("virtualbox-disk-size")
 	d.Boot2DockerURL = flags.String("virtualbox-boot2docker-url")
+	d.SkipUpdate = flags.Bool("virtualbox-skip-update")
+
 	return nil
 }
 
-func cpIso(src, dest string) error {
-	buf, err := ioutil.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(dest, buf, 0600); err != nil {
-		return err
-	}
-	return nil
-}
 
 func (d *Driver) PreCreateCheck() error {
 	return nil
@@ -119,7 +118,6 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) Create() error {
 	var (
 		err    error
-		isoURL string
 	)
 
 	// Check that VBoxManage exists and works
@@ -132,43 +130,9 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if d.Boot2DockerURL != "" {
-		isoURL = d.Boot2DockerURL
-		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := utils.DownloadISO(d.storePath, "boot2docker.iso", isoURL); err != nil {
-			return err
-		}
-	} else {
-		// todo: check latest release URL, download if it's new
-		// until then always use "latest"
-		isoURL, err = utils.GetLatestBoot2DockerReleaseURL()
-		if err != nil {
-			return err
-		}
-
-		// todo: use real constant for .docker
-		rootPath := filepath.Join(utils.GetHomeDir(), ".docker")
-		imgPath := filepath.Join(rootPath, "images")
-		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
-		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
-			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
-
-			// just in case boot2docker.iso has been manually deleted
-			if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-				if err := os.Mkdir(imgPath, 0700); err != nil {
-					return err
-				}
-			}
-
-			if err := utils.DownloadISO(imgPath, "boot2docker.iso", isoURL); err != nil {
-				return err
-			}
-		}
-
-		isoDest := filepath.Join(d.storePath, "boot2docker.iso")
-		if err := cpIso(commonIsoPath, isoDest); err != nil {
-			return err
-		}
+	// I have to ingnore ISO download if cmd has --virtualbox-skip-update
+	if err := utils.GetBoot2DockerISO(d.SkipUpdate, d.Boot2DockerURL, d.storePath); err != nil {
+		return err
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -23,9 +23,8 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/state"
-	cssh "golang.org/x/crypto/ssh"
 	"github.com/docker/machine/utils"
-
+	cssh "golang.org/x/crypto/ssh"
 )
 
 const (
@@ -45,8 +44,8 @@ type Driver struct {
 	CaCertPath     string
 	PrivateKeyPath string
 
-	storePath string
-	SkipUpdate     bool
+	storePath  string
+	SkipUpdate bool
 }
 
 type CreateFlags struct {
@@ -54,7 +53,6 @@ type CreateFlags struct {
 	Memory         *int
 	DiskSize       *int
 	SkipUpdate     *bool
-
 }
 
 func init() {
@@ -145,7 +143,7 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) Create() error {
 
 	var (
-		err    error
+		err error
 	)
 
 	// I have to ingnore ISO download if cmd has --virtualbox-skip-update

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -23,8 +23,9 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/state"
-	"github.com/docker/machine/utils"
 	cssh "golang.org/x/crypto/ssh"
+	"github.com/docker/machine/utils"
+
 )
 
 const (
@@ -45,12 +46,15 @@ type Driver struct {
 	PrivateKeyPath string
 
 	storePath string
+	SkipUpdate     bool
 }
 
 type CreateFlags struct {
 	Boot2DockerURL *string
 	Memory         *int
 	DiskSize       *int
+	SkipUpdate     *bool
+
 }
 
 func init() {
@@ -68,6 +72,10 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "FUSION_BOOT2DOCKER_URL",
 			Name:   "vmwarefusion-boot2docker-url",
 			Usage:  "Fusion URL for boot2docker image",
+		},
+		cli.BoolFlag{
+			Name:  "vmwarefusion-skip-update",
+			Usage: "Skip check for ISO updates, uses cached ISO file",
 		},
 		cli.IntFlag{
 			EnvVar: "FUSION_MEMORY_SIZE",
@@ -97,6 +105,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.DiskSize = flags.Int("vmwarefusion-disk-size")
 	d.Boot2DockerURL = flags.String("vmwarefusion-boot2docker-url")
 	d.ISO = path.Join(d.storePath, "boot2docker.iso")
+	d.SkipUpdate = flags.Bool("vmwarefusion-skip-update")
 
 	return nil
 }
@@ -136,47 +145,12 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) Create() error {
 
 	var (
-		isoURL string
 		err    error
 	)
 
-	if d.Boot2DockerURL != "" {
-		isoURL = d.Boot2DockerURL
-		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := utils.DownloadISO(d.storePath, "boot2docker.iso", isoURL); err != nil {
-			return err
-		}
-	} else {
-		// todo: check latest release URL, download if it's new
-		// until then always use "latest"
-		isoURL, err = utils.GetLatestBoot2DockerReleaseURL()
-		if err != nil {
-			return err
-		}
-
-		// todo: use real constant for .docker
-		rootPath := filepath.Join(utils.GetHomeDir(), ".docker")
-		imgPath := filepath.Join(rootPath, "images")
-		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
-		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
-			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
-
-			// just in case boot2docker.iso has been manually deleted
-			if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-				if err := os.Mkdir(imgPath, 0700); err != nil {
-					return err
-				}
-			}
-
-			if err := utils.DownloadISO(imgPath, "boot2docker.iso", isoURL); err != nil {
-				return err
-			}
-		}
-
-		isoDest := filepath.Join(d.storePath, "boot2docker.iso")
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
-		}
+	// I have to ingnore ISO download if cmd has --virtualbox-skip-update
+	if err := utils.GetBoot2DockerISO(d.SkipUpdate, d.Boot2DockerURL, d.storePath); err != nil {
+		return err
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -22,8 +22,9 @@ import (
 	"github.com/docker/machine/drivers/vmwarevsphere/errors"
 	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/state"
-	"github.com/docker/machine/utils"
 	cssh "golang.org/x/crypto/ssh"
+	"github.com/docker/machine/utils"
+
 )
 
 const (
@@ -56,6 +57,8 @@ type Driver struct {
 	PrivateKeyPath string
 
 	storePath string
+	SkipUpdate     bool
+
 }
 
 type CreateFlags struct {
@@ -71,6 +74,7 @@ type CreateFlags struct {
 	Datacenter     *string
 	Pool           *string
 	HostIP         *string
+	SkipUpdate     *bool
 }
 
 func init() {
@@ -106,6 +110,10 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "VSPHERE_BOOT2DOCKER_URL",
 			Name:   "vmwarevsphere-boot2docker-url",
 			Usage:  "vSphere URL for boot2docker image",
+		},
+		cli.BoolFlag{
+			Name:  "vmwarevsphere-skip-update",
+			Usage: "Skip check for ISO updates, uses cached ISO file",
 		},
 		cli.StringFlag{
 			EnvVar: "VSPHERE_VCENTER",
@@ -174,6 +182,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.HostIP = flags.String("vmwarevsphere-compute-ip")
 
 	d.ISO = path.Join(d.storePath, "boot2docker.iso")
+	d.SkipUpdate = flags.Bool("vmwarevsphere-skip-update")
 
 	return nil
 }
@@ -230,47 +239,14 @@ func (d *Driver) Create() error {
 	}
 
 	var (
-		isoURL string
 		err    error
 	)
 
-	if d.Boot2DockerURL != "" {
-		isoURL = d.Boot2DockerURL
-		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := utils.DownloadISO(d.storePath, "boot2docker.iso", isoURL); err != nil {
-			return err
-		}
-	} else {
-		// todo: check latest release URL, download if it's new
-		// until then always use "latest"
-		isoURL, err = utils.GetLatestBoot2DockerReleaseURL()
-		if err != nil {
-			return err
-		}
-
-		rootPath := utils.GetDockerDir()
-		imgPath := filepath.Join(rootPath, "images")
-		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
-		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
-			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
-
-			// just in case boot2docker.iso has been manually deleted
-			if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-				if err := os.Mkdir(imgPath, 0700); err != nil {
-					return err
-				}
-			}
-
-			if err := utils.DownloadISO(imgPath, "boot2docker.iso", isoURL); err != nil {
-				return err
-			}
-		}
-
-		isoDest := filepath.Join(d.storePath, "boot2docker.iso")
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
-		}
+	// I have to ingnore ISO download if cmd has --virtualbox-skip-update
+	if err := utils.GetBoot2DockerISO(d.SkipUpdate, d.Boot2DockerURL, d.storePath); err != nil {
+		return err
 	}
+
 
 	log.Infof("Generating SSH Keypair...")
 	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -22,9 +22,8 @@ import (
 	"github.com/docker/machine/drivers/vmwarevsphere/errors"
 	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/state"
-	cssh "golang.org/x/crypto/ssh"
 	"github.com/docker/machine/utils"
-
+	cssh "golang.org/x/crypto/ssh"
 )
 
 const (
@@ -56,9 +55,8 @@ type Driver struct {
 	CaCertPath     string
 	PrivateKeyPath string
 
-	storePath string
-	SkipUpdate     bool
-
+	storePath  string
+	SkipUpdate bool
 }
 
 type CreateFlags struct {
@@ -239,14 +237,13 @@ func (d *Driver) Create() error {
 	}
 
 	var (
-		err    error
+		err error
 	)
 
 	// I have to ingnore ISO download if cmd has --virtualbox-skip-update
 	if err := utils.GetBoot2DockerISO(d.SkipUpdate, d.Boot2DockerURL, d.storePath); err != nil {
 		return err
 	}
-
 
 	log.Infof("Generating SSH Keypair...")
 	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {

--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -3,14 +3,12 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	log "github.com/Sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-	log "github.com/Sirupsen/logrus"
-
-
 )
 
 // Get the latest boot2docker release tag name (e.g. "v0.6.0").
@@ -130,5 +128,3 @@ func cpIso(src, dest string) error {
 	}
 	return nil
 }
-
-

--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	log "github.com/Sirupsen/logrus"
+
+
 )
 
 // Get the latest boot2docker release tag name (e.g. "v0.6.0").
@@ -60,3 +63,72 @@ func DownloadISO(dir, file, url string) error {
 	}
 	return nil
 }
+
+func GetBoot2DockerISO(skipUpdate bool, boot2DockerURL string, storePath string) error {
+	if !skipUpdate {
+
+		if boot2DockerURL != "" {
+			isoURL := boot2DockerURL
+			log.Infof("Downloading boot2docker.iso from %s...", isoURL)
+			if err := DownloadISO(storePath, "boot2docker.iso", isoURL); err != nil {
+				return err
+			}
+		} else {
+			// todo: check latest release URL, download if it's new
+			// until then always use "latest"
+			isoURL, err := GetLatestBoot2DockerReleaseURL()
+			if err != nil {
+				return err
+			}
+
+			// todo: use real constant for .docker
+			rootPath := filepath.Join(GetHomeDir(), ".docker")
+			imgPath := filepath.Join(rootPath, "images")
+			commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
+			if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
+				log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
+
+				// just in case boot2docker.iso has been manually deleted
+				if _, err := os.Stat(imgPath); os.IsNotExist(err) {
+					if err := os.Mkdir(imgPath, 0700); err != nil {
+						return err
+					}
+				}
+
+				if err := DownloadISO(imgPath, "boot2docker.iso", isoURL); err != nil {
+					return err
+				}
+			}
+
+			isoDest := filepath.Join(storePath, "boot2docker.iso")
+			if err := cpIso(commonIsoPath, isoDest); err != nil {
+				return err
+			}
+		}
+	} else {
+
+		rootPath := filepath.Join(GetHomeDir(), ".docker")
+		imgPath := filepath.Join(rootPath, "images")
+		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
+
+		isoDest := filepath.Join(storePath, "boot2docker.iso")
+		if err := cpIso(commonIsoPath, isoDest); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func cpIso(src, dest string) error {
+	buf, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(dest, buf, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+


### PR DESCRIPTION
Added three new parameters --virtualbox-skip-update --vmwarevsphere-skip-update --vmwarefusion-skip-update , using this parameter it doesn't check for ISO updates, this parameter could be useful for private network without or limited internet access.

I have tested this parameters in my private network for different connectivity conditions, it works ok.

./docker-machine_linux-amd64 create -d virtualbox --virtualbox-skip-update dockerDEV4
INFO[0000] Creating SSH key...

INFO[0000] Creating VirtualBox VM...

INFO[0010] Starting VirtualBox VM...

INFO[0010] Waiting for VM to start...

INFO[0045] "dockerDEV4" has been created and is now the active machine 
INFO[0045] Configure docker client with: $(docker-machine_linux-amd64 env dockerDEV4)

By the way I tested the code only for the virtualbox driver.