### PR TITLE
use default http client to download iso

### DIFF
--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,20 +15,8 @@ const (
 	timeout = time.Second * 5
 )
 
-func defaultTimeout(network, addr string) (net.Conn, error) {
-	return net.DialTimeout(network, addr, timeout)
-}
-
 func getClient() *http.Client {
-	transport := http.Transport{
-		Dial: defaultTimeout,
-	}
-
-	client := http.Client{
-		Transport: &transport,
-	}
-
-	return &client
+	return http.DefaultClient
 }
 
 type B2dUtils struct {


### PR DESCRIPTION
fix for #625 
The transport of default http client provides:
* proxy support from environment variables (`http_proxy`, `no_proxy` for go 1.3, `https_proxy` for go 1.4)
* 30 seconds http connect timeout
* 30 seconds for keep-alive
* 10 seconds for TLS handshake timeout