### PR TITLE
Add a few improvements to stability

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -13,8 +13,9 @@ import (
 func GetSSHCommand(host string, port int, user string, sshKey string, args ...string) *exec.Cmd {
 	defaultSSHArgs := []string{
 		"-o", "IdentitiesOnly=yes",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=no", // don't bother checking in ~/.ssh/known_hosts
+		"-o", "UserKnownHostsFile=/dev/null", // don't write anything to ~/.ssh/known_hosts
+		"-o", "ConnectionAttempts=30", // retry 30 times if SSH connection fails
 		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 		"-p", fmt.Sprintf("%d", port),
 		"-i", sshKey,


### PR DESCRIPTION
This improves on a few issues which are not frequent but do sometimes
come up:

1. Check that the daemon is up before attempting to do anything
   docker-ey in provisioning Ubuntu
2. Set a max retries for SSH so that if a request fails it attempts
   again before giving up

Also have annotated a few of the SSH options slightly better.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>