### PR TITLE
fixes issue #831 and issue #771 by checking for unset machine name

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -760,12 +760,25 @@ func cmdSsh(c *cli.Context) {
 			log.Fatalf("unable to get active host: %v", err)
 		}
 
+		if host == nil {
+			log.Fatalf("There is no active host. Please set it with %s active <machine name>.", c.App.Name)
+		}
+
 		name = host.Name
 	}
 
 	host, err := mcn.Get(name)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	_, err = host.GetURL()
+	if err != nil {
+		if err == drivers.ErrHostIsNotRunning {
+			log.Fatalf("%s is not running. Please start this with docker-machine start %s", host.Name, host.Name)
+		} else {
+			log.Fatalf("Unexpected error getting machine url: %s", err)
+		}
 	}
 
 	if len(c.Args()) <= 1 {
@@ -879,6 +892,9 @@ func runActionWithContext(actionName string, c *cli.Context) error {
 		activeHost, err := mcn.GetActive()
 		if err != nil {
 			log.Fatalf("Unable to get active host: %v", err)
+		}
+		if activeHost == nil {
+			log.Fatalf("There is no active host. Please set it with %s active <machine name>.", c.App.Name)
 		}
 		machines = []*libmachine.Host{activeHost}
 	}


### PR DESCRIPTION
Catches unset host in CmdSsh before issuing SSH command
Catches unset active host in runActionWithContext before issuing start, stop, restart, upgrade

closes issue #831 
fixes issue #771 

```
$ docker-machine ls
NAME      ACTIVE   DRIVER       STATE     URL                         SWARM
builder            virtualbox   Running   tcp://192.168.99.100:2376
dev                virtualbox   Stopped
$ ./docker-machine_darwin-amd64 ssh
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 active builder
$ ./docker-machine_darwin-amd64 ssh
                        ##        .
                  ## ## ##       ==
               ## ## ## ##      ===
           /""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~
           \______ o          __/
             \    \        __/
              \____\______/
 _                 _   ____     _            _
| |__   ___   ___ | |_|___ \ __| | ___   ___| | _____ _ __
| '_ \ / _ \ / _ \| __| __) / _` |/ _ \ / __| |/ / _ \ '__|
| |_) | (_) | (_) | |_ / __/ (_| | (_) | (__|   <  __/ |
|_.__/ \___/ \___/ \__|_____\__,_|\___/ \___|_|\_\___|_|
Boot2Docker version 1.5.0, build master : a66bce5 - Tue Feb 10 23:31:27 UTC 2015
Docker version 1.5.0, build a8a31ef
docker@builder:~$ exit
$ docker-machine ls
NAME      ACTIVE   DRIVER       STATE     URL                         SWARM
builder            virtualbox   Running   tcp://192.168.99.100:2376
dev                virtualbox   Stopped
$ ./docker-machine_darwin-amd64 start
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 stop
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 kill
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 upgrade
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 restart
FATA[0000] There is no active host. Please set it with docker-machine active <machine name>
$ ./docker-machine_darwin-amd64 active builder
$ ./docker-machine_darwin-amd64 ls
NAME      ACTIVE   DRIVER       STATE     URL                         SWARM
builder   *        virtualbox   Running   tcp://192.168.99.100:2376
dev                virtualbox   Stopped
$ ./docker-machine_darwin-amd64 stop builder
$ ./docker-machine_darwin-amd64 ls
NAME      ACTIVE   DRIVER       STATE     URL   SWARM
builder   *        virtualbox   Stopped
dev                virtualbox   Stopped
```

Signed-off-by: Ken Pepple <ken@solinea.com>