### PR TITLE
hooked a PostCreateCheck for checking the configuration setting 

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -304,6 +304,10 @@ func (d *Driver) PreCreateCheck() error {
 	return d.checkPrereqs()
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) instanceIpAvailable() bool {
 	ip, err := d.GetIP()
 	if err != nil {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -229,6 +229,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	if err := d.setUserSubscription(); err != nil {
 		return err

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -180,6 +180,10 @@ func (d *Driver) PreCreateCheck() error {
 	return fmt.Errorf("digitalocean requires a valid region")
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	log.Infof("Creating SSH key...")
 

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -68,6 +68,9 @@ type Driver interface {
 	// PreCreateCheck allows for pre-create operations to make sure a driver is ready for creation
 	PreCreateCheck() error
 
+	// PostCreateCheck allows for checking the creation of driver met the configuration we specified
+	PostCreateCheck() error
+	
 	// Remove a host
 	Remove() error
 

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -70,7 +70,7 @@ type Driver interface {
 
 	// PostCreateCheck allows for checking the creation of driver met the configuration we specified
 	PostCreateCheck() error
-	
+
 	// Remove a host
 	Remove() error
 

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -68,7 +68,7 @@ func (d *FakeDriver) PreCreateCheck() error {
 	return nil
 }
 
-func (d *Driver) PostCreateCheck() error {
+func (d *FakeDriver) PostCreateCheck() error {
 	return nil
 }
 

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -68,6 +68,10 @@ func (d *FakeDriver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *FakeDriver) Create() error {
 	return nil
 }

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -180,6 +180,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 // Create creates a GCE VM instance acting as a docker host.
 func (d *Driver) Create() error {
 	c, err := newComputeUtil(d)

--- a/drivers/hyperv/hyperv_windows.go
+++ b/drivers/hyperv/hyperv_windows.go
@@ -142,6 +142,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) GetURL() (string, error) {
 	ip, err := d.GetIP()
 	if err != nil {

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -98,6 +98,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Remove() error {
 	return nil
 }

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -355,6 +355,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 	d.KeyPairName = fmt.Sprintf("%s-%s", d.MachineName, utils.GenerateRandomID())
 

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -307,6 +307,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) waitForStart() {
 	log.Infof("Waiting for host to become available")
 	for {

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -173,14 +173,14 @@ func (d *Driver) PostCreateCheck() error {
 		}
 		return vminfoerr
 	}
-	
+
 	reMemorySize := regexp.MustCompile(`(?m)^memory=(\w+)`)
 	realMemorySize := reMemorySize.FindStringSubmatch(vminfostdout)
-	log.Infof("Real Memory Size: %s", realMemorySize[1]) 
+	log.Infof("Real Memory Size: %s", realMemorySize[1])
 	memSize, e := strconv.Atoi(realMemorySize[1])
-    if e != nil {
-        return e
-    }
+	if e != nil {
+		return e
+	}
 
 	if memSize != d.Memory {
 		log.Warnf("Mismatched Memory Size.")
@@ -197,11 +197,11 @@ func (d *Driver) PostCreateCheck() error {
 
 	reDiskSize := regexp.MustCompile(`(?m)^Capacity:(.*)MBytes`)
 	realDiskSize := reDiskSize.FindStringSubmatch(hdinfostdout)
-	log.Infof("Real HD Disk Size: %s", strings.TrimSpace(realDiskSize[1])) 
+	log.Infof("Real HD Disk Size: %s", strings.TrimSpace(realDiskSize[1]))
 	diskSize, e := strconv.Atoi(strings.TrimSpace(realDiskSize[1]))
-    if e != nil {
-        return e
-    }
+	if e != nil {
+		return e
+	}
 	if diskSize != d.DiskSize {
 		log.Warnf("Mismatched Disk Size.")
 	}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -158,6 +158,53 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) PreCreateCheck() error {
+
+	return nil
+}
+
+func (d *Driver) PostCreateCheck() error {
+	// check the settings for configuration
+	log.Infof("Comparing Memory Size ...")
+	vminfostdout, vminfostderr, vminfoerr := vbmOutErr("showvminfo", d.MachineName,
+		"--machinereadable")
+	if vminfoerr != nil {
+		if reMachineNotFound.FindString(vminfostderr) != "" {
+			return ErrMachineNotExist
+		}
+		return vminfoerr
+	}
+	
+	reMemorySize := regexp.MustCompile(`(?m)^memory=(\w+)`)
+	realMemorySize := reMemorySize.FindStringSubmatch(vminfostdout)
+	log.Infof("Real Memory Size: %s", realMemorySize[1]) 
+	memSize, e := strconv.Atoi(realMemorySize[1])
+    if e != nil {
+        return e
+    }
+
+	if memSize != d.Memory {
+		log.Warnf("Mismatched Memory Size.")
+	}
+
+	log.Infof("Comparing Disk Size ...")
+	hdinfostdout, hdinfostderr, hdinfoerr := vbmOutErr("showhdinfo", d.diskPath())
+	if hdinfoerr != nil {
+		if reMachineNotFound.FindString(hdinfostderr) != "" {
+			return ErrMachineNotExist
+		}
+		return hdinfoerr
+	}
+
+	reDiskSize := regexp.MustCompile(`(?m)^Capacity:(.*)MBytes`)
+	realDiskSize := reDiskSize.FindStringSubmatch(hdinfostdout)
+	log.Infof("Real HD Disk Size: %s", strings.TrimSpace(realDiskSize[1])) 
+	diskSize, e := strconv.Atoi(strings.TrimSpace(realDiskSize[1]))
+    if e != nil {
+        return e
+    }
+	if diskSize != d.DiskSize {
+		log.Warnf("Mismatched Disk Size.")
+	}
 	return nil
 }
 

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -195,6 +195,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 
 	var (

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -312,6 +312,10 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
+
 func (d *Driver) Create() error {
 
 	key, err := d.createSSHKey()

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -272,6 +272,9 @@ func (d *Driver) PreCreateCheck() error {
 	return nil
 }
 
+func (d *Driver) PostCreateCheck() error {
+	return nil
+}
 // the current implementation does the following:
 // 1. check whether the docker directory contains the boot2docker ISO
 // 2. generate an SSH keypair and bundle it in a tar.

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -275,6 +275,7 @@ func (d *Driver) PreCreateCheck() error {
 func (d *Driver) PostCreateCheck() error {
 	return nil
 }
+
 // the current implementation does the following:
 // 1. check whether the docker directory contains the boot2docker ISO
 // 2. generate an SSH keypair and bundle it in a tar.

--- a/libmachine/machine.go
+++ b/libmachine/machine.go
@@ -64,6 +64,10 @@ func (m *Machine) Create(name string, driverName string, hostOptions *HostOption
 		return nil, err
 	}
 
+	if err := host.Driver.PostCreateCheck(); err != nil {
+		return nil, err
+	}
+
 	return host, nil
 }
 


### PR DESCRIPTION
Added a method called PostCreateCheck to enable to check if the configuration matches with the params provided or default value after the virtual machine is created. The same method could apply to each driver to do after creation checking. 

 Fix #843