### PR TITLE
Add "eval" to every invocation of "docker-machine env"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ INFO[0000] Creating VirtualBox VM...
 INFO[0007] Starting VirtualBox VM...
 INFO[0007] Waiting for VM to start...
 INFO[0041] "dev" has been created and is now the active machine.
-INFO[0041] To point your Docker client at it, run this in your shell: $(docker-machine env dev)
+INFO[0041] To point your Docker client at it, run this in your shell: eval "$(docker-machine env dev)"
 
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL                         SWARM
 dev    *        virtualbox   Running   tcp://192.168.99.127:2376
 
-$ $(docker-machine env dev)
+$ eval "$(docker-machine env dev)"
 
 $ docker run busybox echo hello world
 Unable to find image 'busybox:latest' locally
@@ -35,7 +35,7 @@ INFO[0001] Creating Digital Ocean droplet...
 INFO[0002] Waiting for SSH...
 INFO[0070] Configuring Machine...
 INFO[0109] "staging" has been created and is now the active machine.
-INFO[0109] To point your Docker client at it, run this in your shell: $(docker-machine env staging)
+INFO[0109] To point your Docker client at it, run this in your shell: eval "$(docker-machine env staging)"
 
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL                          SWARM

--- a/commands.go
+++ b/commands.go
@@ -332,7 +332,7 @@ func cmdCreate(c *cli.Context) {
 	case "fish":
 		info = fmt.Sprintf("%s env %s | source", c.App.Name, name)
 	default:
-		info = fmt.Sprintf("$(%s env %s)", c.App.Name, name)
+		info = fmt.Sprintf(`eval "$(%s env %s)"`, c.App.Name, name)
 	}
 
 	log.Infof("%q has been created and is now the active machine.", name)

--- a/docs/index.md
+++ b/docs/index.md
@@ -273,7 +273,7 @@ $ docker-machine create -d virtualbox local
 Load the Machine configuration into your shell:
 
 ```
-$ $(docker-machine env local)
+$ eval "$(docker-machine env local)"
 ```
 Then run generate the token using the Swarm Docker image:
 
@@ -324,7 +324,7 @@ export DOCKER_HOST=tcp://192.168.99.100:3376
 ```
 
 You can load this into your environment using
-`$(docker-machine env --swarm swarm-master)`.
+`eval "$(docker-machine env --swarm swarm-master)"`.
 
 Now you can use the Docker CLI to query:
 
@@ -389,13 +389,13 @@ run in a subshell.  Running `docker-machine env -u` will print
 
 ```
 $ env | grep DOCKER
-$ $(docker-machine env dev)
+$ eval "$(docker-machine env dev)"
 $ env | grep DOCKER
 DOCKER_HOST=tcp://192.168.99.101:2376
 DOCKER_CERT_PATH=/Users/nathanleclaire/.docker/machines/.client
 DOCKER_TLS_VERIFY=1
 $ # If you run a docker command, now it will run against that host.
-$ $(docker-machine env -u)
+$ eval "$(docker-machine env -u)"
 $ env | grep DOCKER
 $ # The environment variables have been unset.
 ```


### PR DESCRIPTION
See http://unix.stackexchange.com/a/181581 for the rationale behind this change (ie, better compatibility in the future, especially if `env` ever has to get more complex logic performed within the user's shell, since a workaround for one of the issues this solves is already in place).

See also docker/docker#11429, boot2docker/boot2docker#716, and boot2docker/boot2docker#786.