### PR TITLE
fixes error when running config against no active host

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -540,14 +540,20 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 		if err != nil {
 			log.Fatalf("error getting active host: %v", err)
 		}
+		if m == nil {
+			return nil, fmt.Errorf("There is no active host")
+		}
 		machine = m
 	} else {
 		m, err := store.Load(name)
+		fmt.Println(err)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading machine config: %s", err)
 		}
 		machine = m
 	}
+
+	fmt.Println(machine)
 
 	caCert := filepath.Join(utils.GetMachineClientCertDir(), "ca.pem")
 	clientCert := filepath.Join(utils.GetMachineClientCertDir(), "cert.pem")


### PR DESCRIPTION
This returns an error when running `config` with no active host.

Fixes #486 
