### PR TITLE
fakedriver: remove useless methods

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -22,10 +22,6 @@ import (
 	"github.com/docker/machine/state"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 type Driver struct {
 	MachineName             string
 	SubscriptionID          string

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -16,10 +16,6 @@ import (
 	"github.com/docker/machine/state"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 type Driver struct {
 	AccessToken       string
 	DropletID         int
@@ -328,10 +324,6 @@ func (d *Driver) Restart() error {
 func (d *Driver) Kill() error {
 	_, _, err := d.getClient().DropletActions.PowerOff(d.DropletID)
 	return err
-}
-
-func (d *Driver) GetDockerConfigDir() string {
-	return dockerConfigDir
 }
 
 func (d *Driver) getClient() *godo.Client {

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -1,8 +1,6 @@
 package fakedriver
 
 import (
-	"os/exec"
-
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/provider"
 	"github.com/docker/machine/state"
@@ -96,20 +94,4 @@ func (d *FakeDriver) Kill() error {
 
 func (d *FakeDriver) Upgrade() error {
 	return nil
-}
-
-func (d *FakeDriver) StartDocker() error {
-	return nil
-}
-
-func (d *FakeDriver) StopDocker() error {
-	return nil
-}
-
-func (d *FakeDriver) GetDockerConfigDir() string {
-	return ""
-}
-
-func (d *FakeDriver) GetSSHCommand(args ...string) (*exec.Cmd, error) {
-	return &exec.Cmd{}, nil
 }

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -12,10 +12,6 @@ import (
 	"github.com/docker/machine/state"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 // Driver is a struct compatible with the docker.hosts.drivers.Driver interface.
 type Driver struct {
 	MachineName    string

--- a/drivers/hyperv/hyperv_windows.go
+++ b/drivers/hyperv/hyperv_windows.go
@@ -18,10 +18,6 @@ import (
 	"github.com/docker/machine/utils"
 )
 
-const (
-	dockerConfigDir = "/var/lib/boot2docker"
-)
-
 type Driver struct {
 	SSHUser        string
 	SSHPort        int

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -16,10 +16,6 @@ import (
 	"github.com/docker/machine/state"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 type Driver struct {
 	AuthUrl          string
 	Insecure         bool

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -9,10 +9,6 @@ import (
 	"github.com/docker/machine/drivers/openstack"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 // Driver is a machine driver for Rackspace. It's a specialization of the generic OpenStack one.
 type Driver struct {
 	*openstack.Driver
@@ -106,10 +102,6 @@ func NewDriver(machineName string, storePath string, caCert string, privateKey s
 // DriverName is the user-visible name of this driver.
 func (d *Driver) DriverName() string {
 	return "rackspace"
-}
-
-func (d *Driver) GetDockerConfigDir() string {
-	return dockerConfigDir
 }
 
 func missingEnvOrOption(setting, envVar, opt string) error {

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	dockerConfigDir = "/etc/docker"
-	ApiEndpoint     = "https://api.softlayer.com/rest/v3"
+	ApiEndpoint = "https://api.softlayer.com/rest/v3"
 )
 
 type Driver struct {

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	dockerConfigDir = "/var/lib/boot2docker"
-	isoFilename     = "boot2docker.iso"
+	isoFilename = "boot2docker.iso"
 )
 
 type Driver struct {

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -29,10 +29,9 @@ import (
 )
 
 const (
-	B2D_USER        = "docker"
-	B2D_PASS        = "tcuser"
-	dockerConfigDir = "/var/lib/boot2docker"
-	isoFilename     = "boot2docker-1.5.0-GH747.iso"
+	B2D_USER    = "docker"
+	B2D_PASS    = "tcuser"
+	isoFilename = "boot2docker-1.5.0-GH747.iso"
 )
 
 // Driver for VMware Fusion

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -21,10 +21,6 @@ import (
 	"github.com/docker/machine/state"
 )
 
-const (
-	dockerConfigDir = "/etc/docker"
-)
-
 type Driver struct {
 	UserName       string
 	UserPassword   string

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -32,7 +32,6 @@ const (
 	isoFilename        = "boot2docker-1.5.0-GH747.iso"
 	B2D_ISO_NAME       = isoFilename
 	DEFAULT_CPU_NUMBER = 2
-	dockerConfigDir    = "/var/lib/boot2docker"
 	B2D_USER           = "docker"
 	B2D_PASS           = "tcuser"
 )


### PR DESCRIPTION
Since the refactor done in #756, some methods have been removed from the
driver interface. Remove those methods from `fakedriver`:

 - `StartDocker()`
 - `StopDocker()`
 - `GetDockerConfigDir()`
 - `GetSSHCommand()`