### PR TITLE
rebuild-ca and regenerate-certs commands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -560,6 +560,28 @@ NAME   ACTIVE   DRIVER       STATE     URL
 dev    *        virtualbox   Stopped
 ```
 
+#### tls-rebuild-ca
+
+Regenerate TLS CA certificates.
+
+```
+$ docker-machine tls-rebuild-ca
+Rebuild TLS CA?  Warning: this is irreversible. (y/n): y
+INFO[0006] Rebuilding TLS CA
+INFO[0006] Creating CA: /Users/ehazlett/.docker/machine/certs/ca.pem
+INFO[0007] Creating client certificate: /Users/ehazlett/.docker/machine/certs/cert.pem
+```
+
+#### tls-regenerate-certs
+
+Regenerate TLS certificates and update the machine with new certs.
+
+```
+$ docker-machine tls-regenerate-certs
+Regenerate TLS machine certs?  Warning: this is irreversible. (y/n): y
+INFO[0013] Regenerating TLS certificates
+```
+
 #### upgrade
 
 Upgrade a machine to the latest version of Docker.

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -523,7 +523,7 @@ func (d *Driver) StartDocker() error {
 func (d *Driver) StopDocker() error {
 	log.Debug("Stopping Docker...")
 
-	cmd, err := d.GetSSHCommand("if [ -e /var/run/docker.pid ]; then sudo /etc/init.d/docker stop ; fi")
+	cmd, err := d.GetSSHCommand("if [ -e /var/run/docker.pid ] && [ -d /proc/$(cat /var/run/docker.pid) ]; then sudo /etc/init.d/docker stop ; exit 0; fi")
 	if err != nil {
 		return err
 	}

--- a/host.go
+++ b/host.go
@@ -276,7 +276,7 @@ func (h *Host) ConfigureAuth() error {
 	}
 	machineServerKeyPath := path.Join(d.GetDockerConfigDir(), "server-key.pem")
 
-	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(caCert), machineCaCertPath))
+	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(caCert), machineCaCertPath))
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (h *Host) ConfigureAuth() error {
 		return err
 	}
 
-	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(serverKey), machineServerKeyPath))
+	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverKey), machineServerKeyPath))
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (h *Host) ConfigureAuth() error {
 		return err
 	}
 
-	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(serverCert), machineServerCertPath))
+	cmd, err = d.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverCert), machineServerCertPath))
 	if err != nil {
 		return err
 	}

--- a/integration-tests/cli.bats
+++ b/integration-tests/cli.bats
@@ -3,104 +3,116 @@
 load vars
 
 @test "cli: show info" {
-  run ./docker-machine_$PLATFORM-$ARCH
+  run machine
   [ "$status" -eq 0  ]
   [[ ${lines[0]} =~ "NAME:"  ]]
   [[ ${lines[1]} =~ "Create and manage machines running Docker"  ]]
 }
 
 @test "cli: show active help" {
-  run ./docker-machine_$PLATFORM-$ARCH active -h
+  run machine active -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command active"  ]]
 }
 
 @test "cli: show config help" {
-  run ./docker-machine_$PLATFORM-$ARCH config -h
+  run machine config -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command config"  ]]
 }
 
 @test "cli: show inspect help" {
-  run ./docker-machine_$PLATFORM-$ARCH inspect -h
+  run machine inspect -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command inspect"  ]]
 }
 
 @test "cli: show ip help" {
-  run ./docker-machine_$PLATFORM-$ARCH ip -h
+  run machine ip -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command ip"  ]]
 }
 
 @test "cli: show kill help" {
-  run ./docker-machine_$PLATFORM-$ARCH kill -h
+  run machine kill -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command kill"  ]]
 }
 
 @test "cli: show ls help" {
-  run ./docker-machine_$PLATFORM-$ARCH ls -h
+  run machine ls -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command ls"  ]]
 }
 
 @test "cli: show restart help" {
-  run ./docker-machine_$PLATFORM-$ARCH restart -h
+  run machine restart -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command restart"  ]]
 }
 
+@test "cli: show tls-rebuild-ca help" {
+  run machine tls-rebuild-ca -h
+  [ "$status" -eq 0  ]
+  [[ ${lines[3]} =~ "command tls-rebuild-ca"  ]]
+}
+
+@test "cli: show tls-regenerate-certs help" {
+  run machine tls-regenerate-certs -h
+  [ "$status" -eq 0  ]
+  [[ ${lines[3]} =~ "command tls-regenerate-certs"  ]]
+}
+
 @test "cli: show rm help" {
-  run ./docker-machine_$PLATFORM-$ARCH rm -h
+  run machine rm -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command rm"  ]]
 }
 
 @test "cli: show env help" {
-  run ./docker-machine_$PLATFORM-$ARCH env -h
+  run machine env -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command env"  ]]
 }
 
 @test "cli: show ssh help" {
-  run ./docker-machine_$PLATFORM-$ARCH ssh -h
+  run machine ssh -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command ssh"  ]]
 }
 
 @test "cli: show start help" {
-  run ./docker-machine_$PLATFORM-$ARCH start -h
+  run machine start -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command start"  ]]
 }
 
 @test "cli: show stop help" {
-  run ./docker-machine_$PLATFORM-$ARCH stop -h
+  run machine stop -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command stop"  ]]
 }
 
 @test "cli: show upgrade help" {
-  run ./docker-machine_$PLATFORM-$ARCH upgrade -h
+  run machine upgrade -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command upgrade"  ]]
 }
 
 @test "cli: show url help" {
-  run ./docker-machine_$PLATFORM-$ARCH url -h
+  run machine url -h
   [ "$status" -eq 0  ]
   [[ ${lines[3]} =~ "command url"  ]]
 }
 
 @test "flag: show version" {
-  run ./docker-machine_$PLATFORM-$ARCH -v
+  run machine -v
   [ "$status" -eq 0  ]
   [[ ${lines[0]} =~ "version"  ]]
 }
 
 @test "flag: show help" {
-  run ./docker-machine_$PLATFORM-$ARCH --help
+  run machine --help
   [ "$status" -eq 0  ]
   [[ ${lines[0]} =~ "NAME"  ]]
 }

--- a/integration-tests/driver-amazonec2.bats
+++ b/integration-tests/driver-amazonec2.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-azure.bats
+++ b/integration-tests/driver-azure.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-digitalocean.bats
+++ b/integration-tests/driver-digitalocean.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-google.bats
+++ b/integration-tests/driver-google.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-hyperv.bats
+++ b/integration-tests/driver-hyperv.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-rackspace.bats
+++ b/integration-tests/driver-rackspace.bats
@@ -49,6 +49,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop should fail (unsupported)" {
   run machine stop $NAME
   [[ ${lines[1]} == *"not currently support"*  ]]

--- a/integration-tests/driver-softlayer.bats
+++ b/integration-tests/driver-softlayer.bats
@@ -48,6 +48,11 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-virtualbox.bats
+++ b/integration-tests/driver-virtualbox.bats
@@ -58,6 +58,11 @@ function setup() {
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-vmwarefusion.bats
+++ b/integration-tests/driver-vmwarefusion.bats
@@ -53,6 +53,11 @@ function setup() {
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/driver-vmwarevcloudair.bats
+++ b/integration-tests/driver-vmwarevcloudair.bats
@@ -48,6 +48,16 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: regenerate certs" {
+  run machine tls-regenerate-certs --force $NAME
+  [ "$status" -eq 0  ]
+}
+
+@test "$DRIVER: run busybox container after new certs" {
+  run docker $(machine config $NAME) run busybox echo hello world
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/integration-tests/test.go
+++ b/integration-tests/test.go
@@ -1,2 +1,0 @@
-// stub for coverage
-package test


### PR DESCRIPTION
This adds `tls-rebuild-ca` and `tls-regenerate-certs` for rebuilding the local CA cert and keys as well as generating new certificates and propagating them to the specified machines.  This should resolve issues like #531 as well as provide a mechanism to completely re-key all machines.