### PR TITLE
Fix unix:// not working inside VM issue

### DIFF
--- a/test/integration/driver-amazonec2.bats
+++ b/test/integration/driver-amazonec2.bats
@@ -48,6 +48,10 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: docker commands with the socket should work" {
+  run machine ssh $NAME -- docker version
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/test/integration/driver-digitalocean.bats
+++ b/test/integration/driver-digitalocean.bats
@@ -48,6 +48,10 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: docker commands with the socket should work" {
+  run machine ssh $NAME -- docker version
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -63,6 +63,10 @@ function setup() {
   [[ ${lines[0]} =~ "total"  ]]
 }
 
+@test "$DRIVER: docker commands with the socket should work" {
+  run machine ssh $NAME -- docker version
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -100,7 +100,7 @@ func WaitForDocker(ip string, daemonPort int) error {
 	return WaitFor(func() bool {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ip, daemonPort))
 		if err != nil {
-			fmt.Println("Got an error it was", err)
+			log.Debug("Got an error it was", err)
 			return false
 		}
 		conn.Close()


### PR DESCRIPTION
With the way that provisioning was implemented, there was an issue
getting connection to the UNIX socket to work with the new boot2docker
1.6rc2 ISO.  This issue is related to the fact that the docker
service was not truly stopped during the provisioning.  This PR fixes
the issue and provides some tests to help ensure that it does not come
up again.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>