### PR TITLE
do not error with no active host for ls

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -395,21 +395,12 @@ func cmdLs(c *cli.Context) {
 
 	for _, host := range hostList {
 		if !quiet {
-			tmpHost, err := store.GetActive()
-			if err != nil {
-				log.Errorf("There's a problem with the active host: %s", err)
-			}
-
 			if host.SwarmMaster {
 				swarmMasters[host.SwarmDiscovery] = host.Name
 			}
 
 			if host.SwarmDiscovery != "" {
 				swarmInfo[host.Name] = host.SwarmDiscovery
-			}
-
-			if tmpHost == nil {
-				log.Errorf("There's a problem finding the active host")
 			}
 
 			go getHostState(host, *store, hostListItems)


### PR DESCRIPTION
This will not report an error when there is no active host for the `ls` command.

fixes #582 