### PR TITLE
Add docker-machine env unset

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -232,6 +232,10 @@ var Commands = []cli.Command{
 				Name:  "swarm",
 				Usage: "Display the Swarm config instead of the Docker daemon",
 			},
+			cli.BoolFlag{
+				Name:  "unset, u",
+				Usage: "Unset variables instead of setting them",
+			},
 		},
 	},
 	{
@@ -478,6 +482,17 @@ func cmdRm(c *cli.Context) {
 }
 
 func cmdEnv(c *cli.Context) {
+	userShell := filepath.Base(os.Getenv("SHELL"))
+	if c.Bool("unset") {
+		switch userShell {
+		case "fish":
+			fmt.Printf("set -e DOCKER_TLS_VERIFY\nset -e DOCKER_CERT_PATH\nset -e DOCKER_HOST")
+		default:
+			fmt.Println("unset DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_HOST")
+		}
+		return
+	}
+
 	cfg, err := getMachineConfig(c)
 	if err != nil {
 		log.Fatal(err)
@@ -506,7 +521,7 @@ func cmdEnv(c *cli.Context) {
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
 
-	switch filepath.Base(os.Getenv("SHELL")) {
+	switch userShell {
 	case "fish":
 		fmt.Printf("set -x DOCKER_TLS_VERIFY yes\nset -x DOCKER_CERT_PATH %s\nset -x DOCKER_HOST %s\n",
 			utils.GetMachineClientCertDir(), dockerHost)

--- a/docs/index.md
+++ b/docs/index.md
@@ -375,6 +375,28 @@ $ docker-machine config dev
 --tls --tlscacert=/Users/ehazlett/.docker/machines/dev/ca.pem --tlscert=/Users/ehazlett/.docker/machines/dev/cert.pem --tlskey=/Users/ehazlett/.docker/machines/dev/key.pem -H tcp://192.168.99.103:2376
 ```
 
+#### env
+
+Set environment variables to dictate that `docker` should run a command against
+a particular machine.
+
+`docker-machine env machinename` will print out `export` commands which can be
+run in a subshell.  Running `docker-machine env -u` will print
+`unset` commands which reverse this effect.
+
+```
+$ env | grep DOCKER
+$ $(docker-machine env dev)
+$ env | grep DOCKER
+DOCKER_HOST=tcp://192.168.99.101:2376
+DOCKER_CERT_PATH=/Users/nathanleclaire/.docker/machines/.client
+DOCKER_TLS_VERIFY=yes
+$ # If you run a docker command, now it will run against that host.
+$ $(docker-machine env -u)
+$ env | grep DOCKER
+$ # The environment variables have been unset.
+```
+
 #### inspect
 
 Inspect information about a machine.


### PR DESCRIPTION
User was confused about how to unset env variables previously set with `$(docker-machine env blah)`, so I figured there might as well be an automated way to unset them as well.

Also added docs for `env` since there were none.

Will this need to be something different for fish @ehazlett ?

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>