### PR TITLE
Make one call to export, and escape spaces in the cert path

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -524,10 +524,10 @@ func cmdEnv(c *cli.Context) {
 	switch userShell {
 	case "fish":
 		fmt.Printf("set -x DOCKER_TLS_VERIFY yes\nset -x DOCKER_CERT_PATH %s\nset -x DOCKER_HOST %s\n",
-			cfg.machineDir, dockerHost)
+			strings.Replace(cfg.machineDir, ` `, `\ `, -1), dockerHost)
 	default:
-		fmt.Printf("export DOCKER_TLS_VERIFY=yes\nexport DOCKER_CERT_PATH=%s\nexport DOCKER_HOST=%s\n",
-			cfg.machineDir, dockerHost)
+		fmt.Printf("export DOCKER_TLS_VERIFY=yes DOCKER_CERT_PATH=%s DOCKER_HOST=%s\n",
+			strings.Replace(cfg.machineDir, ` `, `\ `, -1), dockerHost)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

this is from https://github.com/boot2docker/boot2docker-cli/pull/351 - OSX users (and I presume Windows users with spaces in their username fall over hard.

