### PR TITLE
Provision OpenStack instances with Docker

### DIFF
--- a/host.go
+++ b/host.go
@@ -403,7 +403,7 @@ func (h *Host) Create(name string) error {
 func (h *Host) Provision() error {
 	// "local" providers use b2d; no provisioning necessary
 	switch h.Driver.DriverName() {
-	case "none", "virtualbox", "vmwarefusion", "vmwarevsphere", "openstack":
+	case "none", "virtualbox", "vmwarefusion", "vmwarevsphere":
 		return nil
 	}
 


### PR DESCRIPTION
Since 54f36078, Machine doesn't check anymore if Docker is installed
in the created instances, which breaks the compatibility between
v0.1.0-rc5 and v0.1.0 when using Machine with some cloud providers
like RunAbove.com.