### PR TITLE
add swarm label of provider by default

### DIFF
--- a/host.go
+++ b/host.go
@@ -327,10 +327,12 @@ func (h *Host) generateDockerConfig(dockerPort int, caCertPath string, serverKey
 
 	swarmLabels = append(swarmLabels, fmt.Sprintf("--label=provider=%s", h.Driver.DriverName()))
 
-	defaultDaemonOpts := fmt.Sprintf(`--tlsverify \
---tlscacert=%s \
---tlskey=%s \
---tlscert=%s %s`, caCertPath, serverKeyPath, serverCertPath, strings.Join(swarmLabels, " "))
+	defaultDaemonOpts := fmt.Sprintf(`--tlsverify --tlscacert=%s --tlskey=%s --tlscert=%s %s`,
+		caCertPath,
+		serverKeyPath,
+		serverCertPath,
+		strings.Join(swarmLabels, " "),
+	)
 
 	switch d.DriverName() {
 	case "virtualbox", "vmwarefusion", "vmwarevsphere", "hyper-v":

--- a/host.go
+++ b/host.go
@@ -322,16 +322,19 @@ func (h *Host) generateDockerConfig(dockerPort int, caCertPath string, serverKey
 		daemonOpts    string
 		daemonOptsCfg string
 		daemonCfg     string
+		swarmLabels   = []string{}
 	)
 
-	// TODO @ehazlett: template?
+	if h.SwarmHost != "" {
+		swarmLabels = append(swarmLabels, fmt.Sprintf("--label=provider=%s", h.Driver.DriverName()))
+	}
+
 	defaultDaemonOpts := fmt.Sprintf(`--tlsverify \
 --tlscacert=%s \
 --tlskey=%s \
---tlscert=%s`, caCertPath, serverKeyPath, serverCertPath)
+--tlscert=%s %s`, caCertPath, serverKeyPath, serverCertPath, strings.Join(swarmLabels, " "))
 
 	switch d.DriverName() {
-
 	case "virtualbox", "vmwarefusion", "vmwarevsphere", "hyper-v":
 		daemonOpts = fmt.Sprintf("-H tcp://0.0.0.0:%d", dockerPort)
 		daemonOptsCfg = path.Join(d.GetDockerConfigDir(), "profile")

--- a/host.go
+++ b/host.go
@@ -325,9 +325,7 @@ func (h *Host) generateDockerConfig(dockerPort int, caCertPath string, serverKey
 		swarmLabels   = []string{}
 	)
 
-	if h.SwarmHost != "" {
-		swarmLabels = append(swarmLabels, fmt.Sprintf("--label=provider=%s", h.Driver.DriverName()))
-	}
+	swarmLabels = append(swarmLabels, fmt.Sprintf("--label=provider=%s", h.Driver.DriverName()))
 
 	defaultDaemonOpts := fmt.Sprintf(`--tlsverify \
 --tlscacert=%s \


### PR DESCRIPTION
This will add a default label of `provider=<provider>` when using Swarm.

This enables things like `docker run -e constraint:provider==digitalocean ...`