### PR TITLE
Adds virtualbox-cpu-count - fixes #819

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -823,6 +823,7 @@ Options:
  - `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
  - `--virtualbox-disk-size`: Size of disk for the host in MB. Default: `20000`
  - `--virtualbox-memory`: Size of memory for the host in MB. Default: `1024`
+ - `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to number of available CPUs.
 
 The VirtualBox driver uses the latest boot2docker image.
 


### PR DESCRIPTION
I added --virtualbox-cpu-count, fixing #819.

One complication is that the existing code used the number of CPUs, so I kept that default, unlike the other drivers which default to 1 or 2. Seemed like the right thing to do since you're going to be running virtualbox locally, which means you'll probably have plenty of CPUs, and we don't want to make it slow in the default case.

This is my first PR to docker, but I've tried to follow the guidelines - let me know if I've missed anything. Includes docs, cli flags, an env var option. Has been gofmted. No tests - none exist for the driver as it is, and I didnt want to complicate this by refactoring to add them. I did test manually though.