### PR TITLE
Provisioner upgrade

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -579,11 +579,25 @@ dev    *        virtualbox   Stopped
 
 #### upgrade
 
-Upgrade a machine to the latest version of Docker.
+Upgrade a machine to the latest version of Docker.  If the machine uses Ubuntu
+as the underlying operating system, it will upgrade the package `lxc-docker`
+(our recommended install method).  If the machine uses boot2docker, this command
+will download the latest boot2docker ISO and replace the machine's existing ISO
+with the latest.
 
 ```
 $ docker-machine upgrade dev
+INFO[0000] Stopping machine to do the upgrade...
+INFO[0005] Upgrading machine dev...
+INFO[0006] Downloading latest boot2docker release to /tmp/store/cache/boot2docker.iso...
+INFO[0008] Starting machine back up...
+INFO[0008] Waiting for VM to start...
 ```
+
+> **Note**: If you are using a custom boot2docker ISO specified using
+> `--virtualbox-boot2docker-url` or an equivalent flag, running an upgrade on
+> that machine will completely replace the specified ISO with the latest
+> "vanilla" boot2docker ISO available.
 
 #### url
 
@@ -826,7 +840,22 @@ Options:
  - `--virtualbox-memory`: Size of memory for the host in MB. Default: `1024`
  - `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to number of available CPUs.
 
-The VirtualBox driver uses the latest boot2docker image.
+The `--virtualbox-boot2docker-url` flag takes a few different forms.  By
+default, if no value is specified for this flag, Machine will check locally for
+a boot2docker ISO.  If one is found, that will be used as the ISO for the
+created machine.  If one is not found, the latest ISO release available on
+[boot2docker/boot2docker](https://github.com/boot2docker/boot2docker) will be
+downloaded and stored locally for future use.  Note that this means you must run
+`docker-machine upgrade` deliberately on a machine if you wish to update the "cached"
+boot2docker ISO.
+
+This is the default behavior (when `--virtualbox-boot2docker-url=""`), but the
+option also supports specifying ISOs by the `http://` and `file://` protocols.
+`file://` will look at the path specified locally to locate the ISO: for
+instance, you could specify `--virtualbox-boot2docker-url
+file://$HOME/Downloads/rc.iso` to test out a release candidate ISO that you have
+downloaded already.  You could also just get an ISO straight from the Internet
+using the `http://` form.
 
 Environment variables:
 
@@ -839,6 +868,7 @@ variable and CLI option are provided the CLI option takes the precedence.
 | `VIRTUALBOX_CPU_COUNT`            | `--virtualbox-cpu-count`          |
 | `VIRTUALBOX_DISK_SIZE`            | `--virtualbox-disk-size`          |
 | `VIRTUALBOX_BOOT2DOCKER_URL`      | `--virtualbox-boot2docker-url`    |
+
 
 #### VMware Fusion
 Creates machines locally on [VMware Fusion](http://www.vmware.com/products/fusion). Requires VMware Fusion to be installed.

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"sort"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/provider"
 	"github.com/docker/machine/ssh"
@@ -174,4 +175,17 @@ func GetSSHCommandFromDriver(d Driver, args ...string) (*exec.Cmd, error) {
 	keyPath := d.GetSSHKeyPath()
 
 	return ssh.GetSSHCommand(host, port, user, keyPath, args...), nil
+}
+
+func MachineInState(d Driver, desiredState state.State) func() bool {
+	return func() bool {
+		currentState, err := d.GetState()
+		if err != nil {
+			log.Debugf("Error getting machine state: %s", err)
+		}
+		if currentState == desiredState {
+			return true
+		}
+		return false
+	}
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -158,8 +158,7 @@ func (d *Driver) PreCreateCheck() error {
 
 func (d *Driver) Create() error {
 	var (
-		err    error
-		isoURL string
+		err error
 	)
 
 	// Check that VBoxManage exists and works
@@ -172,45 +171,12 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	b2dutils := utils.NewB2dUtils("", "")
-	imgPath := utils.GetMachineCacheDir()
-	isoFilename := "boot2docker.iso"
-	commonIsoPath := filepath.Join(imgPath, "boot2docker.iso")
-	// just in case boot2docker.iso has been manually deleted
-	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-		if err := os.Mkdir(imgPath, 0700); err != nil {
-			return err
-		}
-	}
-
-	if d.Boot2DockerURL != "" {
-		isoURL = d.Boot2DockerURL
-		log.Infof("Downloading %s from %s...", isoFilename, isoURL)
-		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
-			return err
-		}
-	} else {
-		// todo: check latest release URL, download if it's new
-		// until then always use "latest"
-		isoURL, err = b2dutils.GetLatestBoot2DockerReleaseURL()
-		if err != nil {
-			log.Warnf("Unable to check for the latest release: %s", err)
-		}
-
-		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
-			log.Infof("Downloading %s to %s...", isoFilename, commonIsoPath)
-			if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
-				return err
-			}
-		}
-
-		isoDest := filepath.Join(d.storePath, isoFilename)
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
-		}
-	}
-
 	log.Infof("Creating SSH key...")
