### PR TITLE
Fix usage of flag parsing terminator

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -403,6 +403,10 @@ func cmdEnv(c *cli.Context) {
 }
 
 func cmdSsh(c *cli.Context) {
+	var (
+		err    error
+		sshCmd *exec.Cmd
+	)
 	name := c.Args().First()
 	store := NewStore(c.GlobalString("storage-path"), c.GlobalString("tls-ca-cert"), c.GlobalString("tls-ca-key"))
 
@@ -415,28 +419,15 @@ func cmdSsh(c *cli.Context) {
 		name = host.Name
 	}
 
-	var cmd string
-
-	var args []string = c.Args()
-
-	for i, arg := range args {
-		if arg == "--" {
-			i++
-			cmd = strings.Join(args[i:], " ")
-			break
-		}
-	}
-
 	host, err := store.Load(name)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var sshCmd *exec.Cmd
-	if len(cmd) == 0 {
+	if len(c.Args()) <= 1 {
 		sshCmd, err = host.Driver.GetSSHCommand()
 	} else {
-		sshCmd, err = host.Driver.GetSSHCommand(cmd)
+		sshCmd, err = host.Driver.GetSSHCommand(c.Args()[1:]...)
 	}
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
There is no need to check for `--` manually.  cli will do this for us.

Try it out:

```console
$ ./docker-machine_darwin-amd64 ssh dev
                        ##        .
                  ## ## ##       ==
               ## ## ## ##      ===
           /""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~
           \______ o          __/
             \    \        __/
              \____\______/
 _                 _   ____     _            _
| |__   ___   ___ | |_|___ \ __| | ___   ___| | _____ _ __
| '_ \ / _ \ / _ \| __| __) / _` |/ _ \ / __| |/ / _ \ '__|
| |_) | (_) | (_) | |_ / __/ (_| | (_) | (__|   <  __/ |
|_.__/ \___/ \___/ \__|_____\__,_|\___/ \___|_|\_\___|_|
Boot2Docker version 1.4.1, build master : 86f7ec8 - Tue Dec 16 23:21:51 UTC 2014
Docker version 1.4.1, build 136b351
docker@dev:~$ exit

$ ./docker-machine_darwin-amd64 ssh dev df
Filesystem           1K-blocks      Used Available Use% Mounted on
rootfs                  921204    210120    711084  23% /
tmpfs                   921204    210120    711084  23% /
tmpfs                   511776         0    511776   0% /dev/shm
/dev/sda1             19049892     59696  17999472   0% /mnt/sda1
cgroup                  511776         0    511776   0% /sys/fs/cgroup
none                 244277768 110600712 133677056  45% /Users
/dev/sda1             19049892     59696  17999472   0% /mnt/sda1/var/lib/docker/aufs

$ ./docker-machine_darwin-amd64 ssh dev -- df -h
Filesystem                Size      Used Available Use% Mounted on
rootfs                  899.6M    205.2M    694.4M  23% /
tmpfs                   899.6M    205.2M    694.4M  23% /
tmpfs                   499.8M         0    499.8M   0% /dev/shm
/dev/sda1                18.2G     58.3M     17.2G   0% /mnt/sda1
cgroup                  499.8M         0    499.8M   0% /sys/fs/cgroup
none                    233.0G    105.5G    127.5G  45% /Users
/dev/sda1                18.2G     58.3M     17.2G   0% /mnt/sda1/var/lib/docker/aufs
```

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>