### PR TITLE
set hostname after ssh is active

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -307,6 +307,10 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+	if err := d.Start(); err != nil {
+		return err
+	}
+
 	log.Debugf("Setting hostname: %s", d.MachineName)
 	cmd, err := d.GetSSHCommand(fmt.Sprintf(
 		"echo \"127.0.0.1 %s\" | sudo tee -a /etc/hosts && sudo hostname %s && echo \"%s\" | sudo tee /etc/hostname",
@@ -318,10 +322,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	if err := d.Start(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This refs https://github.com/docker/machine/commit/861b16dba9020ae6cb3c62e699683db9554300cc#commitcomment-9579065   Don't set the hostname before the instance is active.