### PR TITLE
Added VIRTUALBOX_MEMORY_SIZE and VIRTUALBOX_DISK_SIZE env vars

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -828,6 +828,18 @@ Options:
 
 The VirtualBox driver uses the latest boot2docker image.
 
+Environment variables:
+
+Here comes the list of the supported variables with the corresponding options. If both environment
+variable and CLI option are provided the CLI option takes the precedence.
+
+| Environment variable              | CLI option                        |
+|-----------------------------------|-----------------------------------|
+| `VIRTUALBOX_MEMORY_SIZE`          | `--virtualbox-memory`             |
+| `VIRTUALBOX_CPU_COUNT`            | `--virtualbox-cpu-count`          |
+| `VIRTUALBOX_DISK_SIZE`            | `--virtualbox-disk-size`          |
+| `VIRTUALBOX_BOOT2DOCKER_URL`      | `--virtualbox-boot2docker-url`    |
+
 #### VMware Fusion
 Creates machines locally on [VMware Fusion](http://www.vmware.com/products/fusion). Requires VMware Fusion to be installed.
 

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -65,20 +65,22 @@ func init() {
 func GetCreateFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.IntFlag{
-			Name:  "virtualbox-memory",
-			Usage: "Size of memory for host in MB",
-			Value: 1024,
+			EnvVar: "VIRTUALBOX_MEMORY_SIZE",
+			Name:   "virtualbox-memory",
+			Usage:  "Size of memory for host in MB",
+			Value:  1024,
 		},
 		cli.IntFlag{
+			EnvVar: "VIRTUALBOX_CPU_COUNT",
 			Name:   "virtualbox-cpu-count",
 			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
-			EnvVar: "VIRTUALBOX_CPU_COUNT",
 			Value:  -1,
 		},
 		cli.IntFlag{
-			Name:  "virtualbox-disk-size",
-			Usage: "Size of disk for host in MB",
-			Value: 20000,
+			EnvVar: "VIRTUALBOX_DISK_SIZE",
+			Name:   "virtualbox-disk-size",
+			Usage:  "Size of disk for host in MB",
+			Value:  20000,
 		},
 		cli.StringFlag{
 			EnvVar: "VIRTUALBOX_BOOT2DOCKER_URL",

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -284,11 +284,6 @@ findCPUCount() {
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: cleanup" {
-  run rm -rf $MACHINE_STORAGE_PATH
-  [ "$status" -eq 0  ]
-}
-
 @test "$DRIVER: can create custom machine using disk size and memory size via env vars" {
   run VIRTUALBOX_DISK_SIZE=${CUSTOM_DISKSIZE} VIRTUALBOX_MEMORY_SIZE=${CUSTOM_MEMSIZE} machine create -d $DRIVER $NAME
   [ "$status" -eq 0  ]
@@ -315,4 +310,9 @@ findCPUCount() {
   [ "$status" -eq 0  ]
 }
 
+# Cleanup of machine store should always be the last 'test'
+@test "$DRIVER: cleanup" {
+  run rm -rf $MACHINE_STORAGE_PATH
+  [ "$status" -eq 0  ]
+}
 

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -285,17 +285,13 @@ findCPUCount() {
 }
 
 @test "$DRIVER: can create custom machine using disk size and memory size via env vars" {
-  export VIRTUALBOX_DISK_SIZE=$CUSTOM_DISKSIZE
-  export VIRTUALBOX_MEMORY_SIZE=$CUSTOM_MEMSIZE
-  run machine create -d $DRIVER $NAME
-  export VIRTUALBOX_DISK_SIZE=
-  export VIRTUALBOX_MEMORY_SIZE=
+  VIRTUALBOX_DISK_SIZE=$CUSTOM_DISKSIZE VIRTUALBOX_MEMORY_SIZE=$CUSTOM_MEMSIZE run machine create -d $DRIVER $NAME
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: check machine's memory size was set correctly by env var" {
   findMemorySize
-  [[ ${output} == "${CUSTOM_MEMSIZE}"  ]]
+  [[ ${output} == "$CUSTOM_MEMSIZE"  ]]
 }
 
 @test "$DRIVER: check machine's disk size was set correctly by env var" {

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -260,7 +260,7 @@ findCPUCount() {
 
 @test "$DRIVER: check custom machine memory size" {
   findMemorySize
-  [[ ${output} == "${CUSTOM_MEMSIZE}"  ]]
+  [[ ${output} == "$CUSTOM_MEMSIZE"  ]]
 }
 
 @test "$DRIVER: check custom machine disksize" {
@@ -270,7 +270,7 @@ findCPUCount() {
 
 @test "$DRIVER: check custom machine cpucount" {
   findCPUCount
-  [[ ${output} == "${CUSTOM_CPUCOUNT}" ]]
+  [[ ${output} == "$CUSTOM_CPUCOUNT" ]]
 }
 
 @test "$DRIVER: machine should show running after create" {
@@ -284,8 +284,8 @@ findCPUCount() {
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: can create custom machine using disk size and memory size via env vars" {
-  VIRTUALBOX_DISK_SIZE=$CUSTOM_DISKSIZE VIRTUALBOX_MEMORY_SIZE=$CUSTOM_MEMSIZE run machine create -d $DRIVER $NAME
+@test "$DRIVER: can create custom machine using disk size, cpu count and memory size via env vars" {
+  VIRTUALBOX_DISK_SIZE=$CUSTOM_DISKSIZE VIRTUALBOX_CPU_COUNT=$CUSTOM_CPUCOUNT VIRTUALBOX_MEMORY_SIZE=$CUSTOM_MEMSIZE run machine create -d $DRIVER $NAME
   [ "$status" -eq 0  ]
 }
 
@@ -298,6 +298,12 @@ findCPUCount() {
   findDiskSize
   [[ ${output} == *"$CUSTOM_DISKSIZE"* ]]
 }
+
+@test "$DRIVER: check custom machine cpucount" {
+  findCPUCount
+  [[ ${output} == "$CUSTOM_CPUCOUNT" ]]
+}
+
 
 @test "$DRIVER: machine should show running after create with env" {
   run machine ls

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -285,7 +285,11 @@ findCPUCount() {
 }
 
 @test "$DRIVER: can create custom machine using disk size and memory size via env vars" {
-  run VIRTUALBOX_DISK_SIZE=${CUSTOM_DISKSIZE} VIRTUALBOX_MEMORY_SIZE=${CUSTOM_MEMSIZE} machine create -d $DRIVER $NAME
+  export VIRTUALBOX_DISK_SIZE=$CUSTOM_DISKSIZE
+  export VIRTUALBOX_MEMORY_SIZE=$CUSTOM_MEMSIZE
+  run machine create -d $DRIVER $NAME
+  export VIRTUALBOX_DISK_SIZE=
+  export VIRTUALBOX_MEMORY_SIZE=
   [ "$status" -eq 0  ]
 }
 

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -288,3 +288,31 @@ findCPUCount() {
   run rm -rf $MACHINE_STORAGE_PATH
   [ "$status" -eq 0  ]
 }
+
+@test "$DRIVER: can create custom machine using disk size and memory size via env vars" {
+  run VIRTUALBOX_DISK_SIZE=${CUSTOM_DISKSIZE} VIRTUALBOX_MEMORY_SIZE=${CUSTOM_MEMSIZE} machine create -d $DRIVER $NAME
+  [ "$status" -eq 0  ]
+}
+
+@test "$DRIVER: check machine's memory size was set correctly by env var" {
+  findMemorySize
+  [[ ${output} == "${CUSTOM_MEMSIZE}"  ]]
+}
+
+@test "$DRIVER: check machine's disk size was set correctly by env var" {
+  findDiskSize
+  [[ ${output} == *"$CUSTOM_DISKSIZE"* ]]
+}
+
+@test "$DRIVER: machine should show running after create with env" {
+  run machine ls
+  [ "$status" -eq 0  ]
+  [[ ${lines[1]} == *"Running"*  ]]
+}
+
+@test "$DRIVER: remove after custom env create" {
+  run machine rm -f $NAME
+  [ "$status" -eq 0  ]
+}
+
+


### PR DESCRIPTION
While looking at issue #843 I saw that there were no environment variables that could be used to configure the amount of disk space and memory to allocate to the VirtualBox VM.  This looked inconsistent with some of the other drivers, e.g. VMWare Fusion.

@ehazlett suggested submitting a PR to add env vars for these to params.

```
$ export VIRTUALBOX_MEMORY_SIZE=2048                                                                                                                                                                                                    [25/25]
$ export VIRTUALBOX_DISK_SIZE=15000
$ docker-machine create -d virtualbox vb-env-vars-test
INFO[0000] Creating SSH key...
INFO[0000] Creating VirtualBox VM...
INFO[0005] Starting VirtualBox VM...
INFO[0005] Waiting for VM to start...
INFO[0038] "vb-env-vars-test" has been created and is now the active machine.
INFO[0038] To point your Docker client at it, run this in your shell: eval "$(docker-machine env vb-env-vars-test)"
```

![screen shot 2015-03-25 at 23 05 48](https://cloud.githubusercontent.com/assets/60068/6837470/6f6c1b60-d344-11e4-905b-53c63306f533.png)


Signed-off-by: Tom Barlow <tomwbarlow@gmail.com>