### PR TITLE
Make multiple machine name arguments work for kill, restart, rm, start, stop, and upgrade

### DIFF
--- a/host_test.go
+++ b/host_test.go
@@ -28,7 +28,6 @@ func getTestStore() (*Store, error) {
 		os.Exit(1)
 	}
 
-	os.Setenv("MACHINE_DIR", tmpDir)
 	return NewStore(tmpDir, hostTestCaCert, hostTestPrivateKey), nil
 }
 

--- a/store_test.go
+++ b/store_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/docker/machine/utils"
 )
 
+const (
+	TestStoreDir = ".store-test"
+)
+
+func init() {
+
+	os.Setenv("MACHINE_STORAGE_PATH", TestStoreDir)
+}
+
 type DriverOptionsMock struct {
 	Data map[string]interface{}
 }
@@ -26,7 +35,7 @@ func (d DriverOptionsMock) Bool(key string) bool {
 }
 
 func clearHosts() error {
-	return os.RemoveAll(utils.GetMachineDir())
+	return os.RemoveAll(TestStoreDir)
 }
 
 func getDefaultTestDriverFlags() *DriverOptionsMock {

--- a/store_test.go
+++ b/store_test.go
@@ -6,17 +6,11 @@ import (
 	"testing"
 
 	_ "github.com/docker/machine/drivers/none"
-	"github.com/docker/machine/utils"
 )
 
 const (
 	TestStoreDir = ".store-test"
 )
-
-func init() {
-
-	os.Setenv("MACHINE_STORAGE_PATH", TestStoreDir)
-}
 
 type DriverOptionsMock struct {
 	Data map[string]interface{}
@@ -58,7 +52,7 @@ func TestStoreCreate(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 
 	host, err := store.Create("test", "none", flags)
 	if err != nil {
@@ -67,7 +61,7 @@ func TestStoreCreate(t *testing.T) {
 	if host.Name != "test" {
 		t.Fatal("Host name is incorrect")
 	}
-	path := filepath.Join(utils.GetMachineDir(), "test")
+	path := filepath.Join(TestStoreDir, "test")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Fatalf("Host path doesn't exist: %s", path)
 	}
@@ -80,12 +74,12 @@ func TestStoreRemove(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(utils.GetMachineDir(), "test")
+	path := filepath.Join(TestStoreDir, "test")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Fatalf("Host path doesn't exist: %s", path)
 	}
@@ -105,7 +99,7 @@ func TestStoreList(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
@@ -126,7 +120,7 @@ func TestStoreExists(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 	exists, err := store.Exists("test")
 	if exists {
 		t.Fatal("Exists returned true when it should have been false")
@@ -153,13 +147,13 @@ func TestStoreLoad(t *testing.T) {
 	flags := getDefaultTestDriverFlags()
 	flags.Data["url"] = expectedURL
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	store = NewStore("", "", "")
+	store = NewStore(TestStoreDir, "", "")
 	host, err := store.Load("test")
 	if host.Name != "test" {
 		t.Fatal("Host name is incorrect")
@@ -180,7 +174,7 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore("", "", "")
+	store := NewStore(TestStoreDir, "", "")
 
 	// No hosts set
 	host, err := store.GetActive()


### PR DESCRIPTION
Thanks to @ehazlett for the start of this one.

cc @bfirsh @sthulb PTAL

Fixes #563