### PR TITLE
Deleting Machine-generated SSH key from SoftLayer when host is canceled.

### DIFF
--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -31,6 +31,7 @@ type Driver struct {
 	MachineName    string
 	CaCertPath     string
 	PrivateKeyPath string
+	SSHKeyID       int
 	SwarmMaster    bool
 	SwarmHost      string
 	SwarmDiscovery string
@@ -383,6 +384,9 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+	log.Infof("SSH key %s (%d) created in SoftLayer", key.Label, key.Id)
+	d.SSHKeyID = key.Id
+
 	spec := d.buildHostSpec()
 	spec.SshKeys = []*SshKey{key}
 
@@ -452,7 +456,9 @@ func (d *Driver) publicSSHKeyPath() string {
 func (d *Driver) Kill() error {
 	return d.getClient().VirtualGuest().PowerOff(d.Id)
 }
+
 func (d *Driver) Remove() error {
+	log.Infof("Canceling SoftLayer instance %d...", d.Id)
 	var err error
 	for i := 0; i < 5; i++ {
 		if err = d.getClient().VirtualGuest().Cancel(d.Id); err != nil {
@@ -461,7 +467,16 @@ func (d *Driver) Remove() error {
 		}
 		break
 	}
-	return err
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Removing SSH Key %d...", d.SSHKeyID)
+	if err = d.getClient().SshKey().Delete(d.SSHKeyID); err != nil {
+		return err
+	}
+
+	return nil
 }
 func (d *Driver) Restart() error {
 	return d.getClient().VirtualGuest().Reboot(d.Id)

--- a/drivers/softlayer/softlayer.go
+++ b/drivers/softlayer/softlayer.go
@@ -150,6 +150,19 @@ func (c *sshKey) Create(label, key string) (*SshKey, error) {
 	return &k, nil
 }
 
+func (c *sshKey) Delete(id int) error {
+	var (
+		method = "DELETE"
+		uri    = fmt.Sprintf("%s/%v", c.namespace(), id)
+	)
+
+	_, err := c.newRequest(method, uri, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *Client) VirtualGuest() *virtualGuest {
 	return &virtualGuest{c}
 }


### PR DESCRIPTION
All the other drivers seem to do this, so I can't imagine this is a bad
idea ;)

Fixes #765

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>