### PR TITLE
do hostname validation in commands.go instead of Host.Create()

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -343,6 +343,11 @@ func cmdCreate(c *cli.Context) {
 		log.Fatal("You must specify a machine name")
 	}
 
+	name, err := ValidateHostName(name)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	if err := setupCertificates(c.GlobalString("tls-ca-cert"), c.GlobalString("tls-ca-key"),
 		c.GlobalString("tls-client-cert"), c.GlobalString("tls-client-key")); err != nil {
 		log.Fatalf("Error generating certificates: %s", err)

--- a/host.go
+++ b/host.go
@@ -473,11 +473,6 @@ DOCKER_TLS=no`, opts, caCertPath, serverKeyPath, serverCertPath)
 }
 
 func (h *Host) Create(name string) error {
-	name, err := ValidateHostName(name)
-	if err != nil {
-		return err
-	}
-
 	// create the instance
 	if err := h.Driver.Create(); err != nil {
 		return err


### PR DESCRIPTION
this prevents broken host entries from hanging around in the "db" because of a bad hostname which require an rm -f

Signed-off-by: Aaron Welch <welch@packet.net>