### PR TITLE
revert "function GetActive should return real error when file doesn't ex...

### DIFF
--- a/host_test.go
+++ b/host_test.go
@@ -164,16 +164,12 @@ func TestMachinePort(t *testing.T) {
 	}
 	flags := getTestDriverFlags()
 
-	host, err := store.Create(hostTestName, hostTestDriverName, flags)
+	_, err = store.Create(hostTestName, hostTestDriverName, flags)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := store.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
-	}
-
-	host, err = store.Load(hostTestName)
+	host, err := store.Load(hostTestName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,16 +207,12 @@ func TestMachineCustomPort(t *testing.T) {
 	}
 	flags := getTestDriverFlags()
 
-	host, err := store.Create(hostTestName, hostTestDriverName, flags)
+	_, err = store.Create(hostTestName, hostTestDriverName, flags)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := store.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
-	}
-
-	host, err = store.Load(hostTestName)
+	host, err := store.Load(hostTestName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,10 +252,6 @@ func TestHostConfig(t *testing.T) {
 	host, err := store.Create(hostTestName, hostTestDriverName, flags)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	if err := store.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
 	}
 
 	if err := host.SaveConfig(); err != nil {

--- a/store.go
+++ b/store.go
@@ -142,7 +142,7 @@ func (s *Store) Load(name string) (*Host, error) {
 func (s *Store) GetActive() (*Host, error) {
 	hostName, err := ioutil.ReadFile(s.activePath())
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("no active host")
+		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -79,12 +79,9 @@ func TestStoreRemove(t *testing.T) {
 	flags := getDefaultTestDriverFlags()
 
 	store := NewStore(TestStoreDir, "", "")
-	host, err := store.Create("test", "none", flags)
+	_, err := store.Create("test", "none", flags)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if err := store.SetActive(host); err != nil {
-		t.Fatalf("error setting active host: %v", err)
 	}
 	path := filepath.Join(TestStoreDir, "test")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -189,9 +186,7 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	// No hosts set
 	host, err := store.GetActive()
-	if err.Error() == "no active host" {
-		t.Logf("OK, no active host initially: %v", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -230,9 +225,7 @@ func TestStoreGetSetActive(t *testing.T) {
 	}
 
 	host, err = store.GetActive()
-	if err.Error() == "no active host" {
-		t.Logf("OK, success to remove active host: %v", err)
-	} else if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
#772 caused a regression where the `rm` command was no longer to remove machines when there was no active machine set.  Reverting.

This reverts commit 036b6b07b28845ce54c3c826363a4c0c7d04cadd.