### PR TITLE
First attempt at docker-machine share

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -302,7 +302,7 @@ var Commands = []cli.Command{
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "driver",
-				Usage: "Type of share to create.  Options: vboxsf",
+				Usage: "Type of share to create.  Options: vboxsf, nfs",
 			},
 			cli.StringFlag{
 				Name:  "with",
@@ -815,13 +815,9 @@ func cmdShare(c *cli.Context) {
 		Options: newShare.GetOptions(),
 	})
 
-	// TODO: Is this an appropriate place for this?
-	if err := host.SaveConfig(); err != nil {
-		log.Fatal("There was an error saving the new configuration: %s", err)
-	}
-
+	// Run the host start to mount the new share
 	if err := host.Start(); err != nil {
-		log.Fatal("Error starting host after creating share: %s", err)
+		log.Fatalf("Error starting host after creating share: %s", err)
 	}
 
 	log.Infof("Share created successfully at %s", absSharePath)

--- a/drivers/virtualbox/vbm.go
+++ b/drivers/virtualbox/vbm.go
@@ -54,6 +54,10 @@ func setVBoxManageCmd() string {
 	return cmd
 }
 
+func Vbm(args ...string) error {
+	return vbm(args...)
+}
+
 func vbm(args ...string) error {
 	_, _, err := vbmOutErr(args...)
 	return err

--- a/script/build
+++ b/script/build
@@ -13,6 +13,6 @@ else
     OS_ARCH_ARG=($2)
 fi
 
-docker build -t docker-machine .
+#docker build -t docker-machine .
 rm -f docker-machine*
 exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}" -ldflags="-w -X github.com/docker/machine/version.GITCOMMIT `git rev-parse --short HEAD`"

--- a/share/nfs.go
+++ b/share/nfs.go
@@ -64,7 +64,7 @@ func (ns NfsSharedFolder) Create(d drivers.Driver) error {
 	case "darwin":
 		tmpl, err = template.New("export").Parse(`
 # docker-machine-begin-{{.Name}}-{{.Options.Name}}
-{{.Options.SrcPath}} -alldirs -mapall=root:wheel -network 192.168.99.0 -mask 255.255.255.0
+{{.Options.SrcPath}} -alldirs -maproot=root:wheel -network 192.168.99.0 -mask 255.255.255.0
 # docker-machine-end-{{.Name}}-{{.Options.Name}}
 `)
 

--- a/share/nfs.go
+++ b/share/nfs.go
@@ -1,0 +1,128 @@
+package share
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"text/template"
+
+	"github.com/docker/machine/drivers"
+)
+
+type NfsSharedFolder struct {
+	Options ShareOptions
+}
+
+type EtcExportsTemplateContext struct {
+	Name    string
+	Options ShareOptions
+}
+
+func (ns NfsSharedFolder) ContractFulfilled(d drivers.Driver) (bool, error) {
+	switch runtime.GOOS {
+	case "windows":
+		return false, errors.New("The NFS share driver is not supported on Windows")
+	case "darwin":
+		nfsdPath, err := exec.LookPath("nfsd")
+		if err != nil || nfsdPath == "" {
+			return false, fmt.Errorf("nfsd not found locally: %s", err)
+		}
+	case "linux":
+		// TODO: lol this is probably bad
+		cmd := exec.Command("sudo", "modprobe", "nfs")
+		if err := cmd.Run(); err != nil {
+			return false, fmt.Errorf("Seems that the NFS module is not installed locally: %s", err)
+		}
+	}
+
+	// TODO
+	/*
+		provisioner, err := provision.DetectProvisioner(d)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := provisioner.(provision.Boot2DockerProvisioner); !ok {
+			return false, errors.New("NFS share driver only supported with local VMs using boot2docker")
+		}
+	*/
+
+	return true, nil
+}
+
+func (ns NfsSharedFolder) Create(d drivers.Driver) error {
+	var (
+		buf            bytes.Buffer
+		tmpl           *template.Template
+		err            error
+		nfsdRestartCmd *exec.Cmd
+	)
+
+	switch runtime.GOOS {
+	case "darwin":
+		tmpl, err = template.New("export").Parse(`
+# docker-machine-begin-{{.Name}}-{{.Options.Name}}
+{{.Options.SrcPath}} -alldirs -mapall=root:wheel -network 192.168.99.0 -mask 255.255.255.0
+# docker-machine-end-{{.Name}}-{{.Options.Name}}
+`)
+
+		if err != nil {
+			return err
+		}
+		nfsdRestartCmd = exec.Command("sudo", "nfsd", "restart")
+	case "linux":
+		tmpl, err = template.New("export").Parse(`
+# docker-machine-begin-{{.Name}}-{{.Options.Name}}
+{{.Options.SrcPath}} 192.168.99.0/24(rw,no_root_squash,no_subtree_check)
+# docker-machine-end-{{.Name}}-{{.Options.Name}}
+`)
+		if err != nil {
+			return err
+		}
+		nfsdRestartCmd = exec.Command("sudo", "systemctl", "restart", "nfs-kernel-server")
+	}
+	tmplContext := EtcExportsTemplateContext{
+		Name:    d.GetMachineName(),
+		Options: ns.Options,
+	}
+
+	if err := tmpl.Execute(&buf, tmplContext); err != nil {
+		return err
+	}
+
+	appendCmd := exec.Command("sudo", "tee", "-a", "/etc/exports")
+	appendCmd.Stdin = &buf
+
+	if err := appendCmd.Run(); err != nil {
+		return err
+	}
+
+	if err := nfsdRestartCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ns NfsSharedFolder) Mount(d drivers.Driver) error {
+	cmdFmtString := "sudo mkdir -p %s && sudo mount -t nfs -o vers=3,nolock,udp 192.168.99.1:%s %s"
+	cmd, err := drivers.GetSSHCommandFromDriver(d, fmt.Sprintf(cmdFmtString, ns.Options.SrcPath, ns.Options.SrcPath, ns.Options.DestPath))
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ns NfsSharedFolder) Destroy(d drivers.Driver) error {
+	// TODO
+	return nil
+}
+
+func (ns NfsSharedFolder) GetOptions() ShareOptions {
+	return ns.Options
+}

