### PR TITLE
Custom VMware ISO for B2D 1.5.0

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -160,7 +160,7 @@ func (d *Driver) Create() error {
 		//	log.Warnf("Unable to check for the latest release: %s", err)
 		//}
 
-		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.4.1-vmw/boot2docker-1.4.1-vmw.iso"
+		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.5.0-vmw/boot2docker-1.5.0-vmw.iso"
 
 		rootPath := filepath.Join(utils.GetDockerDir())
 		imgPath := filepath.Join(rootPath, "images")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -255,7 +255,7 @@ func (d *Driver) Create() error {
 
 		//}
 
-		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.4.1-vmw/boot2docker-1.4.1-vmw.iso"
+		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.5.0-vmw/boot2docker-1.5.0-vmw.iso"
 
 		rootPath := filepath.Join(utils.GetDockerDir())
 		imgPath := filepath.Join(rootPath, "images")


### PR DESCRIPTION
This fixes #547 for `vmwarefusion` and `vmwarevsphere`.

Good news is that for 1.6.0 we will most likely have a single b2d release with full VMware Tools support (including shared folders).