### PR TITLE
Add hyper-v to the list of b2d providers

### DIFF
--- a/host.go
+++ b/host.go
@@ -403,7 +403,7 @@ func (h *Host) Create(name string) error {
 func (h *Host) Provision() error {
 	// "local" providers use b2d; no provisioning necessary
 	switch h.Driver.DriverName() {
-	case "none", "virtualbox", "vmwarefusion", "vmwarevsphere":
+	case "none", "hyper-v", "virtualbox", "vmwarefusion", "vmwarevsphere":
 		return nil
 	}
 


### PR DESCRIPTION
The hyper-v provider also uses boot2docker so should it should be in the list of providers which use boot2docker and don't need extra provisioning.

Fixes #666, #647.