### PR TITLE
Use DOCKER_HOST for active host instead of file

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -350,9 +350,11 @@ func TestCmdConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := store.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
+	url, err := host.Driver.GetURL()
+	if err != nil {
+		t.Fatal(err)
 	}
+	os.Setenv("DOCKER_HOST", url)
 
 	outStr := make(chan string)
 
@@ -452,9 +454,11 @@ func TestCmdEnvBash(t *testing.T) {
 		t.Fatalf("error loading host: %v", err)
 	}
 
-	if err := mcn.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
+	url, err := host.Driver.GetURL()
+	if err != nil {
+		t.Fatal(err)
 	}
+	os.Setenv("DOCKER_HOST", url)
 
 	outStr := make(chan string)
 
@@ -550,9 +554,11 @@ func TestCmdEnvFish(t *testing.T) {
 		t.Fatalf("error loading host: %v", err)
 	}
 
-	if err := mcn.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
+	url, err := host.Driver.GetURL()
+	if err != nil {
+		t.Fatal(err)
 	}
+	os.Setenv("DOCKER_HOST", url)
 
 	outStr := make(chan string)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ INFO[0011] Creating SSH key...
 INFO[0012] Creating VirtualBox VM...
 INFO[0019] Starting VirtualBox VM...
 INFO[0020] Waiting for VM to start...
-INFO[0053] "dev" has been created and is now the active machine.
+INFO[0053] "dev" has been created.
 INFO[0053] To point your Docker client at it, run this in your shell: eval "$(docker-machine env dev)"
 ```
 
@@ -84,10 +84,8 @@ again:
 ```
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL                         SWARM
-dev    *        virtualbox   Running   tcp://192.168.99.100:2376
+dev             virtualbox   Running   tcp://192.168.99.100:2376
 ```
-
-The `*` next to `dev` indicates that it is the active host.
 
 Next, as noted in the output of the `docker-machine create` command, we have to tell
 Docker to talk to that machine.  You can do this with the `docker-machine env`
@@ -193,7 +191,7 @@ $ docker-machine create \
 INFO[0000] Creating SSH key...
 INFO[0000] Creating Digital Ocean droplet...
 INFO[0002] Waiting for SSH...
-INFO[0085] "staging" has been created and is now the active machine
+INFO[0085] "staging" has been created.
 INFO[0085] To point your Docker client at it, run this in your shell: eval "$(docker-machine env staging)"
 ```
 
@@ -213,7 +211,14 @@ will be installed on the remote machine and the daemon will be configured to
 accept remote connections over TCP using TLS for authentication.  Once this
 is finished, the host is ready for connection.
 
-And then from this point, the remote host behaves much like the local host we
+To prepare the Docker client to send connections to the remote server we have
+created, we can use the subshell method again:
+
+```
+$ eval "$(docker-machine env staging)"
+```
+
+From this point, the remote host behaves much like the local host we
 created in the last section. If we look at `docker-machine`, we’ll see it is now the
 active host:
 
@@ -223,16 +228,6 @@ $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL
 dev                virtualbox     Running   tcp://192.168.99.103:2376
 staging   *        digitalocean   Running   tcp://104.236.50.118:2376
-```
-
-To select an active host, you can use the `docker-machine active` command.
-
-```
-$ docker-machine active dev
-$ docker-machine ls
-NAME      ACTIVE   DRIVER         STATE     URL
-dev       *        virtualbox     Running   tcp://192.168.99.103:2376
-staging            digitalocean   Running   tcp://104.236.50.118:2376
 ```
 
 To remove a host and all of its containers and images, use `docker-machine rm`:
@@ -344,14 +339,15 @@ Nodes: 1
 
 #### active
 
-Get or set the active machine.
+See which machine is "active" (a machine is active if the `DOCKER_HOST`
+environment variable points to it).
 
 ```
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL
 dev                virtualbox     Running   tcp://192.168.99.103:2376
 staging   *        digitalocean   Running   tcp://104.236.50.118:2376
