### PR TITLE
Fixing inaccurate Usage message for the `--openstack-net-id` option

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -151,7 +151,7 @@ func GetCreateFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "openstack-net-id",
-			Usage: "OpenStack image name to use for the instance",
+			Usage: "OpenStack network id the machine will be connected on",
 			Value: "",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>