### PR TITLE
Introduce universal poll retries function

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
 func GetHomeDir() string {
@@ -78,4 +80,18 @@ func CopyFile(src, dst string) error {
 	}
 
 	return nil
+}
+
+func WaitForSpecific(f func() bool, maxAttempts int, waitInterval time.Duration) error {
+	for i := 0; i < maxAttempts; i++ {
+		if f() {
+			return nil
+		}
+		time.Sleep(waitInterval)
+	}
+	return fmt.Errorf("Maximum number of retries (%d) exceeded", maxAttempts)
+}
+
+func WaitFor(f func() bool) error {
+	return WaitForSpecific(f, 60, 3*time.Second)
 }


### PR DESCRIPTION
I feel like we need something more uniform than the current situation - there are lots and lots of places where this pattern is needed, e.g. https://github.com/docker/machine/pull/665

Think it's important to have an answer so that contributors don't accidentally spin forever without a max attempts or spam a lot by forgetting a sleep.

We can move over instances of this pattern to this universal way as we see them.

Let me know what you think @ehazlett @sthulb 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>