-$ docker-machine active dev
+$ eval "$(docker-machine env staging)"
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL
 dev       *        virtualbox     Running   tcp://192.168.99.103:2376
@@ -369,7 +365,7 @@ INFO[0000] Creating SSH key...
 INFO[0000] Creating VirtualBox VM...
 INFO[0007] Starting VirtualBox VM...
 INFO[0007] Waiting for VM to start...
-INFO[0038] "dev" has been created and is now the active machine.
+INFO[0038] "dev" has been created.
 INFO[0038] To point your Docker client at it, run this in your shell: eval "$(docker-machine env dev)"
 ```
 

--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -2,6 +2,7 @@ package libmachine
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -111,39 +112,20 @@ func (s Filestore) Get(name string) (*Host, error) {
 }
 
 func (s Filestore) GetActive() (*Host, error) {
-	hostName, err := ioutil.ReadFile(s.activePath())
-	if os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
+	hosts, err := s.List()
+	if err != nil {
 		return nil, err
 	}
-	return s.Get(string(hostName))
-}
-
-func (s Filestore) IsActive(host *Host) (bool, error) {
-	active, err := s.GetActive()
-	if err != nil {
-		return false, err
+	dockerHost := os.Getenv("DOCKER_HOST")
+	for _, host := range hosts {
+		url, err := host.Driver.GetURL()
+		if err != nil {
+			return nil, err
+		}
+		if dockerHost == url {
+			return host, nil
+		}
 	}
-	if active == nil {
-		return false, nil
-	}
-	return active.Name == host.Name, nil
-}
 
-func (s Filestore) SetActive(host *Host) error {
-	if err := os.MkdirAll(filepath.Dir(s.activePath()), 0700); err != nil {
-		return err
-	}
-	return ioutil.WriteFile(s.activePath(), []byte(host.Name), 0600)
-}
-
-func (s Filestore) RemoveActive() error {
-	return os.Remove(s.activePath())
-}
-
-// activePath returns the path to the file that stores the name of the
-// active host
-func (s Filestore) activePath() string {
-	return filepath.Join(utils.GetMachineDir(), ".active")
+	return nil, errors.New("Active host not found")
 }

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -195,8 +195,8 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	// No hosts set
 	host, err := store.GetActive()
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("Should have gotten an error since there's no active host set")
 	}
 
 	if host != nil {
@@ -215,9 +215,12 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	originalHost := host
 
-	if err := store.SetActive(originalHost); err != nil {
+	url, err := originalHost.Driver.GetURL()
+	if err != nil {
 		t.Fatal(err)
 	}
+
+	os.Setenv("DOCKER_HOST", url)
 
 	host, err = store.GetActive()
 	if err != nil {
@@ -225,26 +228,5 @@ func TestStoreGetSetActive(t *testing.T) {
 	}
 	if host.Name != host.Name {
 		t.Fatalf("Active host is not 'test', got %s", host.Name)
-	}
-	isActive, err := store.IsActive(host)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if isActive != true {
-		t.Fatal("IsActive: Active host is not test")
-	}
-
-	// remove active host altogether
-	if err := store.RemoveActive(); err != nil {
-		t.Fatal(err)
-	}
-
-	host, err = store.GetActive()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if host != nil {
-		t.Fatalf("Active host %s is not nil", host.Name)
 	}
 }

--- a/libmachine/machine.go
+++ b/libmachine/machine.go
@@ -60,10 +60,6 @@ func (m *Machine) Create(name string, driverName string, hostOptions *HostOption
 		return host, err
 	}
 
-	if err := m.store.SetActive(host); err != nil {
-		return nil, err
-	}
-
 	return host, nil
 }
 
@@ -75,10 +71,6 @@ func (m *Machine) GetActive() (*Host, error) {
 	return m.store.GetActive()
 }
 
-func (m *Machine) IsActive(host *Host) (bool, error) {
-	return m.store.IsActive(host)
-}
-
 func (m *Machine) List() ([]*Host, error) {
 	return m.store.List()
 }
@@ -88,17 +80,6 @@ func (m *Machine) Get(name string) (*Host, error) {
 }
 
 func (m *Machine) Remove(name string, force bool) error {
-	active, err := m.store.GetActive()
-	if err != nil {
-		return err
-	}
-
-	if active != nil && active.Name == name {
-		if err := m.RemoveActive(); err != nil {
-			return err
-		}
-	}
-
 	host, err := m.store.Get(name)
 	if err != nil {
 		return err
@@ -109,12 +90,4 @@ func (m *Machine) Remove(name string, force bool) error {
 		}
 	}
 	return m.store.Remove(name, force)
-}
-
-func (m *Machine) RemoveActive() error {
-	return m.store.RemoveActive()
-}
-
-func (m *Machine) SetActive(host *Host) error {
-	return m.store.SetActive(host)
 }

--- a/libmachine/store.go
+++ b/libmachine/store.go
@@ -11,18 +11,12 @@ type Store interface {
 	GetCACertificatePath() (string, error)
 	// GetPrivateKeyPath returns the private key
 	GetPrivateKeyPath() (string, error)
-	// IsActive returns whether the host is active or not
-	IsActive(host *Host) (bool, error)
 	// List returns a list of hosts
 	List() ([]*Host, error)
 	// Load loads a host by name
 	Get(name string) (*Host, error)
 	// Remove removes a machine from the store
 	Remove(name string, force bool) error
-	// RemoveActive removes the active machine from the store
-	RemoveActive() error
 	// Save persists a machine in the store
 	Save(host *Host) error
-	// SetActive sets the specified host as the active host
-	SetActive(host *Host) error
 }

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -43,8 +43,8 @@ buildMachineWithOldIsoCheckUpgrade() {
 }
 
 @test "$DRIVER: machine should not exist" {
-  run machine active $NAME
-  [ "$status" -eq 1  ]
+  run machine ls
+  [ ${#lines[@]} -eq 1 ]
 }
 
 @test "$DRIVER: VM should not exist" {
@@ -58,8 +58,9 @@ buildMachineWithOldIsoCheckUpgrade() {
 }
 
 @test "$DRIVER: active" {
-  run machine active $NAME
-  [ "$status" -eq 0  ]
+  export DOCKER_HOST=$(machine url $NAME)
+  run machine active
+  [ "$output" = "$NAME" ]
 }
 
 @test "$DRIVER: check default machine memory size" {


### PR DESCRIPTION
This method of tracking the "active" host for machine simply checks which machine is set in `DOCKER_HOST`.

If `DOCKER_HOST` is set to point to an address which is registered with `docker-machine`, the `*` will appear next to the respective machine.

This means that:

![screen shot 2015-03-12 at 5 07 03 pm](https://cloud.githubusercontent.com/assets/1476820/6631435/8dbae88c-c8e3-11e4-984e-cd5babc4916a.png)

_It Just Works_

Interestingly, this implementation prevents the kinds of issues where users attempt to run commands against the active host when there isn't one, since it will simply error out if a user attempts a command of this style instead of trying to go forward (and probably panicing).

## Concerns

- `docker-machine stop` (without arguments, thereby indicating the active host) works out of the box with this method, because it recognizes the active host as the one to stop, but `docker-machine start` does not work with some drivers such as VBox which expect the machine to be up in order to retrieve the IP address.  It forces specificity in this case.
- This causes an additional call to `GetURL` per-goroutine in `ls` (since each goroutine calls to check if it is the active host), which may have (probably minor) performance implications for drivers which actually perform remote operations to get the URL such as VBox.  Most, AFAICT, just grab the "cached" value if it is around (they shouldn't, really; it might change- but that's for another PR).
- I couldn't really figure out how to integration test this (perhaps my own shortcoming, but I am not sure if `bats` messes with environment variables in unexpected ways), and may have missed removing some of those tests, so PTAL.

props to @tiborvass for the idea

cc @ehazlett @bfirsh @sthulb 