### PR TITLE
Follow the redirects.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ To install on OSX or Linux, download the proper binary to somewhere in your
 most OSX machines these commands should suffice:
 
 ```
-$ curl https://github.com/docker/machine/releases/download/v0.2.0/docker-machine_darwin-amd64 > /usr/local/bin/docker-machine
+$ curl -L https://github.com/docker/machine/releases/download/v0.2.0/docker-machine_darwin-amd64 > /usr/local/bin/docker-machine
 $ chmod +x /usr/local/bin/docker-machine
 ```
 


### PR DESCRIPTION
Otherwise it just errors with:

```
DarronFroeseDD@: docker-machine -v
/usr/local/bin/docker-machine: line 1: syntax error near unexpected token `<'
/usr/local/bin/docker-machine: line 1: `<html><body>You are being <a href="https://s3.amazonaws.com/github-cloud/releases/27494663/a56dd51e-e3cf-11e4-8f5e-ac600ecd75cc?response-content-disposition=attachment%3B%20filename%3Ddocker-machine_darwin-amd64&amp;response-content-type=application/octet-stream&amp;AWSAccessKeyId=AKIAISTNZFOVBIJMK3TQ&amp;Expires=1429217439&amp;Signature=DpwpQR8DBJn1nW6A5C75gXFBF2k%3D">redirected</a>.</body></html>'
```