+
+	b2dutils := utils.NewB2dUtils("", "")
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+		return err
+	}
 
 	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/state"
@@ -221,8 +222,19 @@ func (h *Host) Restart() error {
 }
 
 func (h *Host) Upgrade() error {
-	// TODO: refactor to provisioner
-	return fmt.Errorf("centralized upgrade coming in the provisioner")
+	provisioner, err := provision.DetectProvisioner(h.Driver)
+	if err != nil {
+		return err
+	}
+
+	if err := provisioner.Package("docker", pkgaction.Upgrade); err != nil {
+		return err
+	}
+
+	if err := provisioner.Service("docker", pkgaction.Restart); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *Host) Remove(force bool) error {

--- a/libmachine/provision/pkgaction/action.go
+++ b/libmachine/provision/pkgaction/action.go
@@ -27,11 +27,13 @@ type PackageAction int
 const (
 	Install PackageAction = iota
 	Remove
+	Upgrade
 )
 
 var packageActions = []string{
 	"install",
 	"remove",
+	"upgrade",
 }
 
 func (s PackageAction) String() string {

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -56,6 +56,14 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 		packageAction = "install"
 	case pkgaction.Remove:
 		packageAction = "remove"
+	case pkgaction.Upgrade:
+		packageAction = "upgrade"
+	}
+
+	// TODO: This should probably have a const
+	switch name {
+	case "docker":
+		name = "lxc-docker"
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -36,6 +36,12 @@ findCPUCount() {
   run bash -c "VBoxManage showvminfo --machinereadable $NAME | grep cpus= | cut -d'=' -f2"
 }
 
+buildMachineWithOldIsoCheckUpgrade() {
+  run wget https://github.com/boot2docker/boot2docker/releases/download/v1.4.1/boot2docker.iso -O $MACHINE_STORAGE_PATH/cache/boot2docker.iso
+  run machine create -d virtualbox $NAME
+  run machine upgrade $NAME
+}
+
 @test "$DRIVER: machine should not exist" {
   run machine active $NAME
   [ "$status" -eq 1  ]
@@ -314,6 +320,15 @@ findCPUCount() {
 @test "$DRIVER: remove after custom env create" {
   run machine rm -f $NAME
   [ "$status" -eq 0  ]
+}
+
+@test "$DRIVER: upgrade should work" {
+  buildMachineWithOldIsoCheckUpgrade
+  [ "$status" -eq 0 ]
+}
+
+@test "$DRIVER: remove machine after upgrade test" {
+  run machine rm -f $NAME
 }
 
 # Cleanup of machine store should always be the last 'test'

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -100,7 +100,7 @@ func WaitForDocker(ip string, daemonPort int) error {
 	return WaitFor(func() bool {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ip, daemonPort))
 		if err != nil {
-			log.Debug("Got an error it was", err)
+			log.Debugf("Got an error it was %s", err)
 			return false
 		}
 		conn.Close()


### PR DESCRIPTION
cc @ehazlett @sthulb 

This PR implements upgrade feature for the Ubuntu and boot2docker provisioners.  In Ubuntu we run `sudo apt-get upgrade lxc-docker` and for boot2docker we download the latest ISO, then replace the one the machine is currently using with that ISO.

Noteworthy changes:

- `WaitForState` has been pulled into `drivers` instead of `libmachine` in order to make it easier to use cross-package
- The majority of code related to handling moving ISOs around has been moved out of the `virtualbox` driver and into `utils` so it can be used in multiple places.  Come to think of it, maybe I should go update the other local drivers to use this common code as well?
- Adds new docs and integration tests

PTAL