### PR TITLE
rackspace: enable env var for flavor id

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -791,6 +791,7 @@ variable and CLI option are provided the CLI option takes the precedence.
 | `OS_API_KEY`         | `--rackspace-ap-key`        |
 | `OS_REGION_NAME`     | `--rackspace-region`        |
 | `OS_ENDPOINT_TYPE`   | `--rackspace-endpoint-type` |
+| `OS_FLAVOR_ID`       | `--rackspace-flavor-id`     |
 
 The Rackspace driver will use `598a4282-f14b-4e50-af4c-b3e52749d9f9` (Ubuntu 14.04 LTS) by default.
 

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -76,12 +76,12 @@ func GetCreateFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  "rackspace-image-id",
 			Usage: "Rackspace image ID. Default: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)",
-			Value: "",
 		},
 		cli.StringFlag{
-			Name:  "rackspace-flavor-id",
-			Usage: "Rackspace flavor ID. Default: General Purpose 1GB",
-			Value: "general1-1",
+			Name:   "rackspace-flavor-id",
+			Usage:  "Rackspace flavor ID. Default: General Purpose 1GB",
+			Value:  "general1-1",
+			EnvVar: "RACKSPACE_FLAVOR_ID",
 		},
 		cli.StringFlag{
 			Name:  "rackspace-ssh-user",

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -81,7 +81,7 @@ func GetCreateFlags() []cli.Flag {
 			Name:   "rackspace-flavor-id",
 			Usage:  "Rackspace flavor ID. Default: General Purpose 1GB",
 			Value:  "general1-1",
-			EnvVar: "RACKSPACE_FLAVOR_ID",
+			EnvVar: "OS_FLAVOR_ID",
 		},
 		cli.StringFlag{
 			Name:  "rackspace-ssh-user",


### PR DESCRIPTION
Enable setting the Rackspace flavor id via environment variable.