### PR TITLE
fixes #855 for docker-machine env on stopped machines

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -673,6 +673,10 @@ func cmdEnv(c *cli.Context) {
 		log.Fatal(err)
 	}
 
+	if cfg.machineUrl == "" {
+		log.Fatalf("%s is not running. Please start this with docker-machine start %s", cfg.machineName, cfg.machineName)
+	}
+
 	dockerHost := cfg.machineUrl
 	if c.Bool("swarm") {
 		if !cfg.SwarmOptions.Master {


### PR DESCRIPTION
Warns that `$docker-machine env` on stopped hosts will not set environment variables correctly.

closes issue #855 

Signed-off-by: Ken Pepple <ken@solinea.com>