### PR TITLE
add flag to support custom number of virtualbox processors

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -73,7 +73,7 @@ func GetCreateFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.IntFlag{
 			Name:  "virtualbox-processors",
-			Usage: "Number of virtual CPUs cores for host",
+			Usage: "Number of virtual CPUs cores for host. Defaults to number of available cores",
 			Value: GetCPUCores(),
 		},
 		cli.IntFlag{


### PR DESCRIPTION
This is an open feature request at #819 
Presently there are several other providers that expose this as a tunable, so there's an argument to be made that it should be included for consistency. 

The default behavior is to continue using the number of the CPUs on the machine of the flag isn't specified.

Flag is: --virtualbox-processors