### PR TITLE
digitalocean: remove unneeded wait for ssh

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -234,12 +234,6 @@ func (d *Driver) Create() error {
 		newDroplet.Droplet.ID,
 		d.IPAddress)
 
-	log.Infof("Waiting for SSH...")
-
-	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", d.IPAddress, 22)); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This removes a "WaitForSSH" command that seems related to causing hang ups when creating DO droplets.

After this fix, I haven't had a "hang" on creating again -- perhaps just a coincidence :)

Refs #951