### PR TITLE
Start VirtualBox VM if saved

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -344,7 +344,7 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	if s == state.Stopped {
+	if s == state.Stopped || s == state.Saved {
 		if err := vbm("startvm", d.MachineName, "--type", "headless"); err != nil {
 			return err
 		}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -344,7 +344,7 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	if s == state.Stopped || s == state.Saved {
+	if s == state.Stopped {
 		if err := vbm("startvm", d.MachineName, "--type", "headless"); err != nil {
 			return err
 		}


### PR DESCRIPTION
Allows `docker-machine start` to start saved machines when using the VirtualBox driver. VirtualBox often saves VMs by itself, like when a Mac's battery life is lower than 10%.