### PR TITLE
Make swarm env the default on swarm master.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -236,8 +236,8 @@ var Commands = []cli.Command{
 		Action:      cmdEnv,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "swarm",
-				Usage: "Display the Swarm config instead of the Docker daemon",
+				Name:  "engine",
+				Usage: "Display Docker daemon config instead of Swarm config on Swarm master",
 			},
 			cli.BoolFlag{
 				Name:  "unset, u",
@@ -502,10 +502,7 @@ func cmdEnv(c *cli.Context) {
 	}
 
 	dockerHost := cfg.machineUrl
-	if c.Bool("swarm") {
-		if !cfg.swarmMaster {
-			log.Fatalf("%s is not a swarm master", cfg.machineName)
-		}
+	if cfg.swarmMaster && !c.Bool("engine") {
 		u, err := url.Parse(cfg.swarmHost)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
On a machine that is the swarm master, a user is likely to intend to connect to the Swarm manage process. They might accidentally omit `--swarm` and get the docker daemon instead, which can be very confusing if you're new to swarm. The `--engine` flag provides the old functionality if needed. That `engine` name was thrown out by @ehazlett yesterday on IRC when discussing this, but let me know if that flag name or description don't sound right.

I'm not bothering to throw any errors if somebody specifies `--engine` on a non-Swarm master since the result is the same.