### PR TITLE
corrects the rm command line description

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -257,7 +257,7 @@ var Commands = []cli.Command{
 		},
 		Name:        "rm",
 		Usage:       "Remove a machine",
-		Description: "Argument(s) are one or more machine names. Will use the active machine if none is provided.",
+		Description: "Argument(s) are one or more machine names.",
 		Action:      cmdRm,
 	},
 	{


### PR DESCRIPTION
Corrects the `rm` command line description for usage.  The `rm` command will not (and should not) remove the active machine.  A name must be specified.
