### PR TITLE
Adding quotes to the usage hint on `docker-machine env`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -750,9 +750,9 @@ func generateUsageHint(machineName string, userShell string) string {
 		}
 	default:
 		if machineName != "" {
-			cmd = fmt.Sprintf("eval $(docker-machine env %s)", machineName)
+			cmd = fmt.Sprintf("eval \"$(docker-machine env %s)\"", machineName)
 		} else {
-			cmd = "eval $(docker-machine env)"
+			cmd = "eval \"$(docker-machine env)\""
 		}
 	}
 


### PR DESCRIPTION
Brings this message in line with the other docs and usage messages.

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>