### PR TITLE
fix ssh key gen bug windows

### DIFF
--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -79,8 +80,12 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 			return ErrUnableToWriteFile
 		}
 
-		if err := f.Chmod(0600); err != nil {
-			return err
+		// windows does not support chmod
+		switch runtime.GOOS {
+		case "darwin", "linux":
+			if err := f.Chmod(0600); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a bug where SSH keys cannot be created on Windows due to lack of `Chmod` support.