### PR TITLE
Remove binaries in build after building image

### DIFF
--- a/script/build
+++ b/script/build
@@ -13,6 +13,6 @@ else
     OS_ARCH_ARG=($2)
 fi
 
-rm -f docker-machine*
 docker build -t docker-machine .
+rm -f docker-machine*
 exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}"


### PR DESCRIPTION
This will bail before deleting the binaries if it can't connect to a Docker host. Sometimes I build machine binaries when I haven't got a machine and then it removes the machine binaries and then I can't use machine to create a machine and then the universe implodes. :(
