### PR TITLE
keep machine URL consistent in machine config and machine env

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -356,7 +356,7 @@ func cmdConfig(c *cli.Context) {
 
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
-	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H=%q",
+	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H=%s",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, dockerHost)
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"flag"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/codegangsta/cli"
@@ -291,5 +294,56 @@ func TestRunActionForeachMachine(t *testing.T) {
 		if expected[machine.Name] != state {
 			t.Fatalf("Expected machine %s to have state %s, got state %s", machine.Name, state, expected[machine.Name])
 		}
+	}
+}
+
+func TestCmdConfig(t *testing.T) {
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	os.Setenv("MACHINE_STORAGE_PATH", TestStoreDir)
+
+	defer func() {
+		os.Setenv("MACHINE_STORAGE_PATH", "")
+		os.Stdout = stdout
+		w.Close()
+	}()
+
+	if err := clearHosts(); err != nil {
+		t.Fatal(err)
+	}
+
+	flags := getDefaultTestDriverFlags()
+
+	store := NewStore(TestMachineDir, "", "")
+	var err error
+
+	_, err = store.Create("test-a", "none", flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	host, err := store.Load("test-a")
+	if err != nil {
+		t.Fatalf("error loading host: %v", err)
+	}
+
+	if err := store.SetActive(host); err != nil {
+		t.Fatalf("error setting active host: %v", err)
+	}
+
+	set := flag.NewFlagSet("config", 0)
+
+	testOutput := &bytes.Buffer{}
+
+	go io.Copy(testOutput, r)
+
+	c := cli.NewContext(nil, set, set)
+
+	cmdConfig(c)
+
+	if strings.Contains(testOutput.String(), "-H=unix:///var/run/docker.sock") {
+		t.Fatalf("Expect docker host URL")
 	}
 }


### PR DESCRIPTION
Now it output double-quoted string value for docker host only when performing command `machine config`:

    $ machine config
    --tls --tlscacert=/.client/ca.pem --tlscert=/.client/cert.pem --tlskey=/.client/key.pem -H="tcp://192.168.99.100:2376"

Which works for `docker` command only because of docker/docker#6147 but not for other project like [drone/drone](https://github.com/drone/drone) which uses `codegangsta/cli` that does not trim quotes for string flag all the time.

This PR will enable scenario like command `drone build $(docker-machine config)` on OS X, which doesn't work util it removes the double quotes of docker host from command `machine config`. (notice that it doesn't use double quotes in `machine env` too)