### PR TITLE
respect proxy settings for b2d downloads

### DIFF
--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -22,8 +22,9 @@ func defaultTimeout(network, addr string) (net.Conn, error) {
 
 func getClient() *http.Client {
 	transport := http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial:  defaultTimeout,
+		DisableKeepAlives: true,
+		Proxy:             http.ProxyFromEnvironment,
+		Dial:              defaultTimeout,
 	}
 
 	client := http.Client{

--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -22,7 +22,8 @@ func defaultTimeout(network, addr string) (net.Conn, error) {
 
 func getClient() *http.Client {
 	transport := http.Transport{
-		Dial: defaultTimeout,
+		Proxy: http.ProxyFromEnvironment,
+		Dial:  defaultTimeout,
 	}
 
 	client := http.Client{


### PR DESCRIPTION
This fixes docker-machine with boot2docker behind a (corporate) http_proxy