### PR TITLE
Honouring the `--softlayer-image` flag

### DIFF
--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -202,7 +202,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		PrivateNet:    flags.Bool("softlayer-private-net-only"),
 		LocalDisk:     flags.Bool("softlayer-local-disk"),
 		HourlyBilling: flags.Bool("softlayer-hourly-billing"),
-		Image:         "UBUNTU_LATEST",
+		Image:         flags.String("softlayer-image"),
 		Region:        flags.String("softlayer-region"),
 	}
 	return validateDeviceConfig(d.deviceConfig)

--- a/drivers/softlayer/driver_test.go
+++ b/drivers/softlayer/driver_test.go
@@ -1,1 +1,90 @@
 package softlayer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const (
+	testStoreDir          = ".store-test"
+	machineTestName       = "test-host"
+	machineTestCaCert     = "test-cert"
+	machineTestPrivateKey = "test-key"
+)
+
+type DriverOptionsMock struct {
+	Data map[string]interface{}
+}
+
+func (d DriverOptionsMock) String(key string) string {
+	if value, ok := d.Data[key]; ok {
+		return value.(string)
+	}
+	return ""
+}
+
+func (d DriverOptionsMock) Int(key string) int {
+	if value, ok := d.Data[key]; ok {
+		return value.(int)
+	}
+	return 0
+}
+
+func (d DriverOptionsMock) Bool(key string) bool {
+	if value, ok := d.Data[key]; ok {
+		return value.(bool)
+	}
+	return false
+}
+
+func cleanup() error {
+	return os.RemoveAll(testStoreDir)
+}
+
+func getTestStorePath() (string, error) {
+	tmpDir, err := ioutil.TempDir("", "machine-test-")
+	if err != nil {
+		return "", err
+	}
+	os.Setenv("MACHINE_STORAGE_PATH", tmpDir)
+	return tmpDir, nil
+}
+
+func getDefaultTestDriverFlags() *DriverOptionsMock {
+	return &DriverOptionsMock{
+		Data: map[string]interface{}{
+			"name":                   "test",
+			"url":                    "unix:///var/run/docker.sock",
+			"softlayer-api-key":      "12345",
+			"softlayer-user":         "abcdefg",
+			"softlayer-api-endpoint": "https://api.softlayer.com/rest/v3",
+			"softlayer-image":        "MY_TEST_IMAGE",
+		},
+	}
+}
+
+func getTestDriver() (*Driver, error) {
+	storePath, err := getTestStorePath()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	d, err := NewDriver(machineTestName, storePath, machineTestCaCert, machineTestPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	d.SetConfigFromFlags(getDefaultTestDriverFlags())
+	drv := d.(*Driver)
+	return drv, nil
+}
+
+func TestSetConfigFromFlagsSetsImage(t *testing.T) {
+	d, _ := getTestDriver()
+
+	img := d.deviceConfig.Image
+	if img != "MY_TEST_IMAGE" {
+		t.Fatalf("expected 'MY_TEST_IMAGE'; received %s", img)
+	}
+}


### PR DESCRIPTION
Even though Machine only really supports Ubuntu, we still shouldn't
hard-code the softlayer-image to `UBUNTU_LATEST` ;)

Fixes #759

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>