### PR TITLE
Don't let drivers wait for SSH/Docker/State

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -398,12 +398,6 @@ func (d *Driver) Create() error {
 		d.PrivateIPAddress,
 	)
 
-	log.Infof("Waiting for SSH on %s:%d", d.IPAddress, 22)
-
-	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", d.IPAddress, 22)); err != nil {
-		return err
-	}
-
 	log.Debug("Settings tags for instance")
 	tags := map[string]string{
 		"Name": d.MachineName,

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -194,13 +194,6 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		return err
 	}
 
-	instance, err = c.instance()
-	if err != nil {
-		return err
-	}
-	ip := instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-	c.waitForSSH(ip)
-
 	// Update the SSH Key
 	sshKey, err := ioutil.ReadFile(d.GetSSHKeyPath() + ".pub")
 	if err != nil {
@@ -278,12 +271,6 @@ func (c *ComputeUtil) waitForGlobalOp(name string) error {
 	return c.waitForOp(func() (*raw.Operation, error) {
 		return c.service.GlobalOperations.Get(c.project, name).Do()
 	})
-}
-
-// waitForSSH waits for SSH to become ready on the instance.
-func (c *ComputeUtil) waitForSSH(ip string) error {
-	log.Infof("Waiting for SSH...")
-	return ssh.WaitForTCP(fmt.Sprintf("%s:22", ip))
 }
 
 // ip retrieves and returns the external IP address of the instance.

--- a/drivers/hyperv/hyperv_windows.go
+++ b/drivers/hyperv/hyperv_windows.go
@@ -323,12 +323,7 @@ func (d *Driver) wait() error {
 		}
 		time.Sleep(1 * time.Second)
 	}
-	log.Infof("Got IP, waiting for SSH")
-	ip, err := d.GetIP()
-	if err != nil {
-		return err
-	}
-	return ssh.WaitForTCP(fmt.Sprintf("%s:22", ip))
+	return nil
 }
 
 func (d *Driver) Start() error {

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -380,7 +380,7 @@ func (d *Driver) Start() error {
 	if err := d.client.StartInstance(d); err != nil {
 		return err
 	}
-	return d.waitForInstanceToStart()
+	return nil
 }
 
 func (d *Driver) Stop() error {
@@ -392,10 +392,6 @@ func (d *Driver) Stop() error {
 		return err
 	}
 
-	log.WithField("MachineId", d.MachineId).Info("Waiting for the OpenStack instance to stop...")
-	if err := d.client.WaitForInstanceStatus(d, "SHUTOFF", 200); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -423,7 +419,7 @@ func (d *Driver) Restart() error {
 	if err := d.client.RestartInstance(d); err != nil {
 		return err
 	}
-	return d.waitForInstanceToStart()
+	return nil
 }
 
 func (d *Driver) Kill() error {
@@ -690,25 +686,6 @@ func (d *Driver) lookForIpAddress() error {
 		"MachineId": d.MachineId,
 	}).Debug("IP address found")
 	return nil
-}
-
-func (d *Driver) waitForSSHServer() error {
-	ip, err := d.GetIP()
-	if err != nil {
-		return err
-	}
-	log.WithFields(log.Fields{
-		"MachineId": d.MachineId,
-		"IP":        ip,
-	}).Debug("Waiting for the SSH server to be started...")
-	return ssh.WaitForTCP(fmt.Sprintf("%s:%d", ip, d.SSHPort))
-}
-
-func (d *Driver) waitForInstanceToStart() error {
-	if err := d.waitForInstanceActive(); err != nil {
-		return err
-	}
-	return d.waitForSSHServer()
 }
 
 func (d *Driver) publicSSHKeyPath() string {

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -369,9 +369,6 @@ func (d *Driver) Create() error {
 	if err := d.lookForIpAddress(); err != nil {
 		return err
 	}
-	if err := d.waitForSSHServer(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -399,17 +399,6 @@ func (d *Driver) Create() error {
 	d.getIp()
 	d.waitForStart()
 	d.waitForSetupTransactions()
-	ssh.WaitForTCP(d.IPAddress + ":22")
-
-	cmd, err := drivers.GetSSHCommandFromDriver(d, "sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq curl")
-	if err != nil {
-		return err
-
-	}
-	if err := cmd.Run(); err != nil {
-		return err
-
-	}
 
 	return nil
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -343,7 +343,7 @@ func (d *Driver) Start() error {
 		if err := vbm("startvm", d.MachineName, "--type", "headless"); err != nil {
 			return err
 		}
-		log.Infof("Waiting for VM to start...")
+		log.Infof("Starting VM...")
 	case state.Paused:
 		if err := vbm("controlvm", d.MachineName, "resume", "--type", "headless"); err != nil {
 			return err
@@ -353,7 +353,7 @@ func (d *Driver) Start() error {
 		log.Infof("VM not in restartable state")
 	}
 
-	return ssh.WaitForTCP(fmt.Sprintf("localhost:%d", d.SSHPort))
+	return nil
 }
 
 func (d *Driver) Stop() error {

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -409,24 +409,6 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	log.Infof("Waiting for SSH...")
-
-	if err := ssh.WaitForTCP(fmt.Sprintf("%s:%d", d.PublicIP, d.SSHPort)); err != nil {
-		return err
-	}
-
-	connTest := "ping -c 3 www.google.com >/dev/null 2>&1 && ( echo \"Connectivity and DNS tests passed.\" ) || ( echo \"Connectivity and DNS tests failed, trying to add Nameserver to resolv.conf\"; echo \"nameserver 8.8.8.8\" >> /etc/resolv.conf )"
-
-	log.Debugf("Connectivity and DNS sanity test...")
-	cmd, err := drivers.GetSSHCommandFromDriver(d, connTest)
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
 	log.Debugf("Disconnecting from vCloud Air...")
 
 	if err = p.Disconnect(); err != nil {


### PR DESCRIPTION
Waiting for SSH to start or Docker to be available is a step done
directly in the framework (in libmachine). There is no need for the
driver to do that.

Those changes are just untested! Since people copy from drivers, I think this is important to keep the minimal code from each driver. Maybe we should ask each driver maintainer to make the appropriate changes, test them and do a PR. In this case, feel free to discard this one.

The SoftLayer driver still waits for SSH but it needs to `apt-get install curl`. Maybe it could be modified to put this step in some provisioning function instead.

There are separate commits when it is not obvious if the change is correct. For example, in the openstack driver, there is a wait for the machine to be in the correct state. I don't think this is useful since libmachine also does that, but maybe I am mistaken.