### PR TITLE
for ubuntu provision append hostname to 127.0.1.1 line in /etc/hosts

### DIFF
--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -128,8 +128,16 @@ func (provisioner *UbuntuProvisioner) Hostname() (string, error) {
 
 func (provisioner *UbuntuProvisioner) SetHostname(hostname string) error {
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname %s && echo %q | sudo tee /etc/hostname && echo \"127.0.0.1 %s\" | sudo tee -a /etc/hosts",
+		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
 		hostname,
+		hostname,
+	)); err != nil {
+		return err
+	}
+
+	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
 		hostname,
 		hostname,
 	)); err != nil {

--- a/test/integration/driver-digitalocean.bats
+++ b/test/integration/driver-digitalocean.bats
@@ -52,6 +52,12 @@ export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
   run machine ssh $NAME -- docker version
 }
 
+# currently this only checks debian/ubuntu style using 127.0.0.1
+@test "$DRIVER: hostname should be set properly" {
+  run machine ssh $NAME -- "grep -Fxq '127.0.1.1 $NAME' /etc/hosts"
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: stop" {
   run machine stop $NAME
   [ "$status" -eq 0  ]


### PR DESCRIPTION
we should do it this way instead of appending a record for 127.0.0.1 to the file itself. Two reasons for this:

1) you should not have multiple lines in /etc/hosts with the same ip address
2) ubuntu/debian use 127.0.1.1 for this purpose as described here:

https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution

and further discussed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=316099

Signed-off-by: Aaron Welch <welch@packet.net>