--- a/share/share.go
+++ b/share/share.go
@@ -1,0 +1,63 @@
+package share
+
+import (
+	"fmt"
+
+	dockerutils "github.com/docker/docker/utils"
+	"github.com/docker/machine/drivers"
+)
+
+type ShareOptions struct {
+	Name              string
+	Type              string
+	SrcPath, DestPath string
+	SrcUid, DestUid   int
+	SrcGid, DestGid   int
+}
+
+type Share interface {
+	ContractFulfilled(d drivers.Driver) (bool, error)
+	Create(d drivers.Driver) error
+	Mount(d drivers.Driver) error
+	Destroy(d drivers.Driver) error
+	GetOptions() ShareOptions
+}
+
+type ShareWithType struct {
+	Options ShareOptions
+}
+
+func ParseShares(shares []ShareWithType) []Share {
+	parsedShares := []Share{}
+	for _, s := range shares {
+		parsedShares = append(parsedShares, NewShareWithOptions(s.Options))
+	}
+	return parsedShares
+}
+
+func NewShareWithOptions(options ShareOptions) Share {
+	switch options.Type {
+	case "vboxsf":
+		return VBoxSharedFolder{
+			Options: options,
+		}
+	}
+	return nil
+}
+
+func NewShare(shareType, absPath string) (Share, error) {
+	switch shareType {
+	case "vboxsf":
+		return VBoxSharedFolder{
+			Options: ShareOptions{
+				Name:     dockerutils.GenerateRandomID(),
+				DestUid:  1000,
+				DestGid:  50,
+				SrcPath:  absPath,
+				DestPath: absPath,
+				Type:     "vboxsf",
+			},
+		}, nil
+	}
+	return nil, fmt.Errorf("Driver type not recognized: %s", shareType)
+}

--- a/share/share.go
+++ b/share/share.go
@@ -2,6 +2,7 @@ package share
 
 import (
 	"fmt"
+	"syscall"
 
 	dockerutils "github.com/docker/docker/utils"
 	"github.com/docker/machine/drivers"
@@ -41,6 +42,10 @@ func NewShareWithOptions(options ShareOptions) Share {
 		return VBoxSharedFolder{
 			Options: options,
 		}
+	case "nfs":
+		return NfsSharedFolder{
+			Options: options,
+		}
 	}
 	return nil
 }
