### PR TITLE
certs: x509 check ip san

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -381,7 +381,12 @@ func cmdConfig(c *cli.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	dockerHost := cfg.machineUrl
+
+	dockerHost, err := getHost(c).Driver.GetURL()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	if c.Bool("swarm") {
 		if !cfg.swarmMaster {
 			log.Fatalf("%s is not a swarm master", cfg.machineName)
@@ -394,7 +399,7 @@ func cmdConfig(c *cli.Context) {
 		swarmPort := parts[1]
 
 		// get IP of machine to replace in case swarm host is 0.0.0.0
-		mUrl, err := url.Parse(cfg.machineUrl)
+		mUrl, err := url.Parse(dockerHost)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -403,6 +408,8 @@ func cmdConfig(c *cli.Context) {
 
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
+
+	log.Debug(dockerHost)
 
 	u, err := url.Parse(cfg.machineUrl)
 	if err != nil {

--- a/commands.go
+++ b/commands.go
@@ -36,8 +36,11 @@ type machineConfig struct {
 	machineName    string
 	machineDir     string
 	caCertPath     string
+	caKeyPath      string
 	clientCertPath string
 	clientKeyPath  string
+	serverCertPath string
+	serverKeyPath  string
 	machineUrl     string
 	swarmMaster    bool
 	swarmHost      string
@@ -66,6 +69,25 @@ func (h hostListItemByName) Swap(i, j int) {
 
 func (h hostListItemByName) Less(i, j int) bool {
 	return strings.ToLower(h[i].Name) < strings.ToLower(h[j].Name)
+}
+
+func confirmInput(msg string) bool {
+	fmt.Printf("%s (y/n): ", msg)
+	var resp string
+	_, err := fmt.Scanln(&resp)
+
+	if err != nil {
+		log.Fatal(err)
+
+	}
+
+	if strings.Index(strings.ToLower(resp), "y") == 0 {
+		return true
+
+	}
+
+	return false
+
 }
 
 func setupCertificates(caCertPath, caKeyPath, clientCertPath, clientKeyPath string) error {
@@ -206,6 +228,18 @@ var Commands = []cli.Command{
 		Name:   "ls",
 		Usage:  "List machines",
 		Action: cmdLs,
+	},
+	{
+		Name:        "regenerate-certs",
+		Usage:       "Regenerate TLS Certificates for a machine",
+		Description: "Argument(s) are one or more machine names.  Will use the active machine if none is provided.",
+		Action:      cmdRegenerateCerts,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "force, f",
+				Usage: "Force rebuild and do not prompt",
+			},
+		},
 	},
 	{
 		Name:        "restart",
@@ -369,6 +403,33 @@ func cmdConfig(c *cli.Context) {
 
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
+
+	u, err := url.Parse(cfg.machineUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if u.Scheme != "unix" {
+		// validate cert and regenerate if needed
+		valid, err := utils.ValidateCertificate(
+			u.Host,
+			cfg.caCertPath,
+			cfg.serverCertPath,
+			cfg.serverKeyPath,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !valid {
+			log.Debugf("invalid certs detected; regenerating for %s", u.Host)
+
+			if err := runActionWithContext("configureAuth", c); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+
 	fmt.Printf("--tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H=%s",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, dockerHost)
 }
@@ -459,6 +520,16 @@ func cmdLs(c *cli.Context) {
 	w.Flush()
 }
 
+func cmdRegenerateCerts(c *cli.Context) {
+	force := c.Bool("force")
+	if force || confirmInput("Regenerate TLS machine certs?  Warning: this is irreversible.") {
+		log.Infof("Regenerating TLS certificates")
+		if err := runActionWithContext("configureAuth", c); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
 func cmdRm(c *cli.Context) {
 	if len(c.Args()) == 0 {
 		cli.ShowCommandHelp(c, "rm")
@@ -521,6 +592,32 @@ func cmdEnv(c *cli.Context) {
 		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
 	}
 
+	u, err := url.Parse(cfg.machineUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if u.Scheme != "unix" {
+		// validate cert and regenerate if needed
+		valid, err := utils.ValidateCertificate(
+			u.Host,
+			cfg.caCertPath,
+			cfg.serverCertPath,
+			cfg.serverKeyPath,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !valid {
+			log.Debugf("invalid certs detected; regenerating for %s", u.Host)
+
+			if err := runActionWithContext("configureAuth", c); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+
 	switch userShell {
 	case "fish":
 		fmt.Printf("set -x DOCKER_TLS_VERIFY 1;\nset -x DOCKER_CERT_PATH %s;\nset -x DOCKER_HOST %s;\n",
@@ -574,11 +671,12 @@ func cmdSsh(c *cli.Context) {
 // We run commands concurrently and communicate back an error if there was one.
 func machineCommand(actionName string, machine *Host, errorChan chan<- error) {
 	commands := map[string](func() error){
-		"start":   machine.Start,
-		"stop":    machine.Stop,
-		"restart": machine.Restart,
-		"kill":    machine.Kill,
-		"upgrade": machine.Upgrade,
+		"configureAuth": machine.ConfigureAuth,
+		"start":         machine.Start,
+		"stop":          machine.Stop,
+		"restart":       machine.Restart,
+		"kill":          machine.Kill,
+		"upgrade":       machine.Upgrade,
 	}
 
 	log.Debugf("command=%s machine=%s", actionName, machine.Name)
@@ -811,8 +909,11 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 
 	machineDir := filepath.Join(utils.GetMachineDir(), machine.Name)
 	caCert := filepath.Join(machineDir, "ca.pem")
+	caKey := filepath.Join(utils.GetMachineCertDir(), "ca-key.pem")
 	clientCert := filepath.Join(machineDir, "cert.pem")
 	clientKey := filepath.Join(machineDir, "key.pem")
+	serverCert := filepath.Join(machineDir, "server.pem")
+	serverKey := filepath.Join(machineDir, "server-key.pem")
 	machineUrl, err := machine.GetURL()
 	if err != nil {
 		if err == drivers.ErrHostIsNotRunning {
@@ -825,8 +926,11 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 		machineName:    name,
 		machineDir:     machineDir,
 		caCertPath:     caCert,
+		caKeyPath:      caKey,
 		clientCertPath: clientCert,
 		clientKeyPath:  clientKey,
+		serverCertPath: serverCert,
+		serverKeyPath:  serverKey,
 		machineUrl:     machineUrl,
 		swarmMaster:    machine.SwarmMaster,
 		swarmHost:      machine.SwarmHost,

--- a/docs/index.md
+++ b/docs/index.md
@@ -460,6 +460,16 @@ foo3            virtualbox   Running   tcp://192.168.99.108:2376
 foo4   *        virtualbox   Running   tcp://192.168.99.109:2376
 ```
 
+#### regenerate-certs
+
+Regenerate TLS certificates and update the machine with new certs.
+
+```
+$ docker-machine regenerate-certs
+Regenerate TLS machine certs?  Warning: this is irreversible. (y/n): y
+INFO[0013] Regenerating TLS certificates
+```
+
 #### restart
 
 Restart a machine.  Oftentimes this is equivalent to

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -384,10 +384,14 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) GetURL() (string, error) {
-	if d.IPAddress == "" {
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	if ip == "" {
 		return "", nil
 	}
-	return fmt.Sprintf("tcp://%s:%d", d.IPAddress, dockerPort), nil
+	return fmt.Sprintf("tcp://%s:%d", ip, dockerPort), nil
 }
 
 func (d *Driver) GetIP() (string, error) {

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -241,23 +240,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Info("Configuring Machine...")
-
-	log.Debugf("Setting hostname: %s", d.MachineName)
-	cmd, err := d.GetSSHCommand(fmt.Sprintf(
-		"echo \"127.0.0.1 %s\" | sudo tee -a /etc/hosts && sudo hostname %s && echo \"%s\" | sudo tee /etc/hostname",
-		d.MachineName,
-		d.MachineName,
-		d.MachineName,
-	))
-
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -354,57 +336,8 @@ func (d *Driver) Kill() error {
 	return err
 }
 
-func (d *Driver) StartDocker() error {
-	log.Debug("Starting Docker...")
-
-	cmd, err := d.GetSSHCommand("sudo service docker start")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (d *Driver) StopDocker() error {
-	log.Debug("Stopping Docker...")
-
-	cmd, err := d.GetSSHCommand("sudo service docker stop")
-	if err != nil {
-		return err
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (d *Driver) GetDockerConfigDir() string {
 	return dockerConfigDir
-}
-
-func (d *Driver) Upgrade() error {
-	log.Debugf("Upgrading Docker")
-
-	cmd, err := d.GetSSHCommand("sudo apt-get update && sudo apt-get install --upgrade lxc-docker")
-	if err != nil {
-		return err
-
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-
-	}
-
-	return cmd.Run()
-}
-
-func (d *Driver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
-	cmd := ssh.GetSSHCommand(d.IPAddress, 22, "root", d.sshKeyPath(), args...)
-	return cmd, nil
 }
 
 func (d *Driver) getClient() *godo.Client {

--- a/host.go
+++ b/host.go
@@ -610,6 +610,11 @@ func (h *Host) Start() error {
 	if err := h.Driver.Start(); err != nil {
 		return err
 	}
+
+	if err := h.SaveConfig(); err != nil {
+		return err
+	}
+
 	return utils.WaitFor(h.MachineInState(state.Running))
 }
 
@@ -617,6 +622,11 @@ func (h *Host) Stop() error {
 	if err := h.Driver.Stop(); err != nil {
 		return err
 	}
+
+	if err := h.SaveConfig(); err != nil {
+		return err
+	}
+
 	return utils.WaitFor(h.MachineInState(state.Stopped))
 }
 
@@ -624,6 +634,11 @@ func (h *Host) Kill() error {
 	if err := h.Driver.Stop(); err != nil {
 		return err
 	}
+
+	if err := h.SaveConfig(); err != nil {
+		return err
+	}
+
 	return utils.WaitFor(h.MachineInState(state.Stopped))
 }
 
@@ -631,15 +646,23 @@ func (h *Host) Restart() error {
 	if err := h.Stop(); err != nil {
 		return err
 	}
+
 	if err := utils.WaitFor(h.MachineInState(state.Stopped)); err != nil {
 		return err
 	}
+
 	if err := h.Start(); err != nil {
 		return err
 	}
+
 	if err := utils.WaitFor(h.MachineInState(state.Running)); err != nil {
 		return err
 	}
+
+	if err := h.SaveConfig(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -654,6 +677,11 @@ func (h *Host) Remove(force bool) error {
 			return err
 		}
 	}
+
+	if err := h.SaveConfig(); err != nil {
+		return err
+	}
+
 	return h.removeStorePath()
 }
 

--- a/host.go
+++ b/host.go
@@ -245,7 +245,7 @@ func (h *Host) StopDocker() error {
 
 	switch h.Driver.GetProviderType() {
 	case provider.Local:
-		cmd, err = h.GetSSHCommand("if [ -e /var/run/docker.pid ]; then sudo /etc/init.d/docker stop ; fi")
+		cmd, err = h.GetSSHCommand("if [ -e /var/run/docker.pid  ] && [ -d /proc/$(cat /var/run/docker.pid)  ]; then sudo /etc/init.d/docker stop ; exit 0; fi")
 	case provider.Remote:
 		cmd, err = h.GetSSHCommand("sudo service docker stop")
 	default:
@@ -364,7 +364,7 @@ func (h *Host) ConfigureAuth() error {
 	}
 	machineServerKeyPath := path.Join(dockerDir, "server-key.pem")
 
-	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(caCert), machineCaCertPath))
+	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(caCert), machineCaCertPath))
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (h *Host) ConfigureAuth() error {
 		return err
 	}
 
-	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(serverKey), machineServerKeyPath))
+	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverKey), machineServerKeyPath))
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func (h *Host) ConfigureAuth() error {
 		return err
 	}
 
-	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", string(serverCert), machineServerCertPath))
+	cmd, err = h.GetSSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverCert), machineServerCertPath))
 	if err != nil {
 		return err
 	}

--- a/test/integration/driver-amazonec2.bats
+++ b/test/integration/driver-amazonec2.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-azure.bats
+++ b/test/integration/driver-azure.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-digitalocean.bats
+++ b/test/integration/driver-digitalocean.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-google.bats
+++ b/test/integration/driver-google.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-hyperv.bats
+++ b/test/integration/driver-hyperv.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-rackspace.bats
+++ b/test/integration/driver-rackspace.bats
@@ -67,7 +67,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-softlayer.bats
+++ b/test/integration/driver-softlayer.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -93,7 +93,6 @@ function setup() {
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -105,7 +104,6 @@ function setup() {
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-vmwarefusion.bats
+++ b/test/integration/driver-vmwarefusion.bats
@@ -83,7 +83,6 @@ function setup() {
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -95,7 +94,6 @@ function setup() {
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/test/integration/driver-vmwarevcloudair.bats
+++ b/test/integration/driver-vmwarevcloudair.bats
@@ -78,7 +78,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show stopped after kill" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
@@ -90,7 +89,6 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
 @test "$DRIVER: machine should show running after restart" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 

--- a/utils/certs.go
+++ b/utils/certs.go
@@ -192,7 +192,11 @@ func ValidateCertificate(addr, caCertPath, serverCertPath, serverKeyPath string)
 		return false, err
 	}
 
-	_, err = tls.Dial("tcp", addr, tlsConfig)
+	dialer := &net.Dialer{
+		Timeout: time.Second * 2,
+	}
+
+	_, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
 	if err != nil {
 		return false, nil
 	}

--- a/utils/certs.go
+++ b/utils/certs.go
@@ -7,11 +7,32 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
 	"time"
 )
+
+func getTLSConfig(caCert, cert, key []byte, allowInsecure bool) (*tls.Config, error) {
+	// TLS config
+	var tlsConfig tls.Config
+	tlsConfig.InsecureSkipVerify = allowInsecure
+	certPool := x509.NewCertPool()
+
+	certPool.AppendCertsFromPEM(caCert)
+	tlsConfig.RootCAs = certPool
+	keypair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return &tlsConfig, err
+	}
+	tlsConfig.Certificates = []tls.Certificate{keypair}
+	if allowInsecure {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	return &tlsConfig, nil
+}
 
 func newCertificate(org string) (*x509.Certificate, error) {
 	now := time.Now()
@@ -148,4 +169,33 @@ func GenerateCert(hosts []string, certFile, keyFile, caFile, caKeyFile, org stri
 	keyOut.Close()
 
 	return nil
+}
+
+func ValidateCertificate(addr, caCertPath, serverCertPath, serverKeyPath string) (bool, error) {
+	caCert, err := ioutil.ReadFile(caCertPath)
+	if err != nil {
+		return false, err
+	}
+
+	serverCert, err := ioutil.ReadFile(serverCertPath)
+	if err != nil {
+		return false, err
+	}
+
+	serverKey, err := ioutil.ReadFile(serverKeyPath)
+	if err != nil {
+		return false, err
+	}
+
+	tlsConfig, err := getTLSConfig(caCert, serverCert, serverKey, false)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = tls.Dial("tcp", addr, tlsConfig)
+	if err != nil {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/utils/certs_test.go
+++ b/utils/certs_test.go
@@ -12,6 +12,8 @@ func TestGenerateCACertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// cleanup
+	defer os.RemoveAll(tmpDir)
 
 	os.Setenv("MACHINE_DIR", tmpDir)
 	caCertPath := filepath.Join(tmpDir, "ca.pem")
@@ -29,9 +31,6 @@ func TestGenerateCACertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Setenv("MACHINE_DIR", "")
-
-	// cleanup
-	_ = os.RemoveAll(tmpDir)
 }
 
 func TestGenerateCert(t *testing.T) {
@@ -39,6 +38,8 @@ func TestGenerateCert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// cleanup
+	defer os.RemoveAll(tmpDir)
 
 	os.Setenv("MACHINE_DIR", tmpDir)
 	caCertPath := filepath.Join(tmpDir, "ca.pem")
@@ -70,7 +71,4 @@ func TestGenerateCert(t *testing.T) {
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("key not created at %s", keyPath)
 	}
-
-	// cleanup
-	_ = os.RemoveAll(tmpDir)
 }


### PR DESCRIPTION
This depends on #756.

This will check the remote host when using `config` and `env` commands to see if the remote certificate is valid.  If not, it will automatically regenerate new certs and re-configure the engine to use them.

This also implements the `regenerate-certs` command from #702 against the new driver refactor.

Fixes #531