### PR TITLE
Add flag --pull-swarm-image

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -161,6 +161,11 @@ var Commands = []cli.Command{
 				Usage: "addr to advertise for Swarm (default: detect and use the machine IP)",
 				Value: "",
 			},
+			cli.StringFlag{
+				Name:  "pull-swarm-image",
+				Usage: "Set if pull swarm image from Docker Hub",
+				Value: "true",
+			},
 		),
 		Name:   "create",
 		Usage:  "Create a machine",

--- a/store.go
+++ b/store.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -75,7 +76,12 @@ func (s *Store) Create(name string, driverName string, flags drivers.DriverOptio
 		master := flags.Bool("swarm-master")
 		swarmHost := flags.String("swarm-host")
 		addr := flags.String("swarm-addr")
-		if err := host.ConfigureSwarm(discovery, master, swarmHost, addr); err != nil {
+		pullSwarmImage, err := strconv.ParseBool(flags.String("pull-swarm-image"))
+		if err != nil {
+			return nil, err
+		}
+
+		if err := host.ConfigureSwarm(discovery, master, swarmHost, addr, pullSwarmImage); err != nil {
 			log.Errorf("Error configuring Swarm: %s", err)
 		}
 	}


### PR DESCRIPTION
Add the option "pull-swarm-image" to let user choose if pull the latest version of Swarm image. Because in some network case, it is hard to access official docker hub.

Signed-off-by: LaynePeng <appamail@hotmail.com>