@@ -51,11 +56,24 @@ func NewShare(shareType, absPath string) (Share, error) {
 		return VBoxSharedFolder{
 			Options: ShareOptions{
 				Name:     dockerutils.GenerateRandomID(),
+				SrcUid:   syscall.Getuid(),
 				DestUid:  1000,
 				DestGid:  50,
 				SrcPath:  absPath,
 				DestPath: absPath,
 				Type:     "vboxsf",
+			},
+		}, nil
+	case "nfs":
+		return NfsSharedFolder{
+			Options: ShareOptions{
+				Name:     dockerutils.GenerateRandomID(),
+				SrcUid:   syscall.Getuid(),
+				DestUid:  1000,
+				DestGid:  50,
+				SrcPath:  absPath,
+				DestPath: absPath,
+				Type:     "nfs",
 			},
 		}, nil
 	}

--- a/share/vboxsf.go
+++ b/share/vboxsf.go
@@ -1,0 +1,96 @@
+package share
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/machine/drivers"
+	vbox "github.com/docker/machine/drivers/virtualbox"
+)
+
+type VBoxSharedFolder struct {
+	Options ShareOptions
+}
+
+func (sf VBoxSharedFolder) ContractFulfilled(d drivers.Driver) (bool, error) {
+	if d.DriverName() != "virtualbox" {
+		return false, nil
+	}
+	cmd, err := drivers.GetSSHCommandFromDriver(d, "lsmod | grep -i vbox")
+	if err != nil {
+		return false, err
+	}
+	if err := cmd.Run(); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (sf VBoxSharedFolder) Create(d drivers.Driver) error {
+	log.Info("Stopping machine to create the share...")
+
+	if err := d.Stop(); err != nil {
+		return fmt.Errorf("Error stopping the VM: %s")
+	}
+
+	// let VBoxService do nice magic automounting (when it's used)
+	if err := vbox.Vbm("guestproperty", "set", d.GetMachineName(), "/VirtualBox/GuestAdd/SharedFolders/MountPrefix", "/"); err != nil {
+		return err
+	}
+	if err := vbox.Vbm("guestproperty", "set", d.GetMachineName(), "/VirtualBox/GuestAdd/SharedFolders/MountDir", "/"); err != nil {
+		return err
+	}
+
+	if sf.Options.SrcPath != "" {
+		if _, err := os.Stat(sf.Options.SrcPath); err != nil && !os.IsNotExist(err) {
+			return err
+		} else if !os.IsNotExist(err) {
+			if sf.Options.Name == "" {
+				// parts of the VBox internal code are buggy with share names that start with "/"
+				sf.Options.Name = strings.TrimLeft(sf.Options.SrcPath, "/")
+				// TODO do some basic Windows -> MSYS path conversion
+				// ie, s!^([a-z]+):[/\\]+!\1/!; s!\\!/!g
+			}
+
+			// woo, sf.Options.SrcPath exists!  let's carry on!
+			if err := vbox.Vbm("sharedfolder", "add", d.GetMachineName(), "--name", sf.Options.Name, "--hostpath", sf.Options.SrcPath, "--automount"); err != nil {
+				return err
+			}
+
+			// enable symlinks
+			if err := vbox.Vbm("setextradata", d.GetMachineName(), "VBoxInternal2/SharedFoldersEnableSymlinksCreate/"+sf.Options.Name, "1"); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := d.Start(); err != nil {
+		return fmt.Errorf("Error starting the VM: %s")
+	}
+
+	return nil
+}
+
+func (sf VBoxSharedFolder) Mount(d drivers.Driver) error {
+	cmdFmtString := "sudo mkdir -p %s && sudo mount -t vboxsf -o uid=%d,gid=%d %s %s"
+	mountCmd := fmt.Sprintf(cmdFmtString, sf.Options.SrcPath, sf.Options.DestUid, sf.Options.DestGid, sf.Options.Name, sf.Options.SrcPath)
+	cmd, err := drivers.GetSSHCommandFromDriver(d, mountCmd)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sf VBoxSharedFolder) Destroy(d drivers.Driver) error {
+	// lol how do I do this
+	return nil
+}
+
+func (sf VBoxSharedFolder) GetOptions() ShareOptions {
+	return sf.Options
+}


### PR DESCRIPTION
cc @bfirsh @ehazlett @sthulb @SvenDowideit @tianon

Hi, this is nowhere near complete, but I wanted to show what I have done so far so we can talk about it, explain the motivations, and hopefully then we can move forward with a clean and clear design.

### Motivation

This has been discussed ad nauseum, so I won't rehash too much, but rather summarize quickly.

The only currently supported method for sharing folders between machine host and created machines is to auto-mount `/Users` as a VirtualBox shared folder in the boot2docker VM.  This has some issues:

1. __Performance.__  NFS looks really tempting compared to vboxsf.  See Mitchell's article, anecdata, etc.  
2. __Security.__  One of the biggest advantages of running Docker in a VM is that it de-fangs random images you pull and run over the Internet.  It doesn't completely mitigate the risk, but it certainly does help.  Right now users are just one mis-copied or mis-typed command away from having their account credentials, private SSH keys, and more stolen by malicious images.  Limiting the shares to very specific sub-paths on the host system will help with this.  I know that the party line with the current method is "the risk is the same as running Docker natively", it doesn't persuade me that we shouldn't try to do better if we can.
3.  __Flexibility.__  The current method works with boot2docker because of the init script baked into the ISO, but no such guarantees are made if the VM was just a vanilla Ubuntu image.  There's no easy obvious way to share between your host and a cloud provider.  Likewise, there is no common interface to use other options such as SSHFS, SFTP, NFS etc.  Users aren't waiting for us on this and are concocting their own homebrew solutions.  Debugging things will be hard if there's no officially supported way, here we at least will have logs and information available in `inspect`.
4.  __UID / GID mapping.__  Right now if the users are mounting volumes into the containers which use non-root users, they are kind of hosed in terms of actually being able to flexibly read and write to/from those files unless they want to roll their own (share) mounting layer.  A common interface could help us to cover some of those cases for users so they can specify UID mappings much more conveniently if need be.
5.  __Reuse__.  Goal should be to prevent projects like Kitematic or Rancher from having to implement their own custom logic to do this kind of thing if they want to expose such functionality to users.

This is a continuation of the before-mentioned `docker-machine share` proposal: https://github.com/docker/machine/issues/179.

### Implementation

So far, just to get something together, I've just done VBox shared folders, and need some help on the design for making this a more generic interface.

Example usage with this PR:

```console
$ ./docker-machine_darwin-amd64 -D create -d virtualbox share-demo
... Machine create output ...

$ ./docker-machine_darwin-amd64 share --with share-demo --driver vboxsf .
INFO[0005] Waiting for VM to start...
INFO[0037] Share created successfully at /Users/nathanleclaire/go/src/github.com/docker/machine

$ ./docker-machine_darwin-amd64 inspect share-demo
{
    "DriverName": "virtualbox",
    "Driver": {
        "MachineName": "share-demo",
        "SSHUser": "docker",
        "SSHPort": 61063,
        "Memory": 1024,
        "DiskSize": 20000,
        "Boot2DockerURL": "",
        "CaCertPath": "/Users/nathanleclaire/.docker/machine/certs/ca.pem",
        "PrivateKeyPath": "/Users/nathanleclaire/.docker/machine/certs/ca-key.pem",
        "Shares": [
            {
                "Name": "cbdad6227294b5ae09248b88ecf70a392c56edacc95bfcd68b189eb3281410ca",
                "Path": "/Users/nathanleclaire/go/src/github.com/docker/machine",
                "Uid": 1000,
                "Gid": 50
            }
        ],
        "SwarmMaster": false,
        "SwarmHost": "tcp://0.0.0.0:3376",
        "SwarmDiscovery": ""
    },
    "CaCertPath": "/Users/nathanleclaire/.docker/machine/certs/ca.pem",
    "ServerCertPath": "",
    "ServerKeyPath": "",
    "PrivateKeyPath": "/Users/nathanleclaire/.docker/machine/certs/ca-key.pem",
    "ClientCertPath": "",
    "SwarmMaster": false,
    "SwarmHost": "tcp://0.0.0.0:3376",
    "SwarmDiscovery": ""
}

$ # No more homedir secrets in the b2d VM!
$ ./docker-machine_darwin-amd64 ssh share-demo -- cat /Users/$(whoami)/.ssh/id_rsa
cat: can't open '/Users/nathanleclaire/.ssh/id_rsa': No such file or directory
FATA[0000] exit status 1

$ ./docker-machine_darwin-amd64 ssh share-demo -- ls /Users/$(whoami)/go/src/github.com/docker/machine
CHANGES.md
CONTRIBUTING.md
Dockerfile
Godeps
LICENSE
MAINTAINERS
Makefile
README.md
ROADMAP.md
commands.go
commands_test.go
creds
docker-machine_darwin-amd64
docs
drivers
host.go
host_test.go
ignore
imports_windows.go
integration-tests
log.go
main.go
provider
script
share
ssh
state
store.go
store_test.go
test
utils
version.go
```

The code is kind of fun; essentially, in `cmdShare` I check to see if the driver fulfills the `DriverWithShares` interface.  If it doesn't (every driver except VBox), I error out, but if it does, we go ahead and create the share.  This requires us to do things like stopping and starting the machine, which is why in the proposed interface in the next section you pass in the `Driver` to some of the commands.

### Future

Instead of having things sort-of-hardcoded like I do now, I think that where I'd like to move is to have a `type Share interface` which provides all the methods needed to create and maintain the share throughout a machine's lifecycle.  Then there would be `type VboxsfShare struct`, `type NfsShare struct`, etc. which would all be managed through common code.

E.g.:

```go
type DriverWithShares interface {
    GetShares() ([]*Share, error)
}

type ShareOptions struct {
    Name, SrcPath, DestPath string
    SrcUid, SrcGid, DestUid, DestGid int
}

type Share interface {
    ContractFulfilled(d Driver) bool
    Create(d Driver, options ShareOptions) error
    Name() string
    Mount(d Driver)
    Destroy(d Driver) error
}
```

`ContractFulfilled` would check to see if the share can actually be created / used.  "Are the Guest Additions installed?  Is NFS installed?" etc.

`Host`'s `Start` method would be extended slightly to support doing the mounts at start time:

```go
func (h *Host) Start() error {
    if err := h.Driver.Start(); err != nil {
        return err
    }
    // wait for SSH
    if shareDriver, ok := h.Driver.(DriverWithShares); ok {
        shares, err := shareDriver.GetShares()
        if err != nil {
            return err
        }
        for _, share := range shares {
            if err := share.Mount(shareDriver); err != nil {
                log.Warn("Error mounting a share (%s): %s", share.Name(), err)
            }
        }
    }
    return nil
}
```

This isn't _super_ elegant (the problem is really hairy all around), but it'd be a start.

Instead of trying to jump into supporting shares on all drivers all at once, we could do them piecemeal by slowly implementing the `DriverWithShares` interface on a per-driver basis.  That way, we could start with getting the basic idea right for local drivers (easier) and expand the reach gradually.  Hopefully this can help with some of the concern over bringing them to remote providers as well: if it turns out that we're happy with just the local versions, then no need to implement the interface for the remaining drivers.

I really want to enable a mechanism whereby this kind of thing can be done:

```console
$ docker-machine share --with foomachine --driver vboxsf --uidmap $(whoami):apache .
```

To relieve the pain of users who cannot use our current method because their container runs as a non-root user (which, it should be noted, is a security best practice that we should be promoting heavily).

All this type of thing could be added to the proposed [declarative syntax](https://github.com/docker/machine/issues/773) as well.

### Clarifications

- I've waffled before on whether I want this in `docker-machine` or in a separate tool, I think that unless proven otherwise having another tool would just be too much overhead and for convenience it should just all go in one tool (machine) for now.
- I am in favor of a separate `docker-machine scp` command which would handle both `scp` and `rsync` to machines under management separately from these kinds of "two-way" shares.
- I just assume that path on the host will be the same as the path in the machine, which is good for "transparent" use of `-v`, but that won't necessarily
- I might put together a demo NFS and/or SSHFS share driver if there's interest.