### PR TITLE
Add the docs.docker.com build tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,19 @@ validate: validate-dco validate-gofmt
 
 build:
 	script/build
+
+# import the existing docs build cmds from docker/docker
+DOCS_MOUNT := $(if $(DOCSDIR),-v $(CURDIR)/$(DOCSDIR):/$(DOCSDIR))
+DOCSPORT := 8000
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+DOCKER_DOCS_IMAGE := dhe-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE
+
+docs: docs-build
+	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 "$(DOCKER_DOCS_IMAGE)" mkdocs serve
+
+docs-shell: docs-build
+	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 "$(DOCKER_DOCS_IMAGE)" bash
+
+docs-build:
+	docker build -t "$(DOCKER_DOCS_IMAGE)" -f docs/Dockerfile .

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,15 @@
+FROM docs/base:latest
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
+
+# to get the git info for this repo
+COPY . /src
+
+# Reset the /docs dir so we can replace the theme meta with the new repo's git info
+RUN git reset --hard
+
+RUN grep VERSION /src/version.go  | sed 's/.*"\(.*\)".*/\1/' > /docs/VERSION
+COPY docs/* /docs/sources/machine/
+COPY docs/mkdocs.yml /docs/mkdocs-machine.yml
+
+# Then build everything together, ready for mkdocs
+RUN /docs/build.sh

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,2 @@
+
+- ['machine/dockermachine.md', 'User Guide', 'Docker Machine' ]


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

so we can run `make docs` and browse to http://docker-host:8000 and see the machine docs.

the mkdocs.yml will also be used to import these docs into the docs.docker.com docs-releases.