### PR TITLE
Set the User-Agent for OpenStack and Rackspace drivers

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -2,9 +2,11 @@ package openstack
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/machine/version"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
@@ -415,6 +417,8 @@ func (c *GenericClient) Authenticate(d *Driver) error {
 	if err != nil {
 		return err
 	}
+
+	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%s", version.VERSION))
 
 	if d.Insecure {
 		// Configure custom TLS settings.

--- a/drivers/rackspace/client.go
+++ b/drivers/rackspace/client.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/machine/drivers/openstack"
+	"github.com/docker/machine/version"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/rackspace"
 )
@@ -36,10 +37,18 @@ func (c *Client) Authenticate(d *openstack.Driver) error {
 		APIKey:   apiKey,
 	}
 
-	provider, err := rackspace.AuthenticatedClient(opts)
+	provider, err := rackspace.NewClient(rackspace.RackspaceUSIdentity)
 	if err != nil {
 		return err
 	}
+
+	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%s", version.VERSION))
+
+	err = rackspace.Authenticate(provider, opts)
+	if err != nil {
+		return err
+	}
+
 	c.Provider = provider
 
 	return nil


### PR DESCRIPTION
This will be helpful for identifying requests made with `docker-machine` from server logs, to determine how heavily it's used, what versions are most common, and other interesting statistics.