### PR TITLE
Fix build on master

### DIFF
--- a/drivers/hyperv/hyperv_test.go
+++ b/drivers/hyperv/hyperv_test.go
@@ -1,0 +1,1 @@
+package hyperv


### PR DESCRIPTION
`script/generate-coverage` expects at least one test file for each directory.