### PR TITLE
Begin separation of creation and provisioning

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -73,6 +73,10 @@ func (d *FakeDriver) Upgrade() error {
 	return nil
 }
 
+func (d *FakeDriver) GetSSHPort() int {
+	return 22
+}
+
 func (d *FakeDriver) StartDocker() error {
 	return nil
 }
@@ -83,6 +87,18 @@ func (d *FakeDriver) StopDocker() error {
 
 func (d *FakeDriver) GetDockerConfigDir() string {
 	return ""
+}
+
+func (d *FakeDriver) GetSSHKeyPath() string {
+	return "/foo/id_rsa"
+}
+
+func (d *FakeDriver) GetSSHUsername() string {
+	return "root"
+}
+
+func (d *FakeDriver) GetSSHHostname() (string, error) {
+	return "localhost", nil
 }
 
 func (d *FakeDriver) GetSSHCommand(args ...string) (*exec.Cmd, error) {

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -66,6 +66,17 @@ type Driver interface {
 	// GetDockerConfigDir returns the config directory for storing daemon configs
 	GetDockerConfigDir() string
 
+	GetSSHPort() int
+
+	// GetSSHUsername returns the UNIX user the driver uses for SSH
+	GetSSHUsername() string
+
+	// Return the path where the SSH private key for this instance is located.
+	GetSSHKeyPath() string
+
+	// Returns the hostname to use for running SSH commands
+	GetSSHHostname() (string, error)
+
 	// GetSSHCommand returns a command for SSH pointing at the correct user, host
 	// and keys for the host with args appended. If no args are passed, it will
 	// initiate an interactive SSH session as if SSH were passed no args.

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -57,6 +57,14 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
+func (d *Driver) GetSSHPort() int {
+	return 22
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return "", nil
+}
+
 func (d *Driver) GetURL() (string, error) {
 	return d.URL, nil
 }
@@ -113,6 +121,14 @@ func (d *Driver) Upgrade() error {
 	return fmt.Errorf("hosts without a driver cannot be upgraded")
 }
 
+func (d *Driver) GetSSHUsername() string {
+	return ""
+}
+
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 	return nil, fmt.Errorf("hosts without a driver do not support SSH")
+}
+
+func (d *Driver) GetSSHKeyPath() string {
+	return ""
 }

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -450,6 +450,14 @@ func (d *Driver) GetDockerConfigDir() string {
 	return dockerConfigDir
 }
 
+func (d *Driver) GetSSHUsername() string {
+	return d.SSHUser
+}
+
+func (d *Driver) GetSSHPort() int {
+	return d.SSHPort
+}
+
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 	ip, err := d.GetIP()
 	if err != nil {
@@ -462,7 +470,7 @@ func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 	}
 
 	log.WithField("MachineId", d.MachineId).Debug("Command: %s", args)
-	return ssh.GetSSHCommand(ip, d.SSHPort, d.SSHUser, d.sshKeyPath(), args...), nil
+	return ssh.GetSSHCommand(ip, d.SSHPort, d.GetSSHUsername(), d.GetSSHKeyPath(), args...), nil
 }
 
 const (
@@ -624,7 +632,7 @@ func (d *Driver) initNetwork() error {
 
 func (d *Driver) createSSHKey() error {
 	log.WithField("Name", d.KeyPairName).Debug("Creating Key Pair...")
-	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err
 	}
 	publicKey, err := ioutil.ReadFile(d.publicSSHKeyPath())
@@ -759,10 +767,18 @@ func (d *Driver) sshExec(commands []string) error {
 	return nil
 }
 
-func (d *Driver) sshKeyPath() string {
+func (d *Driver) GetSSHHostname() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
+}
+
+func (d *Driver) GetSSHKeyPath() string {
 	return path.Join(d.storePath, "id_rsa")
 }
 
 func (d *Driver) publicSSHKeyPath() string {
-	return d.sshKeyPath() + ".pub"
+	return d.GetSSHKeyPath() + ".pub"
 }

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -33,6 +33,7 @@ type Driver struct {
 	SwarmMaster    bool
 	SwarmHost      string
 	SwarmDiscovery string
+	SSHPort        int
 }
 
 type deviceConfig struct {
@@ -283,8 +284,24 @@ func (d *Driver) GetState() (state.State, error) {
 	return vmState, nil
 }
 
+func (d *Driver) GetSSHPort() int {
+	return d.SSHPort
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return "root"
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
+}
+
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
-	return ssh.GetSSHCommand(d.IPAddress, 22, "root", d.sshKeyPath(), args...), nil
+	return ssh.GetSSHCommand(d.IPAddress, d.GetSSHPort(), d.GetSSHUsername(), d.GetSSHKeyPath(), args...), nil
 }
 
 func (d *Driver) PreCreateCheck() error {
@@ -374,7 +391,7 @@ func (d *Driver) buildHostSpec() *HostSpec {
 }
 
 func (d *Driver) createSSHKey() (*SshKey, error) {
-	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return nil, err
 	}
 
@@ -392,10 +409,10 @@ func (d *Driver) createSSHKey() (*SshKey, error) {
 }
 
 func (d *Driver) publicSSHKeyPath() string {
-	return d.sshKeyPath() + ".pub"
+	return d.GetSSHKeyPath() + ".pub"
 }
 
-func (d *Driver) sshKeyPath() string {
+func (d *Driver) GetSSHKeyPath() string {
 	return path.Join(d.storePath, "id_rsa")
 }
 

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -50,8 +50,8 @@ type Driver struct {
 	SwarmHost      string
 	SwarmDiscovery string
 	CPUS           int
-
-	storePath string
+	storePath      string
+	SSHPort        int
 }
 
 type CreateFlags struct {
@@ -92,7 +92,13 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}, nil
+	return &Driver{
+		MachineName:    machineName,
+		storePath:      storePath,
+		CaCertPath:     caCert,
+		PrivateKeyPath: privateKey,
+		SSHPort:        22,
+	}, nil
 }
 
 func (d *Driver) DriverName() string {
@@ -209,7 +215,7 @@ func (d *Driver) Create() error {
 	}
 
 	log.Infof("Creating SSH key...")
-	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err
 	}
 
@@ -283,20 +289,6 @@ func (d *Driver) Create() error {
 
 	// Expand tar file.
 	vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo /bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar && sudo tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1 && sudo chown -R docker:staff /home/docker")
-
-	log.Debugf("Setting hostname: %s", d.MachineName)
-	cmd, err := d.GetSSHCommand(fmt.Sprintf(
-		"echo \"127.0.0.1 %s\" | sudo tee -a /etc/hosts && sudo hostname %s && echo \"%s\" | sudo tee /etc/hostname",
-		d.MachineName,
-		d.MachineName,
-		d.MachineName,
-	))
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -375,12 +367,24 @@ func (d *Driver) Upgrade() error {
 	return fmt.Errorf("VMware Fusion does not currently support the upgrade operation.")
 }
 
+func (d *Driver) GetSSHHostname() (string, error) {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return "docker"
+}
+
 func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
 	ip, err := d.GetIP()
 	if err != nil {
 		return nil, err
 	}
-	return ssh.GetSSHCommand(ip, 22, "docker", d.sshKeyPath(), args...), nil
+	return ssh.GetSSHCommand(ip, d.GetSSHPort(), d.GetSSHUsername(), d.GetSSHKeyPath(), args...), nil
 }
 
 func (d *Driver) vmxPath() string {
@@ -500,12 +504,16 @@ func (d *Driver) getIPfromDHCPLease() (string, error) {
 
 }
 
-func (d *Driver) sshKeyPath() string {
+func (d *Driver) GetSSHPort() int {
+	return d.SSHPort
+}
+
+func (d *Driver) GetSSHKeyPath() string {
 	return path.Join(d.storePath, "id_rsa")
 }
 
 func (d *Driver) publicSSHKeyPath() string {
-	return d.sshKeyPath() + ".pub"
+	return d.GetSSHKeyPath() + ".pub"
 }
 
 // Make a boot2docker userdata.tar key bundle


### PR DESCRIPTION
- Implement methods to get SSH key path, port, username, and hostname
- Move hostname provisioning out of drivers and into main code path
- implement generic wait for SSH function like in @ggiamarchi PR https://github.com/docker/machine/pull/665

cc @ehazlett @sthulb 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>