### PR TITLE
optionally add docker host to proxy excludes in env command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -283,6 +283,10 @@ var Commands = []cli.Command{
 				Name:  "unset, u",
 				Usage: "Unset variables instead of setting them",
 			},
+			cli.BoolFlag{
+				Name:  "no-proxy",
+				Usage: "Add docker endpoint to NO_PROXY environment variable",
+			},
 		},
 	},
 	{

--- a/commands/env.go
+++ b/commands/env.go
@@ -135,7 +135,7 @@ func cmdEnv(c *cli.Context) {
 		//first check for an existing lower case no_proxy var
 		noProxyVar = "no_proxy"
 		noProxyValue = os.Getenv("no_proxy")
-		//otherwise default to allcaps HTTP_PROXY
+		//otherwise default to allcaps NO_PROXY
 		if noProxyValue == "" {
 			noProxyVar = "NO_PROXY"
 			noProxyValue = os.Getenv("NO_PROXY")

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -76,3 +76,20 @@ set DOCKER_CERT_PATH=C:\Users\captain\.docker\machine\machines\dev
 set DOCKER_MACHINE_NAME=dev
 # Run this command to configure your shell: copy and paste the above values into your command prompt
 ```
+
+## Proxy exclusion
+The env command supports a `--no-proxy` flag that will also add the `DOCKER_HOST` to the `NO_PROXY`/`no_proxy`  environment variable (which ever is already defined).
+
+```
+docker-machine env dev --no-proxy
+set -x DOCKER_TLS_VERIFY "1";
+set -x DOCKER_HOST "tcp://172.16.77.135:2376";
+set -x DOCKER_CERT_PATH "/Users/fabus/.docker/machine/machines/dev";
+set -x DOCKER_MACHINE_NAME "dev";
+set -x NO_PROXY "172.16.77.135";
+# Run this command to configure your shell:
+# eval (docker-machine env dev)
+```
+
+This is useful when using docker-machine with a local VM provider (e.g. virtualbox or vmware fusion/workstation) in network environments where a http proxy is needed for internet access.
+


### PR DESCRIPTION
This adds a `--no-proxy` flag to the `docker-machine env` command.
When set it will take care of adding (and removing) the docker host to/from the *NO_PROXY* environment variable.

This helps using docker-machine with docker >=1.5 with local vm providers (e.g. fusion, virtualbox) in coporate networks where an http proxy is required for internet connectivity.
Since version 1.5 the docker client picks up the *HTTP_PROXY* environment variable when connecting to the docker daemon. This does not work well for the local vm use case. In that case the docker host is inside a local virtual network only reachable from the workstation itself.

@ehazlett This pull request also has the intention to illicit some feedback from you regarding this PR https://github.com/boot2docker/boot2docker-cli/pull/345 :)