### PR TITLE
Softlayer driver, correctly store provisioned VM IP address, issue #915

### DIFF
--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -343,6 +343,7 @@ func (d *Driver) getIp() (string, error) {
 		// not a perfect regex, but should be just fine for our needs
 		exp := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 		if exp.MatchString(ip) {
+			d.IPAddress = ip         
 			return ip, nil
 		}
 		time.Sleep(2 * time.Second)

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -343,7 +343,7 @@ func (d *Driver) getIp() (string, error) {
 		// not a perfect regex, but should be just fine for our needs
 		exp := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 		if exp.MatchString(ip) {
-			d.IPAddress = ip         
+			d.IPAddress = ip
 			return ip, nil
 		}
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
Fix for Docker Machine gets stuck on IBM Softlayer #915
The ip address of the provisioned VM was not being stored in the driver IPAddress variable, this variable
was being used to check if the VM ssh service was up. However as the variable was a blank string the actual address being checked defaulted
to localhost:22, as a result the installation steps on the VM only worked if the user was running an ssh daemon on the machine they were using docker-machine from.

Signed-off-by: Rob Smart <smartrob@uk.ibm.com>