### PR TITLE
Windows vbox share

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -330,10 +330,13 @@ func (d *Driver) Create() error {
 
 	var shareName, shareDir string // TODO configurable at some point
 	switch runtime.GOOS {
+	case "windows":
+		shareName = "c/Users"
+		shareDir = "c:\\Users"
 	case "darwin":
 		shareName = "Users"
 		shareDir = "/Users"
-		// TODO "linux" and "windows"
+		// TODO "linux"
 	}
 
 	if shareDir != "" {


### PR DESCRIPTION
This adds `/c/Users` to the VM mounted as `/c/Users/`.  We still have a ways to go as bash in msysgit rewrites the paths so you still cannot use `docker run -v /c/Users/foo/dev:/app` for example.   However, this is a first step :)

Refs #529 