### PR TITLE
Add --n-instances to specify number of instances to create

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -116,18 +116,11 @@ func TestGetHosts(t *testing.T) {
 		t.Fatalf("List returned %d items", len(storeHosts))
 	}
 
-	set := flag.NewFlagSet("start", 0)
-	set.Parse([]string{"test-a", "test-b"})
-
-	globalSet := flag.NewFlagSet("-d", 0)
-	globalSet.String("-d", "none", "driver")
-	globalSet.String("storage-path", store.Path, "storage path")
-	globalSet.String("tls-ca-cert", "", "")
-	globalSet.String("tls-ca-key", "", "")
-
-	c := cli.NewContext(nil, set, globalSet)
-
-	hosts, err := getHosts(c)
+	machineNames := []string{
+		"test-a",
+		"test-b",
+	}
+	hosts, err := getHosts(machineNames, store)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +252,7 @@ func TestRunActionForeachMachine(t *testing.T) {
 		},
 	}
 
-	runActionForeachMachine("start", machines)
+	runActionForeachMachine("start", machines, &SwarmOptions{})
 
 	expected := map[string]state.State{
 		"foo":  state.Running,
@@ -287,7 +280,7 @@ func TestRunActionForeachMachine(t *testing.T) {
 		"ham":  state.Stopped,
 	}
 
-	runActionForeachMachine("stop", machines)
+	runActionForeachMachine("stop", machines, &SwarmOptions{})
 
 	for _, machine := range machines {
 		state, _ := machine.Driver.GetState()

--- a/store.go
+++ b/store.go
@@ -60,26 +60,6 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		return host, err
 	}
 
-	if err := host.Create(name); err != nil {
-		return host, err
-	}
-
-	if err := host.ConfigureAuth(); err != nil {
-		return host, err
-	}
-
-	if flags.Bool("swarm") {
-		log.Info("Configuring Swarm...")
-
-		discovery := flags.String("swarm-discovery")
-		master := flags.Bool("swarm-master")
-		swarmHost := flags.String("swarm-host")
-		addr := flags.String("swarm-addr")
-		if err := host.ConfigureSwarm(discovery, master, swarmHost, addr); err != nil {
-			log.Errorf("Error configuring Swarm: %s", err)
-		}
-	}
-
 	return host, nil
 }
 


### PR DESCRIPTION
This is much more of a "let's discuss design, play with it and try it out" than a request for merge, but I'm really excited about this functionality and I think others will be too.

Known issues:

- Sometimes (pretty regularly actually) drivers fail at creation, or at provisioning, and we should be able to handle
- What do we do with active host in this situation?  I've just passed the buck completely in this impl
- Right now if the machine requires shared resources before creation and it checks to see if they exist (e.g. security group in Amazon driver), then creates them if they don't, it will race with all the other goroutines to try and do so.  This == :(  and makes me think a separate `Precreate` step, or some kind of "skip shared resource creation" option, may well be a good thing.

Bonus points: Helps reduce some of the constant passing around of `cli.Context` struct.

I'll follow up later with more commentary but... PTAL

@ehazlett @sthulb 
@bfirsh This is pretty similar to something that was originally on the roadmap, so you might be interested.
@aluzzardi @vieux I think you'll be interested in this too.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>