### PR TITLE
show fish usage upon create

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -325,8 +325,21 @@ func cmdCreate(c *cli.Context) {
 		log.Fatalf("error setting active host: %v", err)
 	}
 
+	info := ""
+	userShell := filepath.Base(os.Getenv("SHELL"))
+
+	switch userShell {
+	case "fish":
+		info = fmt.Sprintf("%s env %s | source", c.App.Name, name)
+	default:
+		info = fmt.Sprintf("$(%s env %s)", c.App.Name, name)
+	}
+
 	log.Infof("%q has been created and is now the active machine.", name)
-	log.Infof("To point your Docker client at it, run this in your shell: $(%s env %s)", c.App.Name, name)
+
+	if info != "" {
+		log.Infof("To point your Docker client at it, run this in your shell: %s", info)
+	}
 }
 
 func cmdConfig(c *cli.Context) {


### PR DESCRIPTION
This adds support for showing the proper usage for `env` upon creation when using the fish shell.

Example:

```
...
INFO[0038] "test-vbox" has been created and is now the active machine.
INFO[0038] To point your Docker client at it, run this in your shell: docker-machine_darwin-amd64 env test-vbox | source
```