### PR TITLE
fix download destination for boot2docker iso

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -217,7 +217,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(commonIsoPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
First argument passed to DownloadISO should be a directory, not a filename.  This is a fix for issue #820 

Signed-off-by: Tim Green <timsgreen@gmail.com>