### PR TITLE
remove error message for config failures

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -214,6 +214,7 @@ func cmdCreate(c *cli.Context) {
 func cmdConfig(c *cli.Context) {
 	cfg, err := getMachineConfig(c)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
 		os.Exit(1)
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -214,8 +214,9 @@ func cmdCreate(c *cli.Context) {
 func cmdConfig(c *cli.Context) {
 	cfg, err := getMachineConfig(c)
 	if err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
+
 	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H %s",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, cfg.machineUrl)
 }


### PR DESCRIPTION
My initial thoughts are we should do nothing, except return a non-zero exit code.

Refs: #452 