### PR TITLE
VirtualBox: enable ability to import b2d instances

### DIFF
--- a/docs/boot2docker_migration.md
+++ b/docs/boot2docker_migration.md
@@ -1,0 +1,68 @@
+This guide explains migrating from the Boot2Docker CLI to Docker Machine.
+
+This guide assumes basic knowledge of the Boot2Docker CLI and Docker Machine.  If you are not familiar, please review those docs prior to migrating.
+
+There are a few differences between the Boot2Docker CLI commands and Machine.  Please review the table below for the Boot2Docker command and the corresponding Machine command.  You can also see details on Machine commands in the official [Docker Machine Docs](http://docs.docker.com/machine/#subcommands).
+
+# Migrating
+
+In order to migrate a Boot2Docker VM to Docker Machine, you must have Docker Machine installed.  If you do not have Docker Machine, please see the [install docs](http://docs.docker.com/machine/#installation) before proceeding.
+
+> Note: when migrating to Docker Machine, this will also update Docker to the latest stable version
+
+To migrate a Boot2Docker VM, run the following command where `<boot2docker-vm-name>` is the name of your Boot2Docker VM and `<new-machine-name>` is the name of the new Machine (i.e. `dev`):
+
+> To get the name of your Boot2Docker VM, use the `boot2docker config` command.  Default: `boot2docker-vm`.
+
+```
+docker-machine create -d virtualbox --virtualbox-import-boot2docker-vm <boot2docker-vm-name> <new-machine-name>
+```
+
+> Note: this will stop the Boot2Docker VM in order to safely copy the virtual disk
+
+You should see output similar to the following:
+
+```
+$> docker-machine create -d virtualbox --virtualbox-import-boot2docker-vm boot2docker-vm dev
+INFO[0000] Creating VirtualBox VM...                    
+INFO[0001] Starting VirtualBox VM...                    
+INFO[0001] Waiting for VM to start...                   
+INFO[0035] "dev" has been created and is now the active machine. 
+INFO[0035] To point your Docker client at it, run this in your shell: eval "$(docker-machine env dev)"
+```
+
+You now should have a Machine that contains all of the Docker data from the Boot2Docker VM.  See the Docker Machine [usage docs](http://docs.docker.com/machine/#getting-started-with-docker-machine-using-a-local-vm) for details on working with Machine.
+
+# Cleanup
+When migrating a Boot2Docker VM to Docker Machine the Boot2Docker VM is left intact.  Once you have verified that all of your Docker data (containers, images, etc) are in the new Machine, you can remove the Boot2Docker VM using `boot2docker delete`.
+
+# Command Comparison
+
+|  boot2docker cli | machine | machine description |
+|----|----|----|
+| init | create | creates a new docker host |
+| up | start | starts a stopped machine |
+| ssh | ssh | runs a command or interactive ssh session on the machine |
+| save | - | n/a |
+| down | stop | stops a running machine |
+| poweroff | stop | stops a running machine |
+| reset | restart | restarts a running machine |
+| config | inspect (*) | shows details about machine |
+| status | ls (**) | shows a list of all machines |
+| info | inspect (*) | shows details about machine |
+| ip | url (***) | shows the Docker URL for the machine |
+| shellinit | env | shows the environment configuration needed to configure the Docker CLI for the machine |
+| delete | rm | removes a machine |
+| download | - | |
+| upgrade | upgrade | upgrades Docker on the machine to the latest stable release |
+
+
+\* provides similar functionality but not exact
+
+** `ls` will show all machines including their status
+
+** the `url` command reports the entire Docker URL including the IP / Hostname:
+```
+```
+```
+```

--- a/drivers/virtualbox/disk.go
+++ b/drivers/virtualbox/disk.go
@@ -23,7 +23,8 @@ func parseDiskInfo(r io.Reader) (*VirtualDisk, error) {
 		if res == nil {
 			continue
 		}
-		switch key, val := res[1], res[2]; key {
+		key, val := res[1], res[2]
+		switch key {
 		case "SATA-1-0":
 			disk.Path = val
 		case "SATA-ImageUUID-1-0":

--- a/drivers/virtualbox/disk.go
+++ b/drivers/virtualbox/disk.go
@@ -19,7 +19,7 @@ func parseDiskInfo(r io.Reader) (*VirtualDisk, error) {
 		if line == "" {
 			continue
 		}
-		res := reEqualLine.FindStringSubmatch(line)
+		res := reEqualQuoteLine.FindStringSubmatch(line)
 		if res == nil {
 			continue
 		}

--- a/drivers/virtualbox/disk.go
+++ b/drivers/virtualbox/disk.go
@@ -1,0 +1,46 @@
+package virtualbox
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+type VirtualDisk struct {
+	UUID string
+	Path string
+}
+
+func parseDiskInfo(r io.Reader) (*VirtualDisk, error) {
+	s := bufio.NewScanner(r)
+	disk := &VirtualDisk{}
+	for s.Scan() {
+		line := s.Text()
+		if line == "" {
+			continue
+		}
+		res := reEqualLine.FindStringSubmatch(line)
+		if res == nil {
+			continue
+		}
+		switch key, val := res[1], res[2]; key {
+		case "SATA-1-0":
+			disk.Path = val
+		case "SATA-ImageUUID-1-0":
+			disk.UUID = val
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return disk, nil
+}
+
+func getVMDiskInfo(name string) (*VirtualDisk, error) {
+	out, err := vbmOut("showvminfo", name, "--machinereadable")
+	if err != nil {
+		return nil, err
+	}
+	r := strings.NewReader(out)
+	return parseDiskInfo(r)
+}

--- a/drivers/virtualbox/disk_test.go
+++ b/drivers/virtualbox/disk_test.go
@@ -1,0 +1,36 @@
+package virtualbox
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	testDiskInfoText = `
+storagecontrollerbootable0="on"
+"SATA-0-0"="/home/ehazlett/.boot2docker/boot2docker.iso"
+"SATA-IsEjected"="off"
+"SATA-1-0"="/home/ehazlett/vm/test/disk.vmdk"
+"SATA-ImageUUID-1-0"="12345-abcdefg"
+"SATA-2-0"="none"
+nic1="nat"
+    `
+)
+
+func TestVMDiskInfo(t *testing.T) {
+	r := strings.NewReader(testDiskInfoText)
+	disk, err := parseDiskInfo(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diskPath := "/home/ehazlett/vm/test/disk.vmdk"
+	diskUUID := "12345-abcdefg"
+	if disk.Path != diskPath {
+		t.Fatalf("expected disk path %s", diskPath)
+	}
+
+	if disk.UUID != diskUUID {
+		t.Fatalf("expected disk uuid %s", diskUUID)
+	}
+}

--- a/drivers/virtualbox/vbm.go
+++ b/drivers/virtualbox/vbm.go
@@ -18,6 +18,7 @@ var (
 	reVMNameUUID      = regexp.MustCompile(`"(.+)" {([0-9a-f-]+)}`)
 	reVMInfoLine      = regexp.MustCompile(`(?:"(.+)"|(.+))=(?:"(.*)"|(.*))`)
 	reColonLine       = regexp.MustCompile(`(.+):\s+(.*)`)
+	reEqualLine       = regexp.MustCompile(`"(.+)"="(.*)"`)
 	reMachineNotFound = regexp.MustCompile(`Could not find a registered machine named '(.+)'`)
 )
 

--- a/drivers/virtualbox/vbm.go
+++ b/drivers/virtualbox/vbm.go
@@ -18,7 +18,8 @@ var (
 	reVMNameUUID      = regexp.MustCompile(`"(.+)" {([0-9a-f-]+)}`)
 	reVMInfoLine      = regexp.MustCompile(`(?:"(.+)"|(.+))=(?:"(.*)"|(.*))`)
 	reColonLine       = regexp.MustCompile(`(.+):\s+(.*)`)
-	reEqualLine       = regexp.MustCompile(`"(.+)"="(.*)"`)
+	reEqualLine       = regexp.MustCompile(`(.+)=(.*)`)
+	reEqualQuoteLine  = regexp.MustCompile(`"(.+)"="(.*)"`)
 	reMachineNotFound = regexp.MustCompile(`Could not find a registered machine named '(.+)'`)
 )
 

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -197,13 +197,13 @@ func (d *Driver) Create() error {
 			return err
 		}
 	} else {
-		log.Debugf("Creating disk image...")
-		if err := d.generateDiskImage(d.DiskSize); err != nil {
+		log.Infof("Creating SSH key...")
+		if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 			return err
 		}
 
-		log.Infof("Creating SSH key...")
-		if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+		log.Debugf("Creating disk image...")
+		if err := d.generateDiskImage(d.DiskSize); err != nil {
 			return err
 		}
 	}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -237,8 +237,8 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Infof("CPUS: %d", d.CPU)
-	log.Infof("Mem: %d", d.Memory)
+	log.Debugf("VM CPUS: %d", d.CPU)
+	log.Debugf("VM Memory: %d", d.Memory)
 
 	cpus := d.CPU
 	if cpus < 1 {

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -30,19 +30,20 @@ const (
 )
 
 type Driver struct {
-	CPU            int
-	MachineName    string
-	SSHUser        string
-	SSHPort        int
-	Memory         int
-	DiskSize       int
-	Boot2DockerURL string
-	CaCertPath     string
-	PrivateKeyPath string
-	SwarmMaster    bool
-	SwarmHost      string
-	SwarmDiscovery string
-	storePath      string
+	CPU                 int
+	MachineName         string
+	SSHUser             string
+	SSHPort             int
+	Memory              int
+	DiskSize            int
+	Boot2DockerURL      string
+	CaCertPath          string
+	PrivateKeyPath      string
+	SwarmMaster         bool
+	SwarmHost           string
+	SwarmDiscovery      string
+	storePath           string
+	Boot2DockerImportVM string
 }
 
 func init() {
@@ -79,6 +80,11 @@ func GetCreateFlags() []cli.Flag {
 			Name:   "virtualbox-boot2docker-url",
 			Usage:  "The URL of the boot2docker image. Defaults to the latest available version",
 			Value:  "",
+		},
+		cli.StringFlag{
+			Name:  "virtualbox-import-boot2docker-vm",
+			Usage: "The name of a Boot2Docker VM to import",
+			Value: "",
 		},
 	}
 }
@@ -147,6 +153,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")
 	d.SSHUser = "docker"
+	d.Boot2DockerImportVM = flags.String("virtualbox-import-boot2docker-vm")
 
 	return nil
 }
@@ -170,21 +177,36 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Infof("Creating SSH key...")
-
 	b2dutils := utils.NewB2dUtils("", "")
 	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
 		return err
 	}
 
-	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
-		return err
-	}
-
 	log.Infof("Creating VirtualBox VM...")
 
-	if err := d.generateDiskImage(d.DiskSize); err != nil {
-		return err
+	// import b2d VM if requested
+	if d.Boot2DockerImportVM != "" {
+		log.Debugf("Importing disk image...")
+		if err := d.importB2DVM(d.Boot2DockerImportVM); err != nil {
+			return err
+		}
+
+		log.Debugf("Importing SSH key...")
+		keyPath := filepath.Join(utils.GetHomeDir(), ".ssh", "id_rsa")
+		if err := utils.CopyFile(keyPath, d.GetSSHKeyPath()); err != nil {
+			return err
+		}
+	} else {
+		log.Debugf("Creating disk image...")
+		if err := d.generateDiskImage(d.DiskSize); err != nil {
+			return err
+		}
+
+		log.Infof("Creating SSH key...")
+
+		if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+			return err
+		}
 	}
 
 	if err := vbm("createvm",
@@ -591,6 +613,26 @@ func zeroFill(w io.Writer, n int64) error {
 		}
 		n -= int64(k)
 	}
+	return nil
+}
+
+func (d Driver) importB2DVM(name string) error {
+	// make sure vm is stopped
+	_ = vbm("controlvm", name, "poweroff")
+
+	diskInfo, err := getVMDiskInfo(name)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(diskInfo.Path); err != nil {
+		return err
+	}
+
+	if err := vbm("clonehd", diskInfo.Path, d.diskPath()); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -192,7 +192,7 @@ func (d *Driver) Create() error {
 		}
 
 		log.Debugf("Importing SSH key...")
-		keyPath := filepath.Join(utils.GetHomeDir(), ".ssh", "id_rsa")
+		keyPath := filepath.Join(utils.GetHomeDir(), ".ssh", "id_boot2docker")
 		if err := utils.CopyFile(keyPath, d.GetSSHKeyPath()); err != nil {
 			return err
 		}
@@ -203,7 +203,6 @@ func (d *Driver) Create() error {
 		}
 
 		log.Infof("Creating SSH key...")
-
 		if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 			return err
 		}

--- a/drivers/virtualbox/vm.go
+++ b/drivers/virtualbox/vm.go
@@ -1,0 +1,55 @@
+package virtualbox
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type VirtualBoxVM struct {
+	CPUs   int
+	Memory int
+}
+
+func parseVMInfo(r io.Reader) (*VirtualBoxVM, error) {
+	s := bufio.NewScanner(r)
+	vm := &VirtualBoxVM{}
+	for s.Scan() {
+		line := s.Text()
+		if line == "" {
+			continue
+		}
+		res := reEqualLine.FindStringSubmatch(line)
+		if res == nil {
+			continue
+		}
+		switch key, val := res[1], res[2]; key {
+		case "cpus":
+			v, err := strconv.Atoi(val)
+			if err != nil {
+				return nil, err
+			}
+			vm.CPUs = v
+		case "memory":
+			v, err := strconv.Atoi(val)
+			if err != nil {
+				return nil, err
+			}
+			vm.Memory = v
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return vm, nil
+}
+
+func getVMInfo(name string) (*VirtualBoxVM, error) {
+	out, err := vbmOut("showvminfo", name, "--machinereadable")
+	if err != nil {
+		return nil, err
+	}
+	r := strings.NewReader(out)
+	return parseVMInfo(r)
+}

--- a/drivers/virtualbox/vm_test.go
+++ b/drivers/virtualbox/vm_test.go
@@ -1,0 +1,38 @@
+package virtualbox
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	testVMInfoText = `
+storagecontrollerbootable0="on"
+memory=1024
+cpus=2
+"SATA-0-0"="/home/ehazlett/.boot2docker/boot2docker.iso"
+"SATA-IsEjected"="off"
+"SATA-1-0"="/home/ehazlett/vm/test/disk.vmdk"
+"SATA-ImageUUID-1-0"="12345-abcdefg"
+"SATA-2-0"="none"
+nic1="nat"
+`
+)
+
+func TestVMInfo(t *testing.T) {
+	r := strings.NewReader(testVMInfoText)
+	vm, err := parseVMInfo(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmCPUs := 2
+	vmMemory := 1024
+	if vm.CPUs != vmCPUs {
+		t.Fatalf("expected %d cpus; received %d", vmCPUs, vm.CPUs)
+	}
+
+	if vm.Memory != vmMemory {
+		t.Fatalf("expected memory %d; received %d", vmMemory, vm.Memory)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -79,6 +79,15 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chmod(dst, fi.Mode()); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This adds support for importing a b2d instance (in this case, just the disk).

Discussion:  should we do a full clone of the VM to bring in any changes the user may make to the VM itself?  I didn't do that in the current state as this might add things that Machine does not support (i.e. network configuration, etc).

Refs #904