### PR TITLE
fix bug with attempting to restart vbox instance that is not running

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -379,8 +379,15 @@ func (d *Driver) Remove() error {
 }
 
 func (d *Driver) Restart() error {
-	if err := d.Stop(); err != nil {
+	s, err := d.GetState()
+	if err != nil {
 		return err
+	}
+
+	if s == state.Running {
+		if err := d.Stop(); err != nil {
+			return err
+		}
 	}
 	return d.Start()
 }


### PR DESCRIPTION
This fixes a bug where VBoxManage returns an error when trying to stop an already stopped instance.

Fixes #502 