### PR TITLE
EC2 fixes

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -316,8 +316,8 @@ func (d *Driver) Create() error {
 			return err
 		}
 		if ip != "" {
-
-			d.IPAddress = instance.IpAddress
+			d.IPAddress = ip
+			log.Debugf("Got the IP Address, it's %q", d.IPAddress)
 			break
 		}
 		time.Sleep(5 * time.Second)
@@ -563,10 +563,6 @@ func (d *Driver) waitForInstance() error {
 			break
 		}
 		time.Sleep(1 * time.Second)
-	}
-
-	if err := d.updateDriver(); err != nil {
-		return err
 	}
 
 	return nil

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -402,6 +402,8 @@ func (d *Driver) GetState() (state.State, error) {
 		return state.Stopping, nil
 	case "stopped":
 		return state.Stopped, nil
+	default:
+		return state.Error, nil
 	}
 	return state.None, nil
 }

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -501,9 +501,11 @@ func (e *EC2) GetInstance(instanceId string) (EC2Instance, error) {
 		return ec2Instance, fmt.Errorf("Error unmarshalling AWS response XML: %s", err)
 	}
 
-	reservationSet := unmarshalledResponse.ReservationSet[0]
-	instance := reservationSet.InstancesSet[0]
-	return instance, nil
+	if len(unmarshalledResponse.ReservationSet) > 0 {
+		reservationSet := unmarshalledResponse.ReservationSet[0]
+		ec2Instance = reservationSet.InstancesSet[0]
+	}
+	return ec2Instance, nil
 }
 
 func (e *EC2) StartInstance(instanceId string) error {


### PR DESCRIPTION
Fix a couple of issues I identified with the EC2 driver:

- If the instance is removed remotely via a method other than `docker-machine`, there will be a panic.  This will return the instance as a "Error" state instead.
- We were setting `d.IPAddress` to the wrong value, so this corrects that and fixes an issue where the IP would sometimes not be identified correctly