### PR TITLE
Fixes for on-premise EC2 endpoints

### DIFF
--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"os"
 
 	awsauth "github.com/smartystreets/go-aws-auth"
 )
@@ -130,7 +131,10 @@ func getDecodedResponse(r http.Response, into interface{}) error {
 }
 
 func NewEC2(auth Auth, region string) *EC2 {
-	endpoint := fmt.Sprintf("https://ec2.%s.amazonaws.com", region)
+	endpoint := os.Getenv("EC2_URL")
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://ec2.%s.amazonaws.com", region)
+	}
 	return &EC2{
 		Endpoint: endpoint,
 		Auth:     auth,

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"os"
 
 	awsauth "github.com/smartystreets/go-aws-auth"
 )
@@ -131,14 +130,18 @@ func getDecodedResponse(r http.Response, into interface{}) error {
 }
 
 func NewEC2(auth Auth, region string) *EC2 {
-	endpoint := os.Getenv("EC2_URL")
-	if endpoint == "" {
-		endpoint = fmt.Sprintf("https://ec2.%s.amazonaws.com", region)
+	return &EC2{
+		Endpoint: fmt.Sprintf("https://ec2.%s.amazonaws.com", region),
+		Auth:     auth,
+		Region:   region,
 	}
+}
+
+func NewEC2WithEndpoint(auth Auth, region string, endpoint string) *EC2 {
 	return &EC2{
 		Endpoint: endpoint,
 		Auth:     auth,
-		Region:   region,
+		Region: region,
 	}
 }
 


### PR DESCRIPTION
This pull request relates to this issue: https://github.com/docker/machine/issues/653

**WIP**
 - [x] Allow to set a custom on-premise EC2 endpoint (currently added for testing internally)
 - [x] Add command line argument, replace the environment variable
 - [ ] Allow to trust self-signed certificates for on-premise EC2 endpoints
 - [ ] Add tests