### PR TITLE
Fix location of validating hostname functionality

### DIFF
--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -92,11 +92,8 @@ func LoadHost(name string, StorePath string) (*Host, error) {
 	return host, nil
 }
 
-func ValidateHostName(name string) (string, error) {
-	if !validHostNamePattern.MatchString(name) {
-		return name, ErrInvalidHostname
-	}
-	return name, nil
+func ValidateHostName(name string) bool {
+	return validHostNamePattern.MatchString(name)
 }
 
 func (h *Host) Create(name string) error {

--- a/libmachine/host_test.go
+++ b/libmachine/host_test.go
@@ -122,13 +122,9 @@ func TestValidateHostnameValid(t *testing.T) {
 	}
 
 	for _, v := range hosts {
-		h, err := ValidateHostName(v)
-		if err != nil {
-			t.Fatal("Invalid hostname")
-		}
-
-		if h != v {
-			t.Fatal("Hostname doesn't match")
+		isValid := ValidateHostName(v)
+		if !isValid {
+			t.Fatal("Thought a valid hostname was invalid: %s", v)
 		}
 	}
 }
@@ -141,9 +137,9 @@ func TestValidateHostnameInvalid(t *testing.T) {
 	}
 
 	for _, v := range hosts {
-		_, err := ValidateHostName(v)
-		if err == nil {
-			t.Fatal("No error returned")
+		isValid := ValidateHostName(v)
+		if isValid {
+			t.Fatal("Thought an invalid hostname was valid: %s", v)
 		}
 	}
 }

--- a/libmachine/machine.go
+++ b/libmachine/machine.go
@@ -20,6 +20,10 @@ func New(store Store) (*Machine, error) {
 }
 
 func (m *Machine) Create(name string, driverName string, hostOptions *HostOptions, driverConfig drivers.DriverOptions) (*Host, error) {
+	validName := ValidateHostName(name)
+	if !validName {
+		return nil, ErrInvalidHostname
+	}
 	exists, err := m.store.Exists(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Similar in functionality to #807 (thanks for the tipoff @crunchywelch!), I'd prefer to validate the hostname before we attempt to make the host / serialize it to disk at all.

There seems to be no need for multiple returns as the regex match only returns bool, so I've updated that as well.

cc @ehazlett @sthulb 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>