### PR TITLE
New Driver: CenturyLink Cloud

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 			"Comment": "weekly-56",
 			"Rev": "afe77d958c701557ec5dc56f6936fcc194d15520"
 		},
+                {
+                        "ImportPath": "github.com/CenturyLinkLabs/clcgo",
+                        "Rev": "8b702d20bfe3710be07422907796e97bd1a6acb9"
+                },
 		{
 			"ImportPath": "github.com/MSOpenTech/azure-sdk-for-go",
 			"Comment": "v1.1-17-g515f3ec",

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/.travis.yml
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/LICENSE
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 CenturyLink
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/README.md
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/README.md
@@ -1,0 +1,4 @@
+# clcgo
+
+clcgo is an API wrapper for the CenturyLink Cloud V2 API written in Go. You can read about its usage in [the
+GoDocs](http://godoc.org/github.com/CenturyLinkLabs/clcgo), and about the API's capabilities in [CenturyLink Cloud documentation](https://t3n.zendesk.com/categories/20067994-API-v2-0-Beta-).

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client.go
@@ -1,0 +1,159 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+const authenticationURL = apiRoot + "/authentication/login"
+
+// APICredentials are used by the Client to identify you to CenturyLink Cloud
+// in any request. The BearerToken value will be good for a set period of time,
+// defined in the API documentation.
+//
+// If you anticipate making many API requests in several runs of your
+// application, it may be a good idea to save the BearerToken and AccountAlias
+// values somewhere so that they can be recalled when they are needed again,
+// rather than having to re-authenticate with the API. You can build a
+// APICredentials object with those two fields, then assign it to the Client's
+// APICredentials value.
+//
+// The Username and Password values will be present only if you've used
+// GetAPICredentials, and can otherwise be ignored.
+type APICredentials struct {
+	BearerToken  string `json:"bearerToken"`
+	AccountAlias string `json:"accountAlias"`
+	Username     string `json:"username"` // TODO: nonexistent in get, extract to creation params?
+	Password     string `json:"password"` // TODO: nonexistent in get, extract to creation params?
+}
+
+// The Client stores your current credentials and uses them to set or fetch
+// data from the API. It should be instantiated with the NewClient function.
+type Client struct {
+	APICredentials APICredentials
+	Requestor      requestor
+}
+
+func (c APICredentials) RequestForSave(a string) (request, error) {
+	return request{URL: authenticationURL, Parameters: c}, nil
+}
+
+// NewClient returns a Client that has been configured to communicate to
+// CenturyLink Cloud. Before making any requests, the Client must be authorized
+// by either setting its APICredentials field or calling the GetAPICredentials
+// function.
+func NewClient() *Client {
+	return &Client{Requestor: clcRequestor{}}
+}
+
+// GetAPICredentials accepts username and password strings to populate the
+// Client instance with valid APICredentials.
+//
+// CenturyLink Cloud requires a BearerToken to authorize all requests, and this
+// method will fetch one for the user and associate it with the Client. Any
+// further requests made by the Client will include that BearerToken.
+func (c *Client) GetAPICredentials(u string, p string) error {
+	c.APICredentials = APICredentials{Username: u, Password: p}
+	_, err := c.SaveEntity(&c.APICredentials)
+	if err != nil {
+		if rerr, ok := err.(RequestError); ok && rerr.StatusCode == 400 {
+			err = errors.New("there was a problem with your credentials")
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// GetEntity is used to fetch a summary of a resource. When you pass a pointer
+// to your resource, GetEntity will set its fields appropriately.
+//
+// Different resources have different field requirements before their summaries
+// can be fetched successfully. If you omit an ID field from a Server, for
+// instance, GetEntity will return an error informing you of the missing field.
+// An error from GetEntity likely means that your passed Entity was not
+// modified.
+func (c *Client) GetEntity(e Entity) error {
+	url, err := e.URL(c.APICredentials.AccountAlias)
+	if err != nil {
+		return err
+	}
+	j, err := c.Requestor.GetJSON(c.APICredentials.BearerToken, request{URL: url})
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(j, &e)
+}
+
+// SaveEntity is used to persist a changed resource to CenturyLink Cloud.
+//
+// Beyond the fields absolutely required to form valid URLs, the presence or
+// format of the fields on your resources are not validated before they are
+// submitted.  You should check the CenturyLink Cloud API documentation for
+// this information. If your submission was unsuccessful, it is likely that the
+// error returned is a RequestError, which may contain helpful error messages
+// you can use to determine what went wrong.
+//
+// Calling HasSucceeded on the returned Status will tell you if the resource is
+// ready. Some resources are available immediately, but most are not. If the
+// resource implements CreationStatusProvidingEntity it will likely take time,
+// but regardless you can check with the returned Status to be sure.
+//
+// The Status does not update itself, and you will need to call GetEntity on it
+// periodically to determine when its resource is ready if it was not
+// immediately successful.
+//
+// Never ignore the error result from this call! Even if your code is perfect
+// (congratulations, by the way), errors can still occur due to unexpected
+// server states or networking issues.
+func (c *Client) SaveEntity(e SavableEntity) (Status, error) {
+	req, err := e.RequestForSave(c.APICredentials.AccountAlias)
+	if err != nil {
+		return Status{}, err
+	}
+	resp, err := c.Requestor.PostJSON(c.APICredentials.BearerToken, req)
+	if err != nil {
+		return Status{}, err
+	}
+
+	if spe, ok := e.(CreationStatusProvidingEntity); ok {
+		status, err := spe.StatusFromCreateResponse(resp)
+		if err != nil {
+			return Status{}, err
+		}
+
+		return status, nil
+	}
+
+	json.Unmarshal(resp, &e)
+	return Status{Status: successfulStatus}, nil
+}
+
+// DeleteEntity is used to tell CenturyLink Cloud to remove a resource.
+//
+// The method returns a Status, which can be used as described in the
+// SaveEntity documentation to determine when the work completes. The Entity
+// object will not be modified.
+func (c *Client) DeleteEntity(e Entity) (Status, error) {
+	url, err := e.URL(c.APICredentials.AccountAlias)
+	if err != nil {
+		return Status{}, err
+	}
+	resp, err := c.Requestor.DeleteJSON(c.APICredentials.BearerToken, request{URL: url})
+	if err != nil {
+		return Status{}, err
+	}
+
+	if spe, ok := e.(DeletionStatusProvidingEntity); ok {
+		status, err := spe.StatusFromDeleteResponse(resp)
+		if err != nil {
+			return Status{}, err
+		}
+
+		return status, nil
+	}
+
+	return Status{Status: successfulStatus}, nil
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_authentication_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_authentication_test.go
@@ -1,0 +1,40 @@
+package clcgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfulGetAPICredentials(t *testing.T) {
+	r := newTestRequestor()
+	c := Client{Requestor: r}
+
+	r.registerHandler("POST", authenticationURL, func(token string, req request) (string, error) {
+		c, ok := req.Parameters.(APICredentials)
+		assert.True(t, ok)
+		assert.Empty(t, token)
+		assert.Equal(t, "username", c.Username)
+		assert.Equal(t, "password", c.Password)
+
+		return `{"bearerToken":"expected token"}`, nil
+	})
+
+	err := c.GetAPICredentials("username", "password")
+	assert.NoError(t, err)
+	assert.Equal(t, "expected token", c.APICredentials.BearerToken)
+}
+
+func TestErroredGetAPICredentials(t *testing.T) {
+	r := newTestRequestor()
+	c := Client{Requestor: r}
+
+	r.registerHandler("POST", authenticationURL, func(token string, req request) (string, error) {
+		err := RequestError{Message: "there was a problem with the request", StatusCode: 400}
+		return "Bad Request", err
+	})
+
+	err := c.GetAPICredentials("username", "password")
+	assert.EqualError(t, err, "there was a problem with your credentials")
+	assert.Empty(t, c.APICredentials.BearerToken)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_deletable_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_deletable_test.go
@@ -1,0 +1,118 @@
+package clcgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var deletionResponse = "Deletion Response Body"
+
+type testDeletionStatusProviding struct {
+	CallbackForStatus func([]byte) (Status, error)
+}
+
+func (e testDeletionStatusProviding) URL(a string) (string, error) {
+	return "/entity/url", nil
+}
+
+func (e testDeletionStatusProviding) StatusFromDeleteResponse(r []byte) (Status, error) {
+	if e.CallbackForStatus != nil {
+		return e.CallbackForStatus(r)
+	}
+
+	return Status{}, nil
+}
+
+func TestSuccessfulDeleteEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{
+		CallbackForURL: func(a string) (string, error) {
+			assert.Equal(t, "AA", a)
+			return "/entity/url", nil
+		},
+	}
+
+	r.registerHandler("DELETE", "/entity/url", func(token string, req request) (string, error) {
+		assert.Equal(t, "token", token)
+
+		return deletionResponse, nil
+	})
+
+	status, err := c.DeleteEntity(&e)
+	assert.NoError(t, err)
+	assert.True(t, status.HasSucceeded())
+}
+
+func TestSuccessfulDeletionStatusProvidingEntityDeleteEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	st := Status{Status: "Custom"}
+	e := testDeletionStatusProviding{
+		CallbackForStatus: func(r []byte) (Status, error) {
+			assert.Equal(t, []byte(deletionResponse), r)
+			return st, nil
+		},
+	}
+
+	r.registerHandler("DELETE", "/entity/url", func(token string, req request) (string, error) {
+		return deletionResponse, nil
+	})
+
+	status, err := c.DeleteEntity(&e)
+	assert.NoError(t, err)
+	assert.Equal(t, st, status)
+}
+
+func TestErroredURLDeleteEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{
+		CallbackForURL: func(a string) (string, error) {
+			return "", errors.New("test URL Error")
+		},
+	}
+
+	status, err := c.DeleteEntity(&e)
+	assert.EqualError(t, err, "test URL Error")
+	assert.Equal(t, Status{}, status)
+}
+
+func TestErroredDeleteJSONDeleteEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{}
+
+	r.registerHandler("DELETE", "/entity/url", func(token string, req request) (string, error) {
+		return "", errors.New("test DeleteJSON Error")
+	})
+
+	status, err := c.DeleteEntity(&e)
+	assert.EqualError(t, err, "test DeleteJSON Error")
+	assert.Equal(t, Status{}, status)
+}
+
+func TestDeletionStatusProvidingEntityDeleteEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testDeletionStatusProviding{
+		CallbackForStatus: func(r []byte) (Status, error) {
+			return Status{}, errors.New("test StatusFromDeleteResponse Error")
+		},
+	}
+
+	r.registerHandler("DELETE", "/entity/url", func(token string, req request) (string, error) {
+		return deletionResponse, nil
+	})
+
+	status, err := c.DeleteEntity(&e)
+	assert.EqualError(t, err, "test StatusFromDeleteResponse Error")
+	assert.Equal(t, Status{}, status)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_savable_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_savable_test.go
@@ -1,0 +1,140 @@
+package clcgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var creationResponse = `{"testSerializedKey":"value"}`
+
+type testSavable struct {
+	CallbackForRequest func(string) (request, error)
+	TestSerializedKey  string `json:"testSerializedKey"`
+}
+
+type testStatusProviding struct {
+	CallbackForStatus func([]byte) (Status, error)
+}
+
+type savableCreationParameters struct {
+	Value string
+}
+
+func (s testSavable) RequestForSave(a string) (request, error) {
+	if s.CallbackForRequest != nil {
+		return s.CallbackForRequest(a)
+	}
+
+	return request{
+		URL:        "/creation/url",
+		Parameters: savableCreationParameters{Value: "testSavable"},
+	}, nil
+}
+
+func (s testStatusProviding) RequestForSave(a string) (request, error) {
+	return request{
+		URL:        "/creation/url",
+		Parameters: savableCreationParameters{Value: "testSavable"},
+	}, nil
+}
+
+func (s testStatusProviding) StatusFromCreateResponse(r []byte) (Status, error) {
+	return s.CallbackForStatus(r)
+}
+
+func TestSuccessfulSavableSaveEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	p := savableCreationParameters{Value: "testSavable"}
+	s := testSavable{
+		CallbackForRequest: func(a string) (request, error) {
+			assert.Equal(t, "AA", a)
+			return request{URL: "/savable", Parameters: p}, nil
+		},
+	}
+
+	r.registerHandler("POST", "/savable", func(token string, req request) (string, error) {
+		assert.Equal(t, "token", token)
+		assert.Equal(t, p, req.Parameters)
+
+		return creationResponse, nil
+	})
+
+	status, err := c.SaveEntity(&s)
+	assert.NoError(t, err)
+	assert.True(t, status.HasSucceeded())
+	assert.Equal(t, "value", s.TestSerializedKey)
+}
+
+func TestSuccessfulStatusProvidingSaveEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	st := Status{Status: "Custom"}
+	s := testStatusProviding{
+		CallbackForStatus: func(r []byte) (Status, error) {
+			assert.Equal(t, []byte(creationResponse), r)
+			return st, nil
+		},
+	}
+
+	r.registerHandler("POST", "/creation/url", func(token string, req request) (string, error) {
+		return creationResponse, nil
+	})
+
+	status, err := c.SaveEntity(&s)
+	assert.NoError(t, err)
+	assert.Equal(t, st, status)
+}
+
+func TestErroredRequestSaveEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	s := testSavable{
+		CallbackForRequest: func(a string) (request, error) {
+			return request{}, errors.New("test Request Error")
+		},
+	}
+
+	status, err := c.SaveEntity(&s)
+	assert.Equal(t, Status{}, status)
+	assert.EqualError(t, err, "test Request Error")
+}
+
+func TestErroredPostJSONSaveEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	s := testSavable{}
+
+	r.registerHandler("POST", "/creation/url", func(token string, req request) (string, error) {
+		return "", errors.New("error from PostJSON")
+	})
+
+	status, err := c.SaveEntity(&s)
+	assert.Equal(t, Status{}, status)
+	assert.EqualError(t, err, "error from PostJSON")
+}
+
+func TestErroredStatusSaveEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	s := testStatusProviding{
+		CallbackForStatus: func(r []byte) (Status, error) {
+			return Status{}, errors.New("test Status Error")
+		},
+	}
+
+	r.registerHandler("POST", "/creation/url", func(token string, req request) (string, error) {
+		return "response", nil
+	})
+
+	status, err := c.SaveEntity(&s)
+	assert.Equal(t, Status{}, status)
+	assert.EqualError(t, err, "test Status Error")
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/client_test.go
@@ -1,0 +1,85 @@
+package clcgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var entityResponse = `{"testSerializedKey":"value"}`
+
+type testEntity struct {
+	CallbackForURL    func(string) (string, error)
+	TestSerializedKey string `json:"testSerializedKey"`
+}
+
+func (e testEntity) URL(a string) (string, error) {
+	if e.CallbackForURL != nil {
+		return e.CallbackForURL(a)
+	}
+
+	return "/entity/url", nil
+}
+
+func TestSuccessfulGetEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+
+	r.registerHandler("GET", "/entity", func(token string, req request) (string, error) {
+		assert.Equal(t, "token", token)
+		return entityResponse, nil
+	})
+
+	e := testEntity{
+		CallbackForURL: func(a string) (string, error) {
+			assert.Equal(t, "AA", a)
+			return "/entity", nil
+		},
+	}
+
+	err := c.GetEntity(&e)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", e.TestSerializedKey)
+}
+
+func TestErroredURLInGetEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{
+		CallbackForURL: func(a string) (string, error) {
+			return "", errors.New("test URL Error")
+		},
+	}
+
+	err := c.GetEntity(&e)
+	assert.EqualError(t, err, "test URL Error")
+}
+
+func TestErroredInGetJSONInGetEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{}
+	r.registerHandler("GET", "/entity/url", func(token string, req request) (string, error) {
+		return "", errors.New("error from GetJSON")
+	})
+
+	err := c.GetEntity(&e)
+	assert.EqualError(t, err, "error from GetJSON")
+}
+
+func TestBadJSONInGetJSONInGetEntity(t *testing.T) {
+	r := newTestRequestor()
+	cr := APICredentials{BearerToken: "token", AccountAlias: "AA"}
+	c := Client{Requestor: r, APICredentials: cr}
+	e := testEntity{}
+	r.registerHandler("GET", "/entity/url", func(token string, req request) (string, error) {
+		return ``, nil
+	})
+
+	err := c.GetEntity(&e)
+	assert.EqualError(t, err, "unexpected end of JSON input")
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/datacenters.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/datacenters.go
@@ -1,0 +1,78 @@
+package clcgo
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	dataCentersURL            = apiRoot + "/datacenters/%s"
+	dataCenterGroupURL        = dataCentersURL + "/%s?groupLinks=true"
+	dataCenterCapabilitiesURL = dataCentersURL + "/%s/deploymentCapabilities"
+)
+
+// The DataCenters resource can retrieve a list of available DataCenters.
+type DataCenters []DataCenter
+
+// A DataCenter resource can either be returned by the DataCenters resource, or
+// built manually. It should be used in conjunction with the
+// DataCenterCapabilities resource to request information about it.
+//
+// You must supply the ID if you are building this object manually.
+type DataCenter struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// DataCenterGroup can be used to find associated groups for a datacenter and
+// your account. The linked hardware group can be used with the Group object to
+// query for your account's groups within that datacenter.
+//
+// You must supply the associated DataCenter object.
+type DataCenterGroup struct {
+	DataCenter DataCenter `json:"-"`
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Links      []Link     `json:"links"`
+}
+
+// DataCenterCapabilities gets more information about a specific DataCenter.
+// You must supply the associated DataCenter object.
+type DataCenterCapabilities struct {
+	DataCenter         DataCenter          `json:"-"`
+	DeployableNetworks []DeployableNetwork `json:"deployableNetworks"`
+	Templates          []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"templates"`
+}
+
+// A DeployableNetwork describes a private network that is scoped to an Account
+// and DataCenter. It can be fetched via the DataCenterCapabilities and can
+// optionally be used to put a Server in a specific network.
+type DeployableNetwork struct {
+	Name      string `json:"name"`
+	NetworkID string `json:"networkId"`
+	Type      string `json:"type"`
+	AccountID string `json:"accountID"`
+}
+
+func (d DataCenters) URL(a string) (string, error) {
+	return fmt.Sprintf(dataCentersURL, a), nil
+}
+
+func (d DataCenterCapabilities) URL(a string) (string, error) {
+	if d.DataCenter.ID == "" {
+		return "", errors.New("need a DataCenter with an ID")
+	}
+
+	return fmt.Sprintf(dataCenterCapabilitiesURL, a, d.DataCenter.ID), nil
+}
+
+func (d DataCenterGroup) URL(a string) (string, error) {
+	if d.DataCenter.ID == "" {
+		return "", errors.New("need a DataCenter with an ID")
+	}
+
+	return fmt.Sprintf(dataCenterGroupURL, a, d.DataCenter.ID), nil
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/datacenters_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/datacenters_test.go
@@ -1,0 +1,85 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfulDataCentersURL(t *testing.T) {
+	d := DataCenters{}
+	u, err := d.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/datacenters/AA", u)
+}
+
+func TestDataCenterJSONUnmarshalling(t *testing.T) {
+	j := `{"id": "foo", "name": "bar"}`
+
+	dc := DataCenter{}
+	err := json.Unmarshal([]byte(j), &dc)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "foo", dc.ID)
+
+	assert.Equal(t, "bar", dc.Name)
+}
+
+func TestSuccessfulDataCenterCapabilitiesURL(t *testing.T) {
+	d := DataCenterCapabilities{DataCenter: DataCenter{ID: "abc123"}}
+	u, err := d.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/datacenters/AA/abc123/deploymentCapabilities", u)
+}
+
+func TestErroredDataCenterCapabilitiesURL(t *testing.T) {
+	d := DataCenterCapabilities{}
+	s, err := d.URL("AA")
+	assert.Equal(t, "", s)
+	assert.EqualError(t, err, "need a DataCenter with an ID")
+}
+
+func TestSuccessfulDataCenterCapabilitiesUnmarshalling(t *testing.T) {
+	d := DataCenterCapabilities{}
+	err := json.Unmarshal([]byte(fakeapi.DataCenterCapabilitiesResponse), &d)
+
+	assert.NoError(t, err)
+	if assert.Len(t, d.Templates, 1) {
+		assert.Equal(t, "Name", d.Templates[0].Name)
+		assert.Equal(t, "Description", d.Templates[0].Description)
+	}
+
+	if assert.Len(t, d.DeployableNetworks, 1) {
+		assert.Equal(t, "Test Network", d.DeployableNetworks[0].Name)
+		assert.Equal(t, "id-for-network", d.DeployableNetworks[0].NetworkID)
+	}
+}
+
+func TestSuccessfulDataCenterGroupURL(t *testing.T) {
+	d := DataCenterGroup{DataCenter: DataCenter{ID: "abc123"}}
+	u, err := d.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/datacenters/AA/abc123?groupLinks=true", u)
+}
+
+func TestErroredDataCenterGroupURL(t *testing.T) {
+	d := DataCenterGroup{}
+	_, err := d.URL("AA")
+	assert.EqualError(t, err, "need a DataCenter with an ID")
+}
+
+func TestSuccessfulDataCenterGroupUnmarshalling(t *testing.T) {
+	d := DataCenterGroup{}
+	err := json.Unmarshal([]byte(fakeapi.DataCenterGroupResponse), &d)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "IL1", d.ID)
+	assert.Equal(t, "Illinois 1", d.Name)
+	assert.Len(t, d.Links, 2)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/doc.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/doc.go
@@ -1,0 +1,35 @@
+/*
+Package clcgo is an API wrapper for the CenturyLink Cloud (CLC) API V2. While
+not a complete implementation of the API, it is capable of fulfilling common
+use cases around provisioning and querying servers.
+
+It will be invaluable for you to read the API documentation to understand what
+is available:
+
+https://t3n.zendesk.com/categories/20067994-API-v2-0-Beta-
+
+This library attempts to follow the resource and JSON attribute names exactly
+in naming its structs and fields.
+
+Usage
+
+All API interactions require authentication. You should begin by instantiating
+a Client with the NewClient function. You can then authenticate with your CLC
+username and password using the GetAPICredentials function. You can read more
+about the details of authentication in the documentation for the APICredentials
+struct and the GetAPICredentials function.
+
+Once authenticated, the Client provides a function for fetching resources,
+GetEntity, and one for saving resource, SaveEntity. Both of those functions
+have example documentation around their use. Each individual resource has
+documentation about its capabilities and requirements.
+
+Development and Extension
+
+If you want to use clcgo with an API resource that has not yet been
+implemented, you should look at the documentation for the Entity, SaveEntity,
+and CreationStatusProvidingEntity interfaces. Implementing one or more of those
+interfaces, depending on the resource, will allow you to write your own
+resources and interact with them in the standard fashion.
+*/
+package clcgo

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/entities.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/entities.go
@@ -1,0 +1,45 @@
+package clcgo
+
+const (
+	apiDomain        = "https://api.tier3.com"
+	apiRoot          = apiDomain + "/v2"
+	successfulStatus = "succeeded"
+)
+
+// The Entity interface is implemented by any resource type that can be asked
+// for its details via GetEntity. This seems basic and is implemented in most
+// cases, but a few - PublicIPAddress for instance - can only be sent and not
+// subsequently read.
+type Entity interface {
+	URL(string) (string, error)
+}
+
+type DeletionStatusProvidingEntity interface {
+	StatusFromDeleteResponse([]byte) (Status, error)
+}
+
+// A Status is returned by all SaveEntity calls and can be used to determine
+// when long-running provisioning jobs have completed. Things like Server
+// creation take time, and you can periodically call GetEntity on the returned
+// Status to determine if the server is ready.
+type Status struct {
+	Status string
+	URI    string
+}
+
+func (s Status) URL(a string) (string, error) {
+	return apiDomain + s.URI, nil
+}
+
+// HasSucceeded will, unsurprisingly, tell you if the Status is successful.
+func (s Status) HasSucceeded() bool {
+	return s.Status == successfulStatus
+}
+
+// A Link is a meta object returned in many API responses to help find
+// resources related to the one you've requested.
+type Link struct {
+	ID   string `json:"id"`
+	Rel  string `json:"rel"`
+	HRef string `json:"href"`
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/entities_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/entities_test.go
@@ -1,0 +1,25 @@
+package clcgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusURL(t *testing.T) {
+	s := Status{URI: "/v2/status/1234"}
+	url, err := s.URL("AA")
+	assert.NoError(t, err)
+	assert.Equal(t, apiDomain+"/v2/status/1234", url)
+}
+
+func TestStatusHasSucceeded(t *testing.T) {
+	s := Status{}
+	assert.False(t, s.HasSucceeded())
+
+	s.Status = "executing"
+	assert.False(t, s.HasSucceeded())
+
+	s.Status = "succeeded"
+	assert.True(t, s.HasSucceeded())
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/example_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/example_test.go
@@ -1,0 +1,140 @@
+package clcgo_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/CenturyLinkLabs/clcgo"
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+)
+
+var (
+	exampleDefaultHTTPClient *http.Client
+	fakeAPIServer            *httptest.Server
+)
+
+type exampleDomainRewriter struct {
+	RewriteURL *url.URL
+}
+
+func (r exampleDomainRewriter) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = r.RewriteURL.Host
+
+	t := http.Transport{}
+	return t.RoundTrip(req)
+}
+
+func setupExample() {
+	fakeAPIServer = fakeapi.CreateFakeServer()
+
+	// Replace the clcgo.DefaultHTTPClient with one that will rewrite the
+	// requests to go to the test server instead of production.
+	exampleDefaultHTTPClient = clcgo.DefaultHTTPClient
+	u, _ := url.Parse(fakeAPIServer.URL)
+	clcgo.DefaultHTTPClient = &http.Client{Transport: exampleDomainRewriter{RewriteURL: u}}
+}
+
+func teardownExample() {
+	fakeAPIServer.Close()
+	clcgo.DefaultHTTPClient = exampleDefaultHTTPClient
+}
+
+func ExampleClient_GetAPICredentials_successful() {
+	// Some test-related setup code which you can safely ignore.
+	setupExample()
+	defer teardownExample()
+
+	c := clcgo.NewClient()
+	c.GetAPICredentials("user", "pass")
+
+	fmt.Printf("Account Alias: %s", c.APICredentials.AccountAlias)
+	// Output:
+	// Account Alias: ACME
+}
+
+func ExampleClient_GetAPICredentials_failed() {
+	// Some test-related setup code which you can safely ignore.
+	setupExample()
+	defer teardownExample()
+
+	c := clcgo.NewClient()
+	err := c.GetAPICredentials("bad", "bad")
+
+	fmt.Printf("Error: %s", err)
+	// Output:
+	// Error: there was a problem with your credentials
+}
+
+func ExampleClient_GetEntity_successful() {
+	// Some test-related setup code which you can safely ignore.
+	setupExample()
+	defer teardownExample()
+
+	c := clcgo.NewClient()
+	c.GetAPICredentials("user", "pass")
+
+	s := clcgo.Server{ID: "server1"}
+	c.GetEntity(&s)
+
+	fmt.Printf("Server Name: %s", s.Name)
+	// Output:
+	// Server Name: Test Name
+}
+
+func ExampleClient_GetEntity_expiredToken() {
+	// Some test-related setup code which you can safely ignore.
+	setupExample()
+	defer teardownExample()
+
+	c := clcgo.NewClient()
+	// You are caching this Bearer Token value and it has either expired or for
+	// some other reason become invalid.
+	c.APICredentials = clcgo.APICredentials{BearerToken: "expired", AccountAlias: "ACME"}
+
+	s := clcgo.Server{ID: "server1"}
+	err := c.GetEntity(&s)
+
+	rerr, _ := err.(clcgo.RequestError)
+	fmt.Printf("Error: %s, Status Code: %d", rerr, rerr.StatusCode)
+	// Output:
+	// Error: your bearer token was rejected, Status Code: 401
+}
+
+func ExampleClient_SaveEntity_successful() {
+	// Some test-related setup code which you can safely ignore.
+	setupExample()
+	defer teardownExample()
+
+	c := clcgo.NewClient()
+	c.GetAPICredentials("user", "pass")
+
+	// Build a Server resource. In reality there are many more required fields.
+	s := clcgo.Server{Name: "My Server"}
+
+	// Request the Server be provisioned, returning a Status. In your code you
+	// must NOT ignore the possibility of an error here.
+	st, _ := c.SaveEntity(&s)
+
+	// Refresh the Status until it has completed. In your code you should put a
+	// delay between requests, as this can take a while.
+	if !st.HasSucceeded() {
+		c.GetEntity(&st)
+	}
+
+	// The Status says that the server is provisioned. You can now request its
+	// details. Again, your code should not ignore errors as this is doing.
+	c.GetEntity(&s)
+
+	fmt.Printf("Server ID: %s", s.ID)
+	// Output:
+	// Server ID: test-id
+}
+
+func ExampleCredentials_persisted() {
+	client := clcgo.NewClient()
+	creds := clcgo.APICredentials{BearerToken: "TOKEN", AccountAlias: "ACME"}
+	client.APICredentials = creds // Client now ready for authenticated requests.
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/doc.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/doc.go
@@ -1,0 +1,7 @@
+/*
+Package fakeapi contains canned API responses from the CenturyLink Cloud API,
+and helpers to start an httptest.Server that will return those responses
+appropriately. It is used primarily in clcgo's tests and you are unlikely to
+need it.
+*/
+package fakeapi

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/fixtures.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/fixtures.go
@@ -1,0 +1,137 @@
+package fakeapi
+
+// Fixture constants for the fakeapi's hardcoded responses, including for
+// successful and unsuccessful requests.
+const (
+	AuthenticationSuccessfulResponse = `{
+		"bearerToken": "1234ABCDEF",
+		"accountAlias": "ACME"
+	}`
+
+	ServerResponse = `{
+		"id": "test-id",
+		"name": "Test Name",
+		"groupId": "123il",
+		"status": "active",
+		"details": {
+			"powerState": "started",
+			"ipAddresses": [
+				{
+					"internal": "10.0.0.1"
+				},
+				{
+					"public": "8.8.8.8",
+					"internal": "10.0.0.2"
+				}
+			]
+		}
+	}`
+
+	ServerCredentialsResponse = `{"userName":"root","password":"p4ssw0rd"}`
+
+	SuccessfulStatusResponse = `{ "status":"succeeded" }`
+
+	ServerCreationSuccessfulResponse = `{
+		"server":"web",
+		"isQueued":true,
+		"links":[
+			{
+				"rel":"status",
+				"href":"/v2/operations/alias/status/test-status-id",
+				"id":"test-status-id"
+			},
+			{
+				"rel":"self",
+				"href":"/v2/servers/alias/test-uuid?uuid=True",
+				"id":"test-uuid",
+				"verbs": [ "GET" ]
+			}
+		]
+	}`
+
+	ServerCreationMissingStatusResponse = `{
+		"server":"web",
+		"isQueued":true,
+		"links":[
+			{
+				"rel":"self",
+				"href":"/path/to/self",
+				"id":"id-for-self",
+				"verbs": [ "GET" ]
+			}
+		]
+	}`
+
+	ServerCreationInvalidResponse = `{
+		"message": "the request is invalid.",
+		"modelState": {
+			"body.name": ["The name field is required."],
+			"body.sourceServerId":["The sourceServerId field is required."]
+		}
+	}`
+
+	PauseServersSuccessfulResponse = `[
+		{
+			"server": "test-id",
+			"isQueued": true,
+			"links": [
+				{
+					"rel": "status",
+					"href": "/path/to/status",
+					"id": "id-for-status"
+				}
+			]
+		}
+	]`
+
+	AddPublicIPAddressSuccessfulResponse = `{
+		"rel":"status",
+		"href":"/path/to/status",
+		"id":"id-for-status"
+	}`
+
+	DataCenterCapabilitiesResponse = `{
+		"deployableNetworks":[
+			{
+				"name":"Test Network",
+				"networkId":"id-for-network",
+				"type":"private",
+				"accountID":"ACME"
+			}
+		],
+		"templates": [
+			{ "name": "Name", "description": "Description" }
+		]
+	}`
+
+	DataCenterGroupResponse = `{
+		"id": "IL1",
+		"name": "Illinois 1",
+		"links": [
+			{
+				 "rel": "self",
+				 "href": "/v2/datacenters/ACME/IL1"
+			},
+			{
+				 "rel": "group",
+				 "href": "/v2/groups/ACME/group-id",
+				 "id": "group-id",
+				 "name": "IL1 Hardware"
+			}
+		]
+	}`
+
+	GroupResponse = `{
+		"id": "test-id",
+		"name": "Test Group",
+		"type": "archive",
+		"groups": [
+			{
+				"id": "test-child-id",
+				"name": "Nested Group",
+				"type": "default",
+				"groups": []
+			}
+		]
+	}`
+)

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/server.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/fakeapi/server.go
@@ -1,0 +1,71 @@
+package fakeapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+)
+
+// CreateFakeServer instantiates a new httptest.Server hooked the the correct
+// routes and returning the expected fixture data.
+func CreateFakeServer() *httptest.Server {
+	m := http.NewServeMux()
+	s := httptest.NewServer(m)
+
+	// Authentication
+	m.Handle("/v2/authentication/login", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := struct {
+			Username string
+			Password string
+		}{}
+		s, _ := ioutil.ReadAll(r.Body)
+		json.Unmarshal(s, &p)
+
+		if p.Username == "user" && p.Password == "pass" {
+			fmt.Fprintf(w, AuthenticationSuccessfulResponse)
+		} else {
+			http.Error(w, "{}", 400)
+		}
+	}))
+
+	// Server fetch
+	m.Handle("/v2/servers/ACME/server1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer 1234ABCDEF" {
+			http.Error(w, "", 401)
+		} else {
+			fmt.Fprintf(w, ServerResponse)
+		}
+	}))
+
+	// Server save
+	m.Handle("/v2/servers/ACME", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer 1234ABCDEF" {
+			http.Error(w, "", 401)
+		} else if r.Method != "POST" {
+			http.Error(w, "", 405)
+		} else {
+			fmt.Fprintf(w, ServerCreationSuccessfulResponse)
+		}
+	}))
+
+	// Status fetch
+	m.Handle("/v2/operations/alias/status/test-status-id", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer 1234ABCDEF" {
+			http.Error(w, "", 401)
+		} else {
+			fmt.Fprintf(w, SuccessfulStatusResponse)
+		}
+	}))
+
+	// Server fetch by UUID
+	m.Handle("/v2/servers/alias/test-uuid", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer 1234ABCDEF" {
+			http.Error(w, "", 401)
+		} else {
+			fmt.Fprintf(w, ServerResponse)
+		}
+	}))
+	return s
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/groups.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/groups.go
@@ -1,0 +1,46 @@
+package clcgo
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	groupsURL = apiRoot + "/groups/%s"
+	groupURL  = groupsURL + "/%s"
+)
+
+// A Group resource can be used to discover the hierarchy of the created groups
+// for your account for a given datacenter. The Group's ID can either be for
+// one you have created, or for a datacenter's hardware group (which can be
+// determined via the DataCenterGroup resource).
+//
+// When creating a new group, the ParentGroup field must be set before you
+// attempt to save.
+type Group struct {
+	ParentGroup   *Group  `json:"-"`
+	ID            string  `json:"id"`
+	ParentGroupID string  `json:"parentGroupId"` // TODO: not in get, extract to creation params?
+	Name          string  `json:"name"`
+	Description   string  `json:"description"`
+	Type          string  `json:"type"`
+	Groups        []Group `json:"groups"`
+}
+
+func (g *Group) URL(a string) (string, error) {
+	if g.ID == "" {
+		return "", errors.New("an ID field is required to get a group")
+	}
+
+	return fmt.Sprintf(groupURL, a, g.ID), nil
+}
+
+func (g *Group) RequestForSave(a string) (request, error) {
+	if g.ParentGroup == nil || g.ParentGroup.ID == "" {
+		return request{}, errors.New("a ParentGroup with an ID is required to create a group")
+	}
+
+	url := fmt.Sprintf(groupsURL, a)
+	g.ParentGroupID = g.ParentGroup.ID
+	return request{URL: url, Parameters: *g}, nil
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/groups_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/groups_test.go
@@ -1,0 +1,62 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfulGroupURL(t *testing.T) {
+	g := Group{ID: "test-id"}
+	u, err := g.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/groups/AA/test-id", u)
+}
+
+func TestErroredGroupURL(t *testing.T) {
+	g := Group{}
+	s, err := g.URL("AA")
+	assert.Equal(t, "", s)
+	assert.EqualError(t, err, "an ID field is required to get a group")
+}
+
+func TestGroupUnmarshalling(t *testing.T) {
+	g := Group{}
+	err := json.Unmarshal([]byte(fakeapi.GroupResponse), &g)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test-id", g.ID)
+	assert.Equal(t, "Test Group", g.Name)
+	assert.Equal(t, "archive", g.Type)
+	if assert.Len(t, g.Groups, 1) {
+		assert.Equal(t, "test-child-id", g.Groups[0].ID)
+	}
+}
+
+func TestSuccessfulGroupRequestForSave(t *testing.T) {
+	p := Group{ID: "parent-group-id"}
+	g := Group{
+		Name:        "Test Group",
+		Description: "Description",
+		ParentGroup: &p,
+	}
+	req, err := g.RequestForSave("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/groups/AA", req.URL)
+	assert.Equal(t, g, req.Parameters)
+	rg, ok := req.Parameters.(Group)
+	if assert.True(t, ok) {
+		assert.Equal(t, "parent-group-id", rg.ParentGroupID)
+	}
+}
+
+func TestErroredGroupRequestForSave(t *testing.T) {
+	g := Group{Name: "Test Group"}
+	req, err := g.RequestForSave("AA")
+	assert.Equal(t, request{}, req)
+	assert.EqualError(t, err, "a ParentGroup with an ID is required to create a group")
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/helpers_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/helpers_test.go
@@ -1,0 +1,47 @@
+package clcgo
+
+import "fmt"
+
+type handlerCallback func(string, request) (string, error)
+
+type testRequestor struct {
+	Handlers map[string]map[string]handlerCallback
+}
+
+func newTestRequestor() testRequestor {
+	return testRequestor{
+		Handlers: make(map[string]map[string]handlerCallback),
+	}
+}
+
+// BUG(dp): Handlers that are never called will not fail. There needs to be
+// some kind of ability to verify that a handler was called if you wish.
+func (r *testRequestor) registerHandler(m string, url string, callback handlerCallback) {
+	if _, found := r.Handlers[m]; !found {
+		r.Handlers[m] = make(map[string]handlerCallback)
+	}
+
+	r.Handlers[m][url] = callback
+}
+
+func (r testRequestor) GetJSON(t string, req request) ([]byte, error) {
+	return r.responseForMethod("GET", t, req)
+}
+
+func (r testRequestor) PostJSON(t string, req request) ([]byte, error) {
+	return r.responseForMethod("POST", t, req)
+}
+
+func (r testRequestor) DeleteJSON(t string, req request) ([]byte, error) {
+	return r.responseForMethod("DELETE", t, req)
+}
+
+func (r testRequestor) responseForMethod(m string, t string, req request) ([]byte, error) {
+	callback, found := r.Handlers[m][req.URL]
+	if found {
+		s, err := callback(t, req)
+		return []byte(s), err
+	}
+
+	return nil, fmt.Errorf("there is no handler for %s '%s'", m, req.URL)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/operations.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/operations.go
@@ -1,0 +1,81 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// An OperationType should be used in conjunction with a ServerOperation to
+// instruct a server instance to perform one of several operations.
+type OperationType string
+
+// More information on precisely what each operation does can be found in the
+// CenturyLink Cloud V2 API documentation.
+const (
+	PauseServer    OperationType = "pause"
+	ShutDownServer OperationType = "shutDown"
+	RebootServer   OperationType = "reboot"
+	ResetServer    OperationType = "reset"
+	PowerOnServer  OperationType = "powerOn"
+	PowerOffServer OperationType = "powerOff"
+)
+
+// A ServerOperation is used to perform many tasks around
+// starting/stopping/pausing server instances.
+//
+// You are required to pass both a Server reference and an OperationType, and
+// you will be notified of the operation's progress via the Status that
+// is returned when the ServerOperation is passed to SaveEntity.
+type ServerOperation struct {
+	OperationType OperationType
+	Server        Server
+}
+
+type operationResponse struct {
+	Links []Link `json:"links"`
+}
+
+const (
+	operationsRoot = apiRoot + "/operations"
+	operationURL   = operationsRoot + "/%s/servers/%s"
+)
+
+func (p ServerOperation) RequestForSave(a string) (request, error) {
+	if p.Server.ID == "" || p.OperationType == "" {
+		return request{}, errors.New("a ServerOperation requires a Server and OperationType")
+	}
+
+	r := request{
+		URL:        fmt.Sprintf(operationURL, a, p.OperationType),
+		Parameters: []string{p.Server.ID},
+	}
+
+	return r, nil
+}
+
+func (p ServerOperation) StatusFromCreateResponse(r []byte) (Status, error) {
+	ors := []operationResponse{}
+	err := json.Unmarshal(r, &ors)
+	if err != nil {
+		return Status{}, err
+	}
+
+	// This API is capable of operating on multiple servers in one call, but
+	// allowing for single or multiple entities everywhere is going to require
+	// more reshuffling than we need to do right now. We enforce a single server
+	// on the operation, and error if the API returns more than one operation. It
+	// shouldn't based on us only submitting one server a time, but just in case.
+	// I'd rather error than ignore or panic.
+	if len(ors) != 1 {
+		return Status{}, errors.New("expected a single operation response from the API!")
+	}
+	or := ors[0]
+
+	sl, err := typeFromLinks("status", or.Links)
+	if err != nil {
+		return Status{}, errors.New("the operation response has no status link")
+	}
+
+	return Status{URI: sl.HRef}, nil
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/operations_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/operations_test.go
@@ -1,0 +1,46 @@
+package clcgo
+
+import (
+	"testing"
+
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfulServerOperationRequestForSave(t *testing.T) {
+	s := Server{ID: "test-id"}
+	p := ServerOperation{Server: s, OperationType: PauseServer}
+	req, err := p.RequestForSave("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/operations/AA/servers/pause", req.URL)
+
+	sids, ok := req.Parameters.([]string)
+	if assert.True(t, ok) {
+		assert.Len(t, sids, 1)
+		assert.Equal(t, "test-id", sids[0])
+	}
+}
+
+func TestErroredServerOperationRequestForSave(t *testing.T) {
+	p := ServerOperation{OperationType: PauseServer}
+	req, err := p.RequestForSave("AA")
+
+	assert.Equal(t, request{}, req)
+	assert.EqualError(t, err, "a ServerOperation requires a Server and OperationType")
+
+	s := Server{ID: "test-id"}
+	p = ServerOperation{Server: s}
+	req, err = p.RequestForSave("AA")
+
+	assert.Equal(t, request{}, req)
+	assert.EqualError(t, err, "a ServerOperation requires a Server and OperationType")
+}
+
+func TestServerOperationStatusFromCreateResponse(t *testing.T) {
+	s := Server{ID: "test-id"}
+	p := ServerOperation{Server: s, OperationType: PauseServer}
+	st, err := p.StatusFromCreateResponse([]byte(fakeapi.PauseServersSuccessfulResponse))
+	assert.NoError(t, err)
+	assert.Equal(t, "/path/to/status", st.URI)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/requestor.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/requestor.go
@@ -1,0 +1,146 @@
+package clcgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// DefaultHTTPClient can be overridden in the same fashion as the DefaultClient
+// for http, if you would like to implement some behavioral change around the
+// requests that we could not anticipate.
+var DefaultHTTPClient = &http.Client{}
+
+type requestor interface {
+	PostJSON(string, request) ([]byte, error)
+	GetJSON(string, request) ([]byte, error)
+	DeleteJSON(string, request) ([]byte, error)
+}
+
+type clcRequestor struct{}
+
+type modelStates map[string][]string
+
+// A RequestError can be returned from GetEntity and SaveEntity calls and
+// contain specific information about the unexpected error from your request.
+// It can be especially helpful on SaveEntity validation failures, for instance
+// if you omitted a required field.
+type RequestError struct {
+	Message    string
+	StatusCode int
+	Errors     modelStates
+}
+
+type invalidReqestResponse struct {
+	Message    string      `json:"message"`
+	ModelState modelStates `json:"modelState"`
+}
+
+func (r RequestError) Error() string {
+	return r.Message
+}
+
+func (r clcRequestor) PostJSON(t string, req request) ([]byte, error) {
+	body, code, err := requestFor("POST", t, req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	switch code {
+	case 200, 201, 202:
+		return body, nil
+	case 400:
+		var e invalidReqestResponse
+		err := json.Unmarshal(body, &e)
+		if err != nil {
+			return body, err
+		}
+
+		return body, RequestError{Message: e.Message, StatusCode: 400, Errors: e.ModelState}
+	case 401:
+		return body, RequestError{Message: "your bearer token was rejected", StatusCode: 401}
+	default:
+		return body, RequestError{Message: fmt.Sprintf("got an unexpected status code '%d'", code), StatusCode: code}
+	}
+}
+
+func (r clcRequestor) GetJSON(t string, req request) ([]byte, error) {
+	body, code, err := requestFor("GET", t, req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	switch code {
+	case 200:
+		return body, nil
+	case 401:
+		return body, RequestError{Message: "your bearer token was rejected", StatusCode: 401}
+	default:
+		return body, RequestError{Message: fmt.Sprintf("got an unexpected status code '%d'", code), StatusCode: code}
+	}
+}
+
+func (r clcRequestor) DeleteJSON(t string, req request) ([]byte, error) {
+	body, code, err := requestFor("DELETE", t, req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	switch code {
+	case 202:
+		return body, nil
+	case 401:
+		return body, RequestError{Message: "your bearer token was rejected", StatusCode: 401}
+	default:
+		return body, RequestError{Message: fmt.Sprintf("got an unexpected status code '%d'", code), StatusCode: code}
+	}
+}
+
+func requestFor(m string, t string, req request) ([]byte, int, error) {
+	var params io.Reader
+	if req.Parameters != nil {
+		j, err := json.Marshal(req.Parameters)
+		if err != nil {
+			return []byte{}, 0, err
+		}
+
+		params = bytes.NewReader(j)
+	}
+
+	hr, err := http.NewRequest(m, req.URL, params)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+
+	if t != "" {
+		hr.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t))
+	}
+	hr.Header.Add("Content-Type", "application/json")
+	hr.Header.Add("Accepts", "application/json")
+
+	resp, err := DefaultHTTPClient.Do(hr)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+
+	return body, resp.StatusCode, nil
+}
+
+func typeFromLinks(t string, ls []Link) (Link, error) {
+	for _, l := range ls {
+		if l.Rel == t {
+			return l, nil
+		}
+	}
+
+	return Link{}, fmt.Errorf("no link of type '%s'", t)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/requestor_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/requestor_test.go
@@ -1,0 +1,244 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type testParameters struct {
+	TestKey string
+}
+
+func TestSuccessfulUnauthenticatedPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("accepts"))
+
+		s, _ := ioutil.ReadAll(r.Body)
+		var p testParameters
+		err := json.Unmarshal(s, &p)
+		assert.NoError(t, err)
+		assert.Equal(t, testParameters{"Testing"}, p)
+
+		fmt.Fprintf(w, "Response Text")
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{"Testing"}}
+	response, err := r.PostJSON("", req)
+	assert.NoError(t, err)
+
+	responseString := string(response)
+	assert.Equal(t, "Response Text", responseString)
+}
+
+func TestSuccessfulAuthenticatedPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		fmt.Fprintf(w, "Response Text")
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{}}
+	_, err := r.PostJSON("token", req)
+	assert.NoError(t, err)
+}
+
+func TestSuccessfulPassingArrayToPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, `["first","second"]`, s)
+
+		fmt.Fprintf(w, "Response Text")
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: []string{"first", "second"}}
+	_, err := r.PostJSON("token", req)
+	assert.NoError(t, err)
+}
+
+func TestUnauthorizedPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", 401)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{}}
+	_, err := r.PostJSON("token", req)
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "your bearer token was rejected")
+		assert.Equal(t, 401, reqErr.StatusCode)
+	}
+}
+
+func TestUnhandledStatusOnPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "I'm a teapot", 418)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{"Testing"}}
+	response, err := r.PostJSON("", req)
+	assert.Contains(t, string(response), "I'm a teapot")
+
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "got an unexpected status code '418'")
+		assert.Equal(t, 418, reqErr.StatusCode)
+	}
+}
+
+func Test400WithMessagesOnPostJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, fakeapi.ServerCreationInvalidResponse, 400)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{}}
+	_, err := r.PostJSON("token", req)
+
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "the request is invalid.")
+		assert.Equal(t, 400, reqErr.StatusCode)
+		if assert.Len(t, reqErr.Errors, 2) {
+			assert.Equal(t, "The name field is required.", reqErr.Errors["body.name"][0])
+			assert.Equal(
+				t, "The sourceServerId field is required.", reqErr.Errors["body.sourceServerId"][0],
+			)
+		}
+	}
+}
+
+func TestSuccessfulGetJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Response Text")
+
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("accepts"))
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	response, err := r.GetJSON("token", request{URL: ts.URL})
+	assert.NoError(t, err)
+	assert.Equal(t, "Response Text", string(response))
+}
+
+func TestUnauthorizedGetJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", 401)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	_, err := r.GetJSON("token", request{URL: ts.URL})
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "your bearer token was rejected")
+		assert.Equal(t, 401, reqErr.StatusCode)
+	}
+}
+
+func TestErrored400GetJson(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Bad Request", 400)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	response, err := r.GetJSON("token", request{URL: ts.URL})
+	assert.Contains(t, string(response), "Bad Request")
+
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "got an unexpected status code '400'")
+		assert.Equal(t, 400, reqErr.StatusCode)
+	}
+}
+
+func TestSuccessfulDeleteJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("accepts"))
+
+		w.WriteHeader(202)
+		fmt.Fprintf(w, "Response Text")
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{}}
+	res, err := r.DeleteJSON("token", req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Response Text", string(res))
+}
+
+func TestUnauthorizedDeleteJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", 401)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	req := request{URL: ts.URL, Parameters: testParameters{}}
+	_, err := r.DeleteJSON("token", req)
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "your bearer token was rejected")
+		assert.Equal(t, 401, reqErr.StatusCode)
+	}
+}
+
+func TestErrored400DeleteJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Bad Request", 400)
+	}))
+	defer ts.Close()
+
+	r := &clcRequestor{}
+	response, err := r.DeleteJSON("token", request{URL: ts.URL})
+	assert.Contains(t, string(response), "Bad Request")
+
+	reqErr, ok := err.(RequestError)
+	if assert.True(t, ok) {
+		assert.EqualError(t, reqErr, "got an unexpected status code '400'")
+		assert.Equal(t, 400, reqErr.StatusCode)
+	}
+}
+
+func TestTypeFromLinks(t *testing.T) {
+	l := Link{Rel: "t"}
+	ls := []Link{l}
+
+	found, err := typeFromLinks("t", ls)
+	assert.NoError(t, err)
+	assert.Equal(t, l, found)
+
+	found, err = typeFromLinks("bad", ls)
+	assert.EqualError(t, err, "no link of type 'bad'")
+	assert.Equal(t, Link{}, found)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/savable_entities.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/savable_entities.go
@@ -1,0 +1,24 @@
+package clcgo
+
+type request struct {
+	URL        string
+	Parameters interface{}
+}
+
+// The SavableEntity interface is implemented on any resources that can be
+// saved via SaveEntity.
+type SavableEntity interface {
+	RequestForSave(string) (request, error)
+}
+
+// CreationStatusProvidingEntity will be implemented by some SavableEntity
+// resources when information about the created resource is not immediately
+// available.  For instance, a Server or PublicIPAddress must first be
+// provisioned, so a Status object is returned so that you can query it until
+// the work has been successfully completed.
+//
+// All StatusProvidingEntites must be SavableEntities, but not every
+// SavableEntity is a CreationStatusProvidingEntity.
+type CreationStatusProvidingEntity interface {
+	StatusFromCreateResponse([]byte) (Status, error)
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/server.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/server.go
@@ -1,0 +1,165 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	serverCreationURL       = apiRoot + "/servers/%s"
+	serverURL               = serverCreationURL + "/%s"
+	publicIPAddressURL      = serverURL + "/publicIPAddresses"
+	serverActiveStatus      = "active"
+	serverStartedPowerState = "started"
+	serverPausedPowerState  = "paused"
+)
+
+// A Server can be used to either fetch an existing Server or provision and new
+// one. To fetch, you must supply an ID value. For creation, there are numerous
+// required values. The API documentation should be consulted.
+//
+// The SourceServerID is a required field that allows multiple values which are
+// documented in the API. One of the allowed values is a Template ID, which can
+// be retrieved with the DataCenterCapabilities resource.
+//
+// To make your server a member of a specific network, you can set the
+// DeployableNetwork field. This is optional. The Server will otherwise be a
+// member of the default network. DeployableNetworks exist per account and
+// DataCenter and can be retrieved via the DataCenterCapabilities resource. If
+// you know the NetworkID, you can supply it instead.
+//
+// A Password field can be set for a Server you are saving, but fetching the
+// username and password for an existing Server can only be done via the
+// Credentials resource.
+type Server struct {
+	uuidURI           string            `json:"-"`
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	GroupID           string            `json:"groupId"`
+	Status            string            `json:"status"`
+	SourceServerID    string            `json:"sourceServerId"` // TODO: nonexistent in get, extract to creation params?
+	CPU               int               `json:"cpu"`
+	MemoryGB          int               `json:"memoryGB"` // TODO: memoryMB in get, extract to creation params?
+	Type              string            `json:"type"`
+	DeployableNetwork DeployableNetwork `json:"-"`
+	NetworkID         string            `json:"networkId"`
+	Password          string            `json:"password"`
+	Details           struct {
+		PowerState  string `json:"powerState"`
+		IPAddresses []struct {
+			Public   string `json:"public"`
+			Internal string `json:"internal"`
+		} `json:"ipAddresses"`
+	} `json:"details"`
+}
+
+// Credentials can be used to fetch the username and password for a Server. You
+// must supply the associated Server.
+//
+// This uses an undocumented API endpoint and could be changed or removed.
+type Credentials struct {
+	Server   Server `json:"-"`
+	Username string `json:"userName"`
+	Password string `json:"password"`
+}
+
+type serverCreationResponse struct {
+	Links []Link `json:"links"`
+}
+
+// A PublicIPAddress can be created and associated with an existing,
+// provisioned Server. You must supply the associated Server object.
+//
+// You must supply a slice of Port objects that will make the specified ports
+// accessible at the address.
+type PublicIPAddress struct {
+	Server            Server
+	Ports             []Port `json:"ports"`
+	InternalIPAddress string `json:"internalIPAddress"`
+}
+
+// A Port object specifies a network port that should be made available on a
+// PublicIPAddress. It can only be used in conjunction with the PublicIPAddress
+// resource.
+type Port struct {
+	Protocol string `json:"protocol"`
+	Port     int    `json:"port"`
+}
+
+// IsActive will, unsurprisingly, tell you if the Server is both active and not
+// paused.
+func (s Server) IsActive() bool {
+	return s.Status == serverActiveStatus && s.Details.PowerState == serverStartedPowerState
+}
+
+// IsPaused will tell you if the Server is paused or not.
+func (s Server) IsPaused() bool {
+	return s.Details.PowerState == serverPausedPowerState
+}
+
+func (s Server) URL(a string) (string, error) {
+	if s.ID == "" && s.uuidURI == "" {
+		return "", errors.New("an ID field is required to get a server")
+	} else if s.uuidURI != "" {
+		return apiDomain + s.uuidURI, nil
+	}
+
+	return fmt.Sprintf(serverURL, a, s.ID), nil
+}
+
+func (s *Server) RequestForSave(a string) (request, error) {
+	url := fmt.Sprintf(serverCreationURL, a)
+	s.NetworkID = s.DeployableNetwork.NetworkID
+	return request{URL: url, Parameters: *s}, nil
+}
+
+func (s *Server) StatusFromCreateResponse(r []byte) (Status, error) {
+	scr := serverCreationResponse{}
+	err := json.Unmarshal(r, &scr)
+	if err != nil {
+		return Status{}, err
+	}
+
+	sl, err := typeFromLinks("status", scr.Links)
+	if err != nil {
+		return Status{}, errors.New("the creation response has no status link")
+	}
+
+	il, err := typeFromLinks("self", scr.Links)
+	if err != nil {
+		return Status{}, errors.New("the creation response has no self link")
+	}
+
+	s.uuidURI = il.HRef
+
+	return Status{URI: sl.HRef}, nil
+}
+
+func (c Credentials) URL(a string) (string, error) {
+	if c.Server.ID == "" {
+		return "", errors.New("a Server with an ID is required to fetch credentials")
+	}
+
+	url := fmt.Sprintf("%s/servers/%s/%s/credentials", apiRoot, a, c.Server.ID)
+	return url, nil
+}
+
+func (i PublicIPAddress) RequestForSave(a string) (request, error) {
+	if i.Server.ID == "" {
+		return request{}, errors.New("a Server with an ID is required to add a Public IP Address")
+	}
+
+	url := fmt.Sprintf(publicIPAddressURL, a, i.Server.ID)
+	return request{URL: url, Parameters: i}, nil
+}
+
+func (i PublicIPAddress) StatusFromCreateResponse(r []byte) (Status, error) {
+	l := Link{}
+	err := json.Unmarshal(r, &l)
+	if err != nil {
+		return Status{}, err
+	}
+
+	return Status{URI: l.HRef}, nil
+}

--- a/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/server_test.go
+++ b/Godeps/_workspace/src/github.com/CenturyLinkLabs/clcgo/server_test.go
@@ -1,0 +1,178 @@
+package clcgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/CenturyLinkLabs/clcgo/fakeapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImplementations(t *testing.T) {
+	es := []interface{}{
+		new(DataCenterCapabilities),
+		new(Server),
+		new(Credentials),
+		new(Status),
+	}
+	for _, e := range es {
+		assert.Implements(t, (*Entity)(nil), e)
+	}
+
+	ses := []interface{}{
+		new(Server),
+		new(PublicIPAddress),
+	}
+	for _, se := range ses {
+		assert.Implements(t, (*SavableEntity)(nil), se)
+	}
+}
+
+func TestServerJSONUnmarshalling(t *testing.T) {
+	s := Server{}
+	err := json.Unmarshal([]byte(fakeapi.ServerResponse), &s)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test-id", s.ID)
+	assert.Equal(t, "Test Name", s.Name)
+	assert.Equal(t, "active", s.Status)
+	assert.Equal(t, "123il", s.GroupID)
+	assert.Len(t, s.Details.IPAddresses, 2)
+	assert.Equal(t, "8.8.8.8", s.Details.IPAddresses[1].Public)
+	assert.Equal(t, "started", s.Details.PowerState)
+}
+
+func TestIsActive(t *testing.T) {
+	s := Server{}
+	assert.False(t, s.IsActive())
+
+	s.Status = "active"
+	s.Details.PowerState = "paused"
+	assert.False(t, s.IsActive())
+
+	s.Details.PowerState = "stopped"
+	assert.False(t, s.IsActive())
+
+	s.Details.PowerState = "started"
+	assert.True(t, s.IsActive())
+}
+
+func TestIsPaused(t *testing.T) {
+	s := Server{}
+	assert.False(t, s.IsPaused())
+
+	s.Details.PowerState = "started"
+	assert.False(t, s.IsPaused())
+
+	s.Details.PowerState = "paused"
+	assert.True(t, s.IsPaused())
+}
+
+func TestSuccessfulServerURL(t *testing.T) {
+	s := Server{ID: "abc123"}
+	u, err := s.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/servers/AA/abc123", u)
+}
+
+func TestErroredServerURL(t *testing.T) {
+	u, err := Server{}.URL("AA")
+
+	assert.EqualError(t, err, "an ID field is required to get a server")
+	assert.Empty(t, u)
+}
+
+func TestURLMissingIDHavingUUID(t *testing.T) {
+	u, err := Server{uuidURI: "/v2/alias/1234?uuid=true"}.URL("AA")
+	assert.NoError(t, err)
+	assert.Equal(t, apiDomain+"/v2/alias/1234?uuid=true", u)
+}
+
+func TestServerRequestForSave(t *testing.T) {
+	s := Server{
+		Name:           "Test Name",
+		GroupID:        "1234IL",
+		SourceServerID: "TestID",
+	}
+	req, err := s.RequestForSave("AA")
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/servers/AA", req.URL)
+	assert.Equal(t, s, req.Parameters)
+	assert.Empty(t, s.NetworkID)
+
+	d := DeployableNetwork{NetworkID: "test-network-id"}
+	s.DeployableNetwork = d
+	req, err = s.RequestForSave("AA")
+	assert.Equal(t, s, req.Parameters)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-network-id", s.NetworkID)
+}
+
+func TestSuccessfulStatusFromCreateResponse(t *testing.T) {
+	srv := Server{}
+	s, err := srv.StatusFromCreateResponse([]byte(fakeapi.ServerCreationSuccessfulResponse))
+	assert.NoError(t, err)
+	assert.Equal(t, "/v2/operations/alias/status/test-status-id", s.URI)
+}
+
+func TestErroredMissingStatusLinkStatusFromCreateResponse(t *testing.T) {
+	srv := Server{}
+	s, err := srv.StatusFromCreateResponse([]byte(fakeapi.ServerCreationMissingStatusResponse))
+	assert.Equal(t, Status{}, s)
+	assert.EqualError(t, err, "the creation response has no status link")
+}
+
+func TestSuccessfulIPAddressRequestForSave(t *testing.T) {
+	s := Server{ID: "1234il"}
+	ps := []Port{Port{Protocol: "TCP", Port: 31981}}
+	i := PublicIPAddress{Server: s, Ports: ps}
+	req, err := i.RequestForSave("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiDomain+"/v2/servers/AA/1234il/publicIPAddresses", req.URL)
+	assert.Equal(t, i, req.Parameters)
+}
+
+func TestErroredIPAddressRequestForSave(t *testing.T) {
+	s := Server{}
+	i := PublicIPAddress{Server: s}
+	req, err := i.RequestForSave("AA")
+
+	assert.Equal(t, request{}, req)
+	assert.EqualError(t, err, "a Server with an ID is required to add a Public IP Address")
+}
+
+func TestIPAddressStatusFromCreateResponse(t *testing.T) {
+	i := PublicIPAddress{}
+	s, err := i.StatusFromCreateResponse([]byte(fakeapi.AddPublicIPAddressSuccessfulResponse))
+	assert.NoError(t, err)
+	assert.Equal(t, "/path/to/status", s.URI)
+}
+
+func TestCredentialsJSONUnmarshalling(t *testing.T) {
+	c := Credentials{}
+	err := json.Unmarshal([]byte(fakeapi.ServerCredentialsResponse), &c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "root", c.Username)
+	assert.Equal(t, "p4ssw0rd", c.Password)
+}
+
+func TestSuccessfulCredentialsURL(t *testing.T) {
+	s := Server{ID: "abc123"}
+	c := Credentials{Server: s}
+	u, err := c.URL("AA")
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiRoot+"/servers/AA/abc123/credentials", u)
+}
+
+func TestErroredCredentialsURL(t *testing.T) {
+	c := Credentials{}
+	c.Server = Server{ID: ""}
+
+	u, err := c.URL("AA")
+	assert.EqualError(t, err, "a Server with an ID is required to fetch credentials")
+	assert.Empty(t, u)
+}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/machine/drivers"
 	_ "github.com/docker/machine/drivers/amazonec2"
 	_ "github.com/docker/machine/drivers/azure"
+	_ "github.com/docker/machine/drivers/centurylinkcloud"
 	_ "github.com/docker/machine/drivers/digitalocean"
 	_ "github.com/docker/machine/drivers/exoscale"
 	_ "github.com/docker/machine/drivers/generic"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1129,6 +1129,18 @@ Environment variables and default values:
 | `--amazonec2-private-address-only`  | -                       | `false`          |
 | `--amazonec2-monitoring`            | -                       | `false`          |
 
+### CenturyLink Cloud
+Create machines on [CenturyLink Cloud](http://www.centurylinkcloud.com). The same username and password you use to access the CenturyLink Cloud console is required during server creation.
+
+Options:
+
+ - `--centurylinkcloud-username`: **required** CLC username
+ - `--centurylinkcloud-password`: **required** CLC password
+ - `--centurylinkcloud-group-id`: **required** Group ID. The group the server will be created in. This will also determine the datacenter. If you do not have a group, you must create one. The ID can be determined by looking at the last segment of the URL when viewing the group in the control panel, e.g. `f1329903893b437e91613ffc33fd6fbf`.
+ - `--centurylinkcloud-source-server-id`: A template ID or the ID of an existing server to use when creating. It will otherwise default to the Ubuntu template.
+ - `--centurylinkcloud-cpu`: The number of CPUs for the created instance.  Defaults to 1.
+ - `--centurylinkcloud-memory-gb`: The amount of RAM in GB for the created server. Defaults to 2.
+
 #### Digital Ocean
 Create Docker machines on [Digital Ocean](https://www.digitalocean.com/).
 

--- a/drivers/centurylinkcloud/centurylinkcloud.go
+++ b/drivers/centurylinkcloud/centurylinkcloud.go
@@ -1,0 +1,300 @@
+package centurylinkcloud
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/CenturyLinkLabs/clcgo"
+	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/log"
+	"github.com/docker/machine/state"
+)
+
+const statusWaitSeconds = 10
+
+type Driver struct {
+	MachineName    string
+	CaCertPath     string
+	PrivateKeyPath string
+	storePath      string
+	BearerToken    string
+	AccountAlias   string
+	ServerID       string
+	Username       string
+	Password       string
+	GroupID        string
+	SourceServerID string
+	CPU            int
+	MemoryGB       int
+}
+
+func init() {
+	drivers.Register("centurylinkcloud", &drivers.RegisteredDriver{
+		New:            NewDriver,
+		GetCreateFlags: getCreateFlags,
+	})
+}
+
+func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
+	return &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}, nil
+}
+
+func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
+	return nil
+}
+
+func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
+	return nil
+}
+
+func (d *Driver) GetMachineName() string {
+	return d.MachineName
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+func (d *Driver) GetSSHKeyPath() string {
+	return filepath.Join(d.storePath, "id_rsa")
+}
+
+func (d *Driver) GetSSHPort() (int, error) {
+	return 22, nil
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return "root"
+}
+
+func (d *Driver) DriverName() string {
+	return "centurylinkcloud"
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	d.Username = flags.String("centurylinkcloud-username")
+	d.Password = flags.String("centurylinkcloud-password")
+	d.GroupID = flags.String("centurylinkcloud-group-id")
+	d.SourceServerID = flags.String("centurylinkcloud-source-server-id")
+	d.CPU = flags.Int("centurylinkcloud-cpu")
+	d.MemoryGB = flags.Int("centurylinkcloud-memory-gb")
+
+	if d.Username == "" {
+		return fmt.Errorf("centurylinkcloud driver requires the --centurylinkcloud-username option")
+	}
+
+	if d.GroupID == "" {
+		return fmt.Errorf("centurylinkcloud driver requires the --centurylinkcloud-group-id option")
+	}
+
+	return nil
+}
+
+func (d *Driver) GetURL() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("tcp://%s:2376", ip), nil
+}
+
+func (d *Driver) GetIP() (string, error) {
+	_, s, err := d.getServer()
+	if err != nil {
+		return "", err
+	}
+
+	address := publicIPFromServer(s)
+	if address != "" {
+		return address, nil
+	}
+
+	return "", errors.New("no IP could be found for this server")
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	_, s, err := d.getServer()
+	if err != nil {
+		return state.Error, err
+	}
+
+	if s.IsActive() {
+		return state.Running, nil
+	} else if s.IsPaused() {
+		return state.Paused, nil
+	}
+
+	return state.Stopped, nil
+}
+
+func (d *Driver) Remove() error {
+	c, s, err := d.getServer()
+	if err != nil {
+		return err
+	}
+
+	st, err := c.DeleteEntity(&s)
+	if err != nil {
+		return err
+	}
+
+	for !st.HasSucceeded() {
+		time.Sleep(time.Second * statusWaitSeconds)
+		if err := c.GetEntity(&st); err != nil {
+			return err
+		}
+		log.Debugf("Deletion status: %s", st.Status)
+	}
+
+	return nil
+}
+
+func (d *Driver) Start() error {
+	if err := d.doOperation(clcgo.PowerOnServer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) Stop() error {
+	if err := d.doOperation(clcgo.PowerOffServer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) Restart() error {
+	if err := d.doOperation(clcgo.RebootServer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) Kill() error {
+	if err := d.doOperation(clcgo.PowerOffServer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) getClientWithPersistence() (*clcgo.Client, error) {
+	c := clcgo.NewClient()
+	if d.BearerToken == "" || d.AccountAlias == "" {
+		if err := d.updateAPICredentials(c); err != nil {
+			return nil, err
+		}
+	} else {
+		c.APICredentials = clcgo.APICredentials{
+			BearerToken:  d.BearerToken,
+			AccountAlias: d.AccountAlias,
+		}
+
+		// Something to validate your BearerToken.
+		err := c.GetEntity(&clcgo.DataCenters{})
+		if err != nil {
+			if rerr, ok := err.(clcgo.RequestError); ok && rerr.StatusCode == 401 {
+				err := d.updateAPICredentials(c)
+				if err != nil {
+					return c, err
+				}
+
+				return c, nil
+			}
+
+			return c, err
+		}
+	}
+
+	return c, nil
+}
+
+func (d *Driver) updateAPICredentials(c *clcgo.Client) error {
+	if err := c.GetAPICredentials(d.Username, d.Password); err != nil {
+		return err
+	}
+	// Known Issue: the store is not saved after initial machine create, and so
+	// upon BearerToken expiration it will be making one token request for every
+	// machine command for the rest of time, as it can't persist the token it
+	// fetches.
+	d.AccountAlias = c.APICredentials.AccountAlias
+	d.BearerToken = c.APICredentials.BearerToken
+
+	return nil
+}
+
+func (d *Driver) getServer() (*clcgo.Client, clcgo.Server, error) {
+	s := clcgo.Server{ID: d.ServerID}
+	c, err := d.getClientWithPersistence()
+	if err != nil {
+		return nil, s, err
+	}
+
+	err = c.GetEntity(&s)
+
+	if err != nil {
+		if rerr, ok := err.(clcgo.RequestError); ok {
+			if rerr.StatusCode == 404 {
+				return nil, s, fmt.Errorf("unable to find a server with the ID '%s'", d.ServerID)
+			}
+		}
+
+		return nil, s, err
+	}
+
+	return c, s, nil
+}
+
+func (d *Driver) doOperation(t clcgo.OperationType) error {
+	c, s, err := d.getServer()
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Performing '%s' operation on '%s'...", t, s.ID)
+	o := clcgo.ServerOperation{Server: s, OperationType: t}
+	st, err := c.SaveEntity(&o)
+	if err != nil {
+		return nil
+	}
+
+	for !st.HasSucceeded() {
+		time.Sleep(time.Second * statusWaitSeconds)
+		if err := c.GetEntity(&st); err != nil {
+			return err
+		}
+		log.Debugf("Operation status: %s", st.Status)
+	}
+
+	return nil
+}
+
+func logAndReturnError(err error) error {
+	if rerr, ok := err.(clcgo.RequestError); ok {
+		for f, ms := range rerr.Errors {
+			for _, m := range ms {
+				log.Errorf("%v: %v", f, m)
+			}
+		}
+
+		return rerr
+	}
+
+	return err
+}
+
+func publicIPFromServer(s clcgo.Server) string {
+	addresses := s.Details.IPAddresses
+	for _, a := range addresses {
+		if a.Public != "" {
+			return a.Public
+		}
+	}
+
+	return ""
+}

--- a/drivers/centurylinkcloud/centurylinkcloud_test.go
+++ b/drivers/centurylinkcloud/centurylinkcloud_test.go
@@ -1,0 +1,1 @@
+package centurylinkcloud

--- a/drivers/centurylinkcloud/create.go
+++ b/drivers/centurylinkcloud/create.go
@@ -1,0 +1,205 @@
+package centurylinkcloud
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/CenturyLinkLabs/clcgo"
+	"github.com/codegangsta/cli"
+	"github.com/docker/machine/log"
+	"github.com/docker/machine/ssh"
+)
+
+const serverRequirementsWarning = "CenturyLink Cloud requires that machine names are 2 to 6 characters long"
+
+func getCreateFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			EnvVar: "CENTURYLINKCLOUD_USERNAME",
+			Name:   "centurylinkcloud-username",
+			Usage:  "CenturyLink Cloud Username",
+		},
+		cli.StringFlag{
+			EnvVar: "CENTURYLINKCLOUD_PASSWORD",
+			Name:   "centurylinkcloud-password",
+			Usage:  "CenturyLink Cloud Password",
+		},
+		cli.StringFlag{
+			EnvVar: "CENTURYLINKCLOUD_SERVER_NAME",
+			Name:   "centurylinkcloud-server-name",
+			Usage:  "CenturyLink Cloud Server Name",
+		},
+		cli.StringFlag{
+			EnvVar: "CENTURYLINKCLOUD_GROUP_ID",
+			Name:   "centurylinkcloud-group-id",
+			Usage:  "CenturyLink Cloud Group ID",
+		},
+		cli.StringFlag{
+			EnvVar: "CENTURYLINKCLOUD_SOURCE_SERVER_ID",
+			Name:   "centurylinkcloud-source-server-id",
+			Usage:  "CenturyLink Cloud Source Server ID",
+			Value:  "UBUNTU-14-64-TEMPLATE",
+		},
+		cli.IntFlag{
+			EnvVar: "CENTURYLINKCLOUD_CPU",
+			Name:   "centurylinkcloud-cpu",
+			Usage:  "CenturyLink Cloud CPU Count",
+			Value:  1,
+		},
+		cli.IntFlag{
+			EnvVar: "CENTURYLINKCLOUD_MEMORYGB",
+			Name:   "centurylinkcloud-memory-gb",
+			Usage:  "CenturyLink Cloud Memory GB",
+			Value:  2,
+		},
+	}
+}
+
+func (d *Driver) PreCreateCheck() error {
+	i := len(d.MachineName)
+	if i < 2 {
+		return errors.New(serverRequirementsWarning)
+	}
+
+	return nil
+}
+
+func (d *Driver) Create() error {
+	c, err := d.getClientWithPersistence()
+	if err != nil {
+		return err
+	}
+
+	s, err := d.createServer(c)
+	if err != nil {
+		return err
+	}
+
+	if err := d.addPublicIPAddress(c, &s); err != nil {
+		return err
+	}
+
+	if err = d.generateAndWriteSSHKey(c, s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) createServer(c *clcgo.Client) (clcgo.Server, error) {
+	log.Infof("Creating server...")
+
+	name := d.MachineName[:6]
+	if name != d.MachineName {
+		log.Warnf(
+			"%s. Your server name has been truncated to: %s",
+			serverRequirementsWarning, name,
+		)
+	}
+
+	s := clcgo.Server{
+		Name:           name,
+		GroupID:        d.GroupID,
+		SourceServerID: d.SourceServerID,
+		CPU:            d.CPU,
+		MemoryGB:       d.MemoryGB,
+		Type:           "standard",
+	}
+
+	st, err := c.SaveEntity(&s)
+	if err != nil {
+		return s, logAndReturnError(err)
+	}
+
+	for !st.HasSucceeded() {
+		time.Sleep(time.Second * statusWaitSeconds)
+		log.Debugf("Checking status...")
+		if err := c.GetEntity(&st); err != nil {
+			return s, err
+		}
+	}
+
+	if err = c.GetEntity(&s); err != nil {
+		return s, err
+	}
+	d.ServerID = s.ID
+	log.Infof("Server '%s' is provisioned", s.Name)
+
+	return s, nil
+}
+
+func (d Driver) addPublicIPAddress(c *clcgo.Client, s *clcgo.Server) error {
+	log.Infof("Adding public IP address...")
+
+	ports := []clcgo.Port{
+		{Protocol: "TCP", Port: 22},   // SSH
+		{Protocol: "TCP", Port: 2376}, // Docker
+	}
+	a := clcgo.PublicIPAddress{Server: *s, Ports: ports}
+	st, err := c.SaveEntity(&a)
+	if err != nil {
+		return logAndReturnError(err)
+	}
+	for !st.HasSucceeded() {
+		time.Sleep(time.Second * statusWaitSeconds)
+		log.Debugf("Checking status...")
+		err = c.GetEntity(&st)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := c.GetEntity(s); err != nil {
+		return err
+	}
+	ip := publicIPFromServer(*s)
+	if ip == "" {
+		return errors.New("could not find an IP Address for the server")
+	}
+
+	log.Infof("IP Address '%s' has been provisioned", ip)
+
+	return nil
+}
+
+func (d Driver) generateAndWriteSSHKey(c *clcgo.Client, s clcgo.Server) error {
+	cr := clcgo.Credentials{Server: s}
+	if err := c.GetEntity(&cr); err != nil {
+		return err
+	}
+
+	hostname, err := d.GetSSHHostname()
+	if err != nil {
+		return err
+	}
+	port, err := d.GetSSHPort()
+	if err != nil {
+		return err
+	}
+
+	auth := ssh.Auth{Passwords: []string{cr.Password}}
+	sshClient, err := ssh.NewNativeClient(d.GetSSHUsername(), hostname, port, &auth)
+	if err != nil {
+		return err
+	}
+
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+		return err
+	}
+
+	keyPath := d.GetSSHKeyPath() + ".pub"
+	key, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Adding public key to authorized_keys")
+	cmd := fmt.Sprintf(`echo "%s" >> ~/.ssh/authorized_keys`, string(key))
+	if _, err = sshClient.Output(cmd); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/drivers/centurylinkcloud/create.go
+++ b/drivers/centurylinkcloud/create.go
@@ -197,7 +197,7 @@ func (d Driver) generateAndWriteSSHKey(c *clcgo.Client, s clcgo.Server) error {
 	}
 
 	log.Info("Adding public key to authorized_keys")
-	cmd := fmt.Sprintf(`echo "%s" >> ~/.ssh/authorized_keys`, string(key))
+	cmd := fmt.Sprintf(`mkdir -p ~/.ssh && echo "%s" >> ~/.ssh/authorized_keys`, string(key))
 	if _, err = sshClient.Output(cmd); err != nil {
 		return err
 	}

--- a/drivers/centurylinkcloud/create.go
+++ b/drivers/centurylinkcloud/create.go
@@ -91,8 +91,9 @@ func (d *Driver) Create() error {
 func (d *Driver) createServer(c *clcgo.Client) (clcgo.Server, error) {
 	log.Infof("Creating server...")
 
-	name := d.MachineName[:6]
-	if name != d.MachineName {
+	name := d.MachineName
+	if len(name) > 6 {
+		name = name[:6]
 		log.Warnf(
 			"%s. Your server name has been truncated to: %s",
 			serverRequirementsWarning, name,

--- a/drivers/centurylinkcloud/create_test.go
+++ b/drivers/centurylinkcloud/create_test.go
@@ -1,0 +1,1 @@
+package centurylinkcloud

--- a/script/run-integration-tests
+++ b/script/run-integration-tests
@@ -1,3 +1,0 @@
-#!/bin/sh
-godep go test -v ./_integration-test
-


### PR DESCRIPTION
This adds the code and documentation for a CenturyLink Cloud driver. It's failing consistently on two integration tests, but it's a pair of tests that are also failing for me using the DigitalOcean driver (they're both around what the CLI displays once a server is stopped). Are there some known failures in master right now?

I have the latest version of `godep` installed, and doing a `godep save` to add my single new dependency is causing an enormous number of unrelated dependencies to be removed from the manifest (mostly docker libraries!). Is there a special syntax to use for adding dependencies? I manually tweaked the manifest in my vendoring commit.

I couldn't help but notice that none of the drivers are implementing anything in `Authorize`/`DeauthorizePort`. I know my API is capable of adding and removing ports from a public IP address, but I just did a dummy implementation of that since it doesn't appear to be used anywhere in the code.

Last but not least, while I was in there I noticed an old integration test script that doesn't seem to be referenced anymore. I tacked that onto this PR, but I can knock that commit off if I'm missing something.