### PR TITLE
fixes regression causing intermittent TLS errors in azure

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -254,11 +254,7 @@ func (driver *Driver) GetURL() (string, error) {
 }
 
 func (driver *Driver) GetIP() (string, error) {
-	addrs, err := net.LookupIP(driver.getHostname())
-	if err != nil {
-		return "", err
-	}
-	return addrs[0].String(), nil
+	return driver.getHostname(), nil
 }
 
 func (driver *Driver) GetState() (state.State, error) {


### PR DESCRIPTION
There is an issue doing a lookup on the hostname causing intermittent TLS errors.  This fixes #600 