### PR TITLE
consistent naming for DOCKER_TLS_VERIFY env var

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -523,10 +523,10 @@ func cmdEnv(c *cli.Context) {
 
 	switch userShell {
 	case "fish":
-		fmt.Printf("set -x DOCKER_TLS_VERIFY yes;\nset -x DOCKER_CERT_PATH %s;\nset -x DOCKER_HOST %s;\n",
+		fmt.Printf("set -x DOCKER_TLS_VERIFY 1;\nset -x DOCKER_CERT_PATH %s;\nset -x DOCKER_HOST %s;\n",
 			cfg.machineDir, dockerHost)
 	default:
-		fmt.Printf("export DOCKER_TLS_VERIFY=yes\nexport DOCKER_CERT_PATH=%s\nexport DOCKER_HOST=%s\n",
+		fmt.Printf("export DOCKER_TLS_VERIFY=1\nexport DOCKER_CERT_PATH=%s\nexport DOCKER_HOST=%s\n",
 			cfg.machineDir, dockerHost)
 	}
 }


### PR DESCRIPTION
This sets the env var `DOCKER_TLS_VERIFY` to "1" instead of "yes" to be consistent with Docker.

Fixes #734 