### PR TITLE
make ssh username configurable for ec2

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -146,6 +146,12 @@ func GetCreateFlags() []cli.Flag {
 			Name:  "amazonec2-iam-instance-profile",
 			Usage: "AWS IAM Instance Profile",
 		},
+		cli.StringFlag{
+			Name:   "amazonec2-ssh-user",
+			Usage:  "set the name of the ssh user",
+			Value:  "ubuntu",
+			EnvVar: "AWS_SSH_USER",
+		},
 	}
 }
 
@@ -199,7 +205,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")
-	d.SSHUser = "ubuntu"
+	d.SSHUser = flags.String("amazonec2-ssh-user")
 	d.SSHPort = 22
 
 	if d.AccessKey == "" {

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -77,6 +77,7 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-zone":                 "e",
 			"amazonec2-root-size":            10,
 			"amazonec2-iam-instance-profile": "",
+			"amazonec2-ssh-user":             "ubuntu",
 		},
 	}
 }


### PR DESCRIPTION
@ehazlett 

Im working on provisioning rancherOS instance using machine. For aws, the SSH user needs to be 'rancher' for rancherOS instead of the default 'ubuntu'. 

I made the SSH user name a configurable flag to support this.  