### PR TITLE
Fix check for whether docker is installed

### DIFF
--- a/host.go
+++ b/host.go
@@ -401,15 +401,9 @@ func (h *Host) Create(name string) error {
 }
 
 func (h *Host) Provision() error {
-	// "local" providers use b2d; no provisioning necessary
-	switch h.Driver.DriverName() {
-	case "none", "virtualbox", "vmwarefusion", "vmwarevsphere":
-		return nil
-	}
-
 	// install docker - until cloudinit we use ubuntu everywhere so we
 	// just install it using the docker repos
-	cmd, err := h.Driver.GetSSHCommand("if [ ! -e /usr/bin/docker ]; then curl -sSL https://get.docker.com | sh -; fi")
+	cmd, err := h.Driver.GetSSHCommand("command -v docker || curl -sSL https://get.docker.com | sh -;")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Should fix https://github.com/docker/machine/issues/666 and is a more robust solution than checking whether the driver uses b2d by default or not (what if user wants to use Ubuntu VM locally?)

cc @ehazlett @sthulb 


Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>