### PR TITLE
Make config and env return empty URL instead of error

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -279,7 +279,7 @@ func cmdConfig(c *cli.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H %s",
+	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H=%q",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, cfg.machineUrl)
 }
 
@@ -554,7 +554,11 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 	clientKey := filepath.Join(utils.GetMachineClientCertDir(), "key.pem")
 	machineUrl, err := machine.GetURL()
 	if err != nil {
-		return nil, fmt.Errorf("Error getting machine url: %s", err)
+		if err == drivers.ErrHostIsNotRunning {
+			machineUrl = ""
+		} else {
+			return nil, fmt.Errorf("Unexpected error getting machine url: %s", err)
+		}
 	}
 	return &machineConfig{
 		caCertPath:     caCert,


### PR DESCRIPTION
This will return an empty URL and consequently the Docker client will
fail to connect instead of spitting out an illegible error with the
subshell method.  Hopefully this will tip users off to the underlying
source of the problem.

Ex:

```console
$ ./docker-machine_darwin-amd64 ls
NAME   ACTIVE   DRIVER       STATE     URL
dev    *        virtualbox   Running   tcp://192.168.99.101:2376

$ ./docker-machine_darwin-amd64 stop dev

$ $(./docker-machine_darwin-amd64 env dev)

$ docker version
Client version: 1.4.1
Client API version: 1.16
Go version (client): go1.3.3
Git commit (client): 5bc2ff8
OS/Arch (client): darwin/amd64
FATA[0000] An error occurred trying to connect: Get https:///var/run/docker.sock/v1.16/version: dial unix /var/run/docker.sock: no such file or directory
```
Refs https://github.com/docker/machine/issues/452

cc @sthulb @ehazlett 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>