### PR TITLE
allow retries for GetIP when issuing cert

### DIFF
--- a/host.go
+++ b/host.go
@@ -206,9 +206,26 @@ func (h *Host) ConfigureAuth() error {
 		return nil
 	}
 
-	ip, err := h.Driver.GetIP()
-	if err != nil {
-		return err
+	var (
+		ip         = ""
+		ipErr      error
+		maxRetries = 4
+	)
+
+	for i := 0; i < maxRetries; i++ {
+		ip, ipErr = h.Driver.GetIP()
+		if ip != "" {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
+	if ipErr != nil {
+		return ipErr
+	}
+
+	if ip == "" {
+		return fmt.Errorf("unable to get machine IP")
 	}
 
 	serverCertPath := filepath.Join(h.storePath, "server.pem")

--- a/host.go
+++ b/host.go
@@ -217,6 +217,7 @@ func (h *Host) ConfigureAuth() error {
 		if ip != "" {
 			break
 		}
+		log.Debug("waiting for ip")
 		time.Sleep(5 * time.Second)
 	}
 

--- a/host.go
+++ b/host.go
@@ -217,7 +217,7 @@ func (h *Host) ConfigureAuth() error {
 		if ip != "" {
 			break
 		}
-		log.Debug("waiting for ip")
+		log.Debugf("waiting for ip: %s", ipErr)
 		time.Sleep(5 * time.Second)
 	}
 


### PR DESCRIPTION
This will help in the case that a driver does not have an IP yet.  Ideally the driver should not continue the `Create` until it does, but in some cases this call can fail.

Fixes #600 