### PR TITLE
Move images dir to stop polluting the docker path

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -144,11 +144,11 @@ func (d *Driver) Create() error {
 		isoURL, err = b2dutils.GetLatestBoot2DockerReleaseURL()
 		if err != nil {
 			log.Warnf("Unable to check for the latest release: %s", err)
-
 		}
+
 		// todo: use real constant for .docker
-		rootPath := filepath.Join(utils.GetDockerDir())
-		imgPath := filepath.Join(rootPath, "images")
+		rootPath := filepath.Join(utils.GetMachineDir())
+		imgPath := filepath.Join(rootPath, ".images")
 		commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
@@ -156,22 +156,18 @@ func (d *Driver) Create() error {
 			if _, err := os.Stat(imgPath); os.IsNotExist(err) {
 				if err := os.Mkdir(imgPath, 0700); err != nil {
 					return err
-
 				}
 
 			}
 			if err := b2dutils.DownloadISO(imgPath, "boot2docker.iso", isoURL); err != nil {
 				return err
-
 			}
-
 		}
+
 		isoDest := filepath.Join(d.storePath, "boot2docker.iso")
 		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
 			return err
-
 		}
-
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -168,8 +168,8 @@ func (d *Driver) Create() error {
 
 		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.5.0-vmw/boot2docker-1.5.0-vmw.iso"
 
-		rootPath := filepath.Join(utils.GetDockerDir())
-		imgPath := filepath.Join(rootPath, "images")
+		rootPath := filepath.Join(utils.GetMachineDir())
+		imgPath := filepath.Join(rootPath, ".images")
 		commonIsoPath := filepath.Join(imgPath, isoFilename)
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -263,8 +263,8 @@ func (d *Driver) Create() error {
 
 		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.5.0-vmw/boot2docker-1.5.0-vmw.iso"
 
-		rootPath := filepath.Join(utils.GetDockerDir())
-		imgPath := filepath.Join(rootPath, "images")
+		rootPath := filepath.Join(utils.GetMachineDir())
+		imgPath := filepath.Join(rootPath, ".images")
 		commonIsoPath := filepath.Join(imgPath, B2D_ISO_NAME)
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)


### PR DESCRIPTION
Moves images path to be inside the machine dir.

Fixes #580

cc: @ehazlett @bfirsh 