### PR TITLE
refactor directories to machines, certs, cache

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -149,10 +149,20 @@ func (d *Driver) Create() error {
 
 	b2dutils := utils.NewB2dUtils("", "")
 
+	imgPath := utils.GetMachineCacheDir()
+	commonIsoPath := filepath.Join(imgPath, isoFilename)
+	// just in case boot2docker.iso has been manually deleted
+	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
+		if err := os.Mkdir(imgPath, 0700); err != nil {
+			return err
+		}
+
+	}
+
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(commonIsoPath, isoFilename, isoURL); err != nil {
 			return err
 		}
 
@@ -168,9 +178,6 @@ func (d *Driver) Create() error {
 
 		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.5.0-vmw/boot2docker-1.5.0-vmw.iso"
 
-		rootPath := filepath.Join(utils.GetMachineDir())
-		imgPath := filepath.Join(rootPath, ".images")
-		commonIsoPath := filepath.Join(imgPath, isoFilename)
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
 			// just in case boot2docker.iso has been manually deleted

--- a/host_test.go
+++ b/host_test.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
 	_ "github.com/docker/machine/drivers/none"
-	"github.com/docker/machine/utils"
 )
 
 const (
@@ -27,6 +25,7 @@ func getTestStore() (*Store, error) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	os.Setenv("MACHINE_STORAGE_PATH", tmpDir)
 
 	return NewStore(tmpDir, hostTestCaCert, hostTestPrivateKey), nil
 }
@@ -115,37 +114,6 @@ func TestValidateHostnameInvalid(t *testing.T) {
 		if err == nil {
 			t.Fatal("No error returned")
 		}
-	}
-}
-
-func TestGenerateClientCertificate(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "machine-test-")
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	os.Setenv("MACHINE_DIR", tmpDir)
-
-	caCertPath := filepath.Join(tmpDir, "ca.pem")
-	caKeyPath := filepath.Join(tmpDir, "key.pem")
-	testOrg := "test-org"
-	bits := 2048
-	if err := utils.GenerateCACertificate(caCertPath, caKeyPath, testOrg, bits); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := GenerateClientCertificate(caCertPath, caKeyPath); err != nil {
-		t.Fatal(err)
-	}
-
-	clientCertPath := filepath.Join(utils.GetMachineDir(), "cert.pem")
-	clientKeyPath := filepath.Join(utils.GetMachineDir(), "key.pem")
-	if _, err := os.Stat(clientCertPath); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(clientKeyPath); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -35,31 +35,32 @@ func main() {
 		cli.StringFlag{
 			EnvVar: "MACHINE_STORAGE_PATH",
 			Name:   "storage-path",
+			Value:  utils.GetMachineRoot(),
 			Usage:  "Configures storage path",
 		},
 		cli.StringFlag{
 			EnvVar: "MACHINE_TLS_CA_CERT",
 			Name:   "tls-ca-cert",
 			Usage:  "CA to verify remotes against",
-			Value:  filepath.Join(utils.GetMachineDir(), "ca.pem"),
+			Value:  filepath.Join(utils.GetMachineCertDir(), "ca.pem"),
 		},
 		cli.StringFlag{
 			EnvVar: "MACHINE_TLS_CA_KEY",
 			Name:   "tls-ca-key",
 			Usage:  "Private key to generate certificates",
-			Value:  filepath.Join(utils.GetMachineDir(), "key.pem"),
+			Value:  filepath.Join(utils.GetMachineCertDir(), "ca-key.pem"),
 		},
 		cli.StringFlag{
 			EnvVar: "MACHINE_TLS_CLIENT_CERT",
 			Name:   "tls-client-cert",
 			Usage:  "Client cert to use for TLS",
-			Value:  filepath.Join(utils.GetMachineClientCertDir(), "cert.pem"),
+			Value:  filepath.Join(utils.GetMachineCertDir(), "cert.pem"),
 		},
 		cli.StringFlag{
 			EnvVar: "MACHINE_TLS_CLIENT_KEY",
 			Name:   "tls-client-key",
 			Usage:  "Private key used in client TLS auth",
-			Value:  filepath.Join(utils.GetMachineClientCertDir(), "key.pem"),
+			Value:  filepath.Join(utils.GetMachineCertDir(), "key.pem"),
 		},
 	}
 

--- a/store_test.go
+++ b/store_test.go
@@ -12,6 +12,10 @@ const (
 	TestStoreDir = ".store-test"
 )
 
+var (
+	TestMachineDir = filepath.Join(TestStoreDir, "machine", "machines")
+)
+
 type DriverOptionsMock struct {
 	Data map[string]interface{}
 }
@@ -174,7 +178,11 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	flags := getDefaultTestDriverFlags()
 
-	store := NewStore(TestStoreDir, "", "")
+	//store := NewStore(TestStoreDir, "", "")
+	store, err := getTestStore()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// No hosts set
 	host, err := store.GetActive()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,23 +15,31 @@ func GetHomeDir() string {
 }
 
 func GetBaseDir() string {
-	baseDir := os.Getenv("MACHINE_DIR")
+	baseDir := os.Getenv("MACHINE_STORAGE_PATH")
 	if baseDir == "" {
-		baseDir = GetHomeDir()
+		baseDir = filepath.Join(GetHomeDir(), ".docker")
 	}
 	return baseDir
 }
 
 func GetDockerDir() string {
-	return filepath.Join(GetBaseDir(), ".docker")
+	return filepath.Join(GetHomeDir(), ".docker")
+}
+
+func GetMachineRoot() string {
+	return filepath.Join(GetBaseDir(), "machine")
 }
 
 func GetMachineDir() string {
-	return filepath.Join(GetDockerDir(), "machines")
+	return filepath.Join(GetMachineRoot(), "machines")
 }
 
-func GetMachineClientCertDir() string {
-	return filepath.Join(GetMachineDir(), ".client")
+func GetMachineCertDir() string {
+	return filepath.Join(GetMachineRoot(), "certs")
+}
+
+func GetMachineCacheDir() string {
+	return filepath.Join(GetMachineRoot(), "cache")
 }
 
 func GetUsername() string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,44 +15,34 @@ func TestGetBaseDir(t *testing.T) {
 	homeDir := GetHomeDir()
 	baseDir := GetBaseDir()
 
-	if strings.Index(homeDir, baseDir) != 0 {
+	if strings.Index(baseDir, homeDir) != 0 {
 		t.Fatalf("expected base dir with prefix %s; received %s", homeDir, baseDir)
 	}
 }
 
 func TestGetCustomBaseDir(t *testing.T) {
 	root := "/tmp"
-	os.Setenv("MACHINE_DIR", root)
+	os.Setenv("MACHINE_STORAGE_PATH", root)
 	baseDir := GetBaseDir()
 
-	if strings.Index(root, baseDir) != 0 {
+	if strings.Index(baseDir, root) != 0 {
 		t.Fatalf("expected base dir with prefix %s; received %s", root, baseDir)
 	}
-	os.Setenv("MACHINE_DIR", "")
+	os.Setenv("MACHINE_STORAGE_PATH", "")
 }
 
 func TestGetDockerDir(t *testing.T) {
-	root := "/tmp"
-	os.Setenv("MACHINE_DIR", root)
-	dockerDir := GetDockerDir()
+	homeDir := GetHomeDir()
+	baseDir := GetBaseDir()
 
-	if strings.Index(dockerDir, root) != 0 {
-		t.Fatalf("expected docker dir with prefix %s; received %s", root, dockerDir)
+	if strings.Index(baseDir, homeDir) != 0 {
+		t.Fatalf("expected base dir with prefix %s; received %s", homeDir, baseDir)
 	}
-
-	path, filename := path.Split(dockerDir)
-	if strings.Index(path, root) != 0 {
-		t.Fatalf("expected base path of %s; received %s", root, path)
-	}
-	if filename != ".docker" {
-		t.Fatalf("expected docker dir \".docker\"; received %s", filename)
-	}
-	os.Setenv("MACHINE_DIR", "")
 }
 
 func TestGetMachineDir(t *testing.T) {
 	root := "/tmp"
-	os.Setenv("MACHINE_DIR", root)
+	os.Setenv("MACHINE_STORAGE_PATH", root)
 	machineDir := GetMachineDir()
 
 	if strings.Index(machineDir, root) != 0 {
@@ -66,13 +56,13 @@ func TestGetMachineDir(t *testing.T) {
 	if filename != "machines" {
 		t.Fatalf("expected machine dir \"machines\"; received %s", filename)
 	}
-	os.Setenv("MACHINE_DIR", "")
+	os.Setenv("MACHINE_STORAGE_PATH", "")
 }
 
-func TestGetMachineClientCertDir(t *testing.T) {
+func TestGetMachineCertDir(t *testing.T) {
 	root := "/tmp"
-	os.Setenv("MACHINE_DIR", root)
-	clientDir := GetMachineClientCertDir()
+	os.Setenv("MACHINE_STORAGE_PATH", root)
+	clientDir := GetMachineCertDir()
 
 	if strings.Index(clientDir, root) != 0 {
 		t.Fatalf("expected machine client cert dir with prefix %s; received %s", root, clientDir)
@@ -82,10 +72,10 @@ func TestGetMachineClientCertDir(t *testing.T) {
 	if strings.Index(path, root) != 0 {
 		t.Fatalf("expected base path of %s; received %s", root, path)
 	}
-	if filename != ".client" {
-		t.Fatalf("expected machine client dir \".client\"; received %s", filename)
+	if filename != "certs" {
+		t.Fatalf("expected machine client dir \"certs\"; received %s", filename)
 	}
-	os.Setenv("MACHINE_DIR", "")
+	os.Setenv("MACHINE_STORAGE_PATH", "")
 }
 
 func TestCopyFile(t *testing.T) {


### PR DESCRIPTION
This refactors the directories in machine to be `machines` for all machines, `certs` for CA and client certs/keys, and `cache` for the image cache (b2d) to not pollute the root directory.  This will cause less technical debt for the future and eliminate the need for a migration path in the future.

I think it would be quite a bit of migration to regenerate certs for the old ones and make sure we don't overwrite any custom certs in the process, etc.  IMHO we should do this before the 0.1.0 release.

Refs #217 and #603