### PR TITLE
add trailing newline when unsetting env in fish

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -473,7 +473,7 @@ func cmdEnv(c *cli.Context) {
 	if c.Bool("unset") {
 		switch userShell {
 		case "fish":
-			fmt.Printf("set -e DOCKER_TLS_VERIFY\nset -e DOCKER_CERT_PATH\nset -e DOCKER_HOST")
+			fmt.Printf("set -e DOCKER_TLS_VERIFY\nset -e DOCKER_CERT_PATH\nset -e DOCKER_HOST\n")
 		default:
 			fmt.Println("unset DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_HOST")
 		}


### PR DESCRIPTION
This fixes using docker-machine with boot2docker behind a (corporate) http_proxy