### PR TITLE
uses --tlsverify instead of --tls in config output

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -369,7 +369,7 @@ func cmdConfig(c *cli.Context) {
 
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
-	fmt.Printf("--tls --tlscacert=%s --tlscert=%s --tlskey=%s -H=%s",
+	fmt.Printf("--tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H=%s",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, dockerHost)
 }
 


### PR DESCRIPTION
Now it outputs `export DOCKER_TLS_VERIFY=yes` when performing command `docker-machine env` but it outputs `--tls` only when performing `docker-machine config`.

Since it requires TLS by default and both client side and server side certs are presented, it should use `--tlsverify` all the time.