### PR TITLE
do not show debug for docker install by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,6 @@ Options:
    there is no IP address already allocated a new IP will be allocated and assigned to the machine.
  - `--openstack-ssh-user`: The username to use for SSH into the machine. If not provided `root` will be used.
  - `--openstack-ssh-port`: Customize the SSH port if the SSH server on the machine does not listen on the default port.
- - `--openstack-docker-install`: Boolean flag to indicate if docker has to be installed on the machine. Useful when
-   docker is already installed and configured in the OpenStack image. Default set to `true`
 
 Environment variables:
 
@@ -336,7 +334,6 @@ Options:
   - `--softlayer-hostname`: hostname for the machine
   - `--softlayer-hourly-billing`: Sets the hourly billing flag (default), otherwise uses monthly billing
   - `--softlayer-image`: OS Image to use
-  - `--softlayer-install-script`: custom install script to use for installing Docker, other setup actions
   - `--softlayer-local-disk`: Use local machine disk instead of softlayer SAN.
   - `--softlayer-memory`: Memory for host in MB
   - `--softlayer-private-net-only`: Disable public networking

--- a/docs/index.md
+++ b/docs/index.md
@@ -659,7 +659,6 @@ Options:
   - `--softlayer-hostname`: hostname for the machine
   - `--softlayer-hourly-billing`: Sets the hourly billing flag (default), otherwise uses monthly billing
   - `--softlayer-image`: OS Image to use
-  - `--softlayer-install-script`: custom install script to use for installing Docker, other setup actions
   - `--softlayer-local-disk`: Use local machine disk instead of softlayer SAN.
   - `--softlayer-memory`: Memory for host in MB
   - `--softlayer-private-net-only`: Disable public networking
@@ -716,8 +715,6 @@ Options:
    there is no IP address already allocated a new IP will be allocated and assigned to the machine.
  - `--openstack-ssh-user`: The username to use for SSH into the machine. If not provided `root` will be used.
  - `--openstack-ssh-port`: Customize the SSH port if the SSH server on the machine does not listen on the default port.
- - `--openstack-docker-install`: Boolean flag to indicate if docker have to be installed on the machine. Useful when
-   docker is already installed and configured in the OpenStack image. Default set to `true`
 
 Environment variables:
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -308,18 +308,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Debugf("Installing Docker")
-
-	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
-	if err != nil {
-		return err
-
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-
-	}
-
 	return nil
 }
 

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -226,14 +226,6 @@ func (driver *Driver) Create() error {
 		return err
 	}
 
-	cmd, err := driver.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -178,18 +178,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Debugf("Installing Docker")
-
-	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sh -; fi")
-	if err != nil {
-		return err
-
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-
-	}
-
 	return nil
 }
 
@@ -335,7 +323,8 @@ func (d *Driver) Upgrade() error {
 }
 
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
-	return ssh.GetSSHCommand(d.IPAddress, 22, "root", d.sshKeyPath(), args...), nil
+	cmd := ssh.GetSSHCommand(d.IPAddress, 22, "root", d.sshKeyPath(), args...)
+	return cmd, nil
 }
 
 func (d *Driver) getClient() *godo.Client {

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -237,18 +237,6 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		return err
 	}
 
-	log.Debugf("Installing Docker")
-
-	cmd, err = d.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sL https://get.docker.com | sudo sh -; fi")
-	if err != nil {
-		return err
-
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-
-	}
-
 	return nil
 }
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,36 +21,35 @@ const (
 )
 
 type Driver struct {
-	AuthUrl             string
-	Username            string
-	Password            string
-	TenantName          string
-	TenantId            string
-	Region              string
-	EndpointType        string
-	MachineName         string
-	MachineId           string
-	FlavorName          string
-	FlavorId            string
-	ImageName           string
-	ImageId             string
-	KeyPairName         string
-	NetworkName         string
-	NetworkId           string
-	SecurityGroups      []string
-	FloatingIpPool      string
-	FloatingIpPoolId    string
-	SSHUser             string
-	SSHPort             int
-	Ip                  string
-	EnableDockerInstall bool
-	CaCertPath          string
-	PrivateKeyPath      string
-	storePath           string
-	SwarmMaster         bool
-	SwarmHost           string
-	SwarmDiscovery      string
-	client              Client
+	AuthUrl          string
+	Username         string
+	Password         string
+	TenantName       string
+	TenantId         string
+	Region           string
+	EndpointType     string
+	MachineName      string
+	MachineId        string
+	FlavorName       string
+	FlavorId         string
+	ImageName        string
+	ImageId          string
+	KeyPairName      string
+	NetworkName      string
+	NetworkId        string
+	SecurityGroups   []string
+	FloatingIpPool   string
+	FloatingIpPoolId string
+	SSHUser          string
+	SSHPort          int
+	Ip               string
+	CaCertPath       string
+	PrivateKeyPath   string
+	storePath        string
+	SwarmMaster      bool
+	SwarmHost        string
+	SwarmDiscovery   string
+	client           Client
 }
 
 type CreateFlags struct {
@@ -175,13 +173,6 @@ func GetCreateFlags() []cli.Flag {
 			Usage: "OpenStack SSH port",
 			Value: 22,
 		},
-		// Using a StringFlag rather than a BoolFlag because
-		// the BoolFlag default value is always false
-		cli.StringFlag{
-			Name:  "openstack-docker-install",
-			Usage: "Openstack should install docker on the machine",
-			Value: "true",
-		},
 	}
 }
 
@@ -234,11 +225,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")
 
-	installDocker, err := strconv.ParseBool(flags.String("openstack-docker-install"))
-	if err != nil {
-		return err
-	}
-	d.EnableDockerInstall = installDocker
 	return d.checkConfig()
 }
 
@@ -347,11 +333,6 @@ func (d *Driver) Create() error {
 	}
 	if err := d.waitForSSHServer(); err != nil {
 		return err
-	}
-	if d.EnableDockerInstall {
-		if err := d.installDocker(); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -755,29 +736,6 @@ func (d *Driver) waitForInstanceToStart() error {
 		return err
 	}
 	return d.waitForSSHServer()
-}
-
-func (d *Driver) installDocker() error {
-	log.WithField("MachineId", d.MachineId).Debug("Installing docker daemon on the machine")
-
-	if err := d.sshExec([]string{
-		`apt-get install -y curl`,
-		`curl -sSL https://get.docker.com | sh`,
-	}); err != nil {
-		log.Error("The docker installation failed.")
-		log.Error(
-			"The driver assumes that your instance is running Ubuntu. If this is not the case, you should ",
-			"use the option --openstack-docker-install=false (or --{provider}-docker-install=false) when ",
-			"creating a machine, and then install and configure docker manually.",
-		)
-		log.Error(
-			`Also, you can use "machine ssh" to manually configure docker on this host.`,
-		)
-
-		// Don't return this ssh error so that host creation succeeds and "machine ssh" and "machine rm"
-		// are usable.
-	}
-	return nil
 }
 
 func (d *Driver) sshExec(commands []string) error {

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -149,7 +149,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.FlavorId = flags.String("rackspace-flavor-id")
 	d.SSHUser = flags.String("rackspace-ssh-user")
 	d.SSHPort = flags.Int("rackspace-ssh-port")
-	d.EnableDockerInstall = flags.String("rackspace-docker-install") == "true"
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -17,9 +17,8 @@ import (
 )
 
 const (
-	dockerConfigDir  = "/etc/docker"
-	ApiEndpoint      = "https://api.softlayer.com/rest/v3"
-	DockerInstallUrl = "https://get.docker.com"
+	dockerConfigDir = "/etc/docker"
+	ApiEndpoint     = "https://api.softlayer.com/rest/v3"
 )
 
 type Driver struct {
@@ -45,7 +44,6 @@ type deviceConfig struct {
 	Memory        int
 	Image         string
 	HourlyBilling bool
-	InstallScript string
 	LocalDisk     bool
 	PrivateNet    bool
 }
@@ -142,12 +140,6 @@ func GetCreateFlags() []cli.Flag {
 			Usage:  "OS image for machine",
 			Value:  "UBUNTU_LATEST",
 		},
-		cli.StringFlag{
-			EnvVar: "SOFTLAYER_INSTALL_SCRIPT",
-			Name:   "softlayer-install-script",
-			Usage:  "Install script to call after the machine is initialized (should install Docker)",
-			Value:  DockerInstallUrl,
-		},
 	}
 }
 
@@ -210,7 +202,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		PrivateNet:    flags.Bool("softlayer-private-net-only"),
 		LocalDisk:     flags.Bool("softlayer-local-disk"),
 		HourlyBilling: flags.Bool("softlayer-hourly-billing"),
-		InstallScript: flags.String("softlayer-install-script"),
 		Image:         "UBUNTU_LATEST",
 		Region:        flags.String("softlayer-region"),
 	}
@@ -372,7 +363,6 @@ func (d *Driver) buildHostSpec() *HostSpec {
 		Cpu:            d.deviceConfig.Cpu,
 		Memory:         d.deviceConfig.Memory,
 		Datacenter:     Datacenter{Name: d.deviceConfig.Region},
-		InstallScript:  d.deviceConfig.InstallScript,
 		Os:             d.deviceConfig.Image,
 		HourlyBilling:  d.deviceConfig.HourlyBilling,
 		PrivateNetOnly: d.deviceConfig.PrivateNet,

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -423,22 +423,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if d.Provision {
-		dockerInstall := "curl -sSL https://get.docker.com | sudo sh"
-
-		log.Infof("Installing Docker...")
-
-		cmd, err = d.GetSSHCommand(dockerInstall)
-		if err != nil {
-			return err
-		}
-
-		if err = cmd.Run(); err != nil {
-			return err
-		}
-
-	}
-
 	log.Debugf("Disconnecting from vCloud Air...")
 
 	if err = p.Disconnect(); err != nil {


### PR DESCRIPTION
This hides the debug output from the Docker install for drivers.  It also refactors the install process out of the driver.

fixes #587
