### PR TITLE
fixes #564 by surfacing govc errors to end user

### DIFF
--- a/drivers/vmwarevsphere/govc.go
+++ b/drivers/vmwarevsphere/govc.go
@@ -19,7 +19,7 @@ var (
 func govc(args ...string) error {
 	cmd := exec.Command(GovcCmd, args...)
 
-	log.Debugf("executing: %v %v", GovcCmd, strings.Join(args, " "))
+	log.Debugf("govc executing: %v %v", GovcCmd, strings.Join(args, " "))
 
 	if err := cmd.Run(); err != nil {
 		return err
@@ -30,7 +30,7 @@ func govc(args ...string) error {
 func govcOutErr(args ...string) (string, string, error) {
 	cmd := exec.Command(GovcCmd, args...)
 
-	log.Debugf("executing: %v %v", GovcCmd, strings.Join(args, " "))
+	log.Debugf("govcOutErr executing: %v %v", GovcCmd, strings.Join(args, " "))
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/drivers/vmwarevsphere/vc_conn.go
+++ b/drivers/vmwarevsphere/vc_conn.go
@@ -49,11 +49,16 @@ func (conn VcConn) DatastoreMkdir(dirName string) error {
 	args = append(args, fmt.Sprintf("--dc=%s", conn.driver.Datacenter))
 	args = append(args, dirName)
 	_, stderr, err := govcOutErr(args...)
-	if stderr == "" && err == nil {
-		return nil
-	} else {
+
+	if stderr != "" {
 		return errors.NewDatastoreError(conn.driver.Datastore, "mkdir", stderr)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (conn VcConn) DatastoreUpload(localPath string) error {


### PR DESCRIPTION
This change makes it more apparently which command function is being called and makes sure that the error generated by  exec.Command get returned up the stack instead of being squashed.