### PR TITLE
Git commit version info

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/utils"
+	"github.com/docker/machine/version"
 )
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 	app.Commands = Commands
 	app.CommandNotFound = cmdNotFound
 	app.Usage = "Create and manage machines running Docker."
-	app.Version = VERSION
+	app.Version = version.VERSION + " (" + version.GITCOMMIT + ")"
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/script/build
+++ b/script/build
@@ -15,4 +15,4 @@ fi
 
 docker build -t docker-machine .
 rm -f docker-machine*
-exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}"
+exec docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}" -ldflags="-w -X github.com/docker/machine/version.GITCOMMIT `git rev-parse --short HEAD`"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,0 @@
-package main
-
-const VERSION = "0.1.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+var (
+	// VERSION should be updated by hand at each release
+	VERSION = "0.1.0"
+
+	// GITCOMMIT will be overritten automatically by the build system
+	GITCOMMIT = "HEAD"
+)

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,1 @@
+package version


### PR DESCRIPTION
This depends on #767 

This adds the git commit info to the version string:

```
VERSION:
   0.1.0 (4e966c4)

AUTHOR:
  Docker Machine Contributors - <https://github.com/docker/machine>
```

And like this for `-v`:

```
docker-machine version 0.1.0 (4e966c4)
```

Lifted from https://github.com/docker/swarm/blob/master/version/version.go -- thanks @vieux!