### PR TITLE
fixes Issue #750 by allowing virtualbox driver

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -344,11 +344,19 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	if s == state.Stopped {
+	switch s {
+	case state.Stopped, state.Saved:
 		if err := vbm("startvm", d.MachineName, "--type", "headless"); err != nil {
 			return err
 		}
 		log.Infof("Waiting for VM to start...")
+	case state.Paused:
+		if err := vbm("controlvm", d.MachineName, "resume", "--type", "headless"); err != nil {
+			return err
+		}
+		log.Infof("Resuming VM ...")
+	default:
+		log.Infof("VM not in restartable state")
 	}
 
 	return ssh.WaitForTCP(fmt.Sprintf("localhost:%d", d.SSHPort))


### PR DESCRIPTION
fixes Issue #750 by allowing virtualbox driver start command to start VMs in saved state and
resume VMs in paused state.

Signed-off-by: Ken Pepple <ken@solinea.com>