### PR TITLE
shell selection for env

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -658,8 +659,8 @@ func detectShell() (string, error) {
 	// attempt to get the SHELL env var
 	shell := filepath.Base(os.Getenv("SHELL"))
 	// none detected; check for windows env
-	if shell == "." && os.Getenv("windir") != "" {
-		log.Printf("On Windows, please specify either cmd or powershell with the --shell flag.\n\n")
+	if runtime.GOOS == "windows" {
+		log.Printf("On Windows, please specify either 'cmd' or 'powershell' with the --shell flag.\n\n")
 		return "", ErrUnknownShell
 	}
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -228,6 +228,10 @@ var Commands = []cli.Command{
 				Name:  "swarm",
 				Usage: "Display the Swarm config instead of the Docker daemon",
 			},
+			cli.StringFlag{
+				Name:  "shell",
+				Usage: "Force environment to be configured for specified shell",
+			},
 			cli.BoolFlag{
 				Name:  "unset, u",
 				Usage: "Unset variables instead of setting them",

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,6 +32,10 @@ import (
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/state"
 	"github.com/docker/machine/utils"
+)
+
+var (
+	ErrUnknownShell = errors.New("unknown shell")
 )
 
 type machineConfig struct {
@@ -647,4 +652,20 @@ func getCertPathInfo(c *cli.Context) libmachine.CertPathInfo {
 		ClientCertPath: clientCertPath,
 		ClientKeyPath:  clientKeyPath,
 	}
+}
+
+func detectShell() (string, error) {
+	// attempt to get the SHELL env var
+	shell := filepath.Base(os.Getenv("SHELL"))
+	// none detected; check for windows env
+	if shell == "." && os.Getenv("windir") != "" {
+		log.Printf("On Windows, please specify either cmd or powershell with the --shell flag.\n\n")
+		return "", ErrUnknownShell
+	}
+
+	if shell == "" {
+		return "", ErrUnknownShell
+	}
+
+	return shell, nil
 }

--- a/commands/create.go
+++ b/commands/create.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
@@ -89,21 +88,8 @@ func cmdCreate(c *cli.Context) {
 		log.Fatalf("error setting active host: %v", err)
 	}
 
-	info := ""
-	userShell := filepath.Base(os.Getenv("SHELL"))
-
-	switch userShell {
-	case "fish":
-		info = fmt.Sprintf("%s env %s | source", c.App.Name, name)
-	default:
-		info = fmt.Sprintf(`eval "$(%s env %s)"`, c.App.Name, name)
-	}
-
-	log.Infof("%q has been created and is now the active machine.", name)
-
-	if info != "" {
-		log.Infof("To point your Docker client at it, run this in your shell: %s", info)
-	}
+	info := fmt.Sprintf("%s env %s", c.App.Name, name)
+	log.Infof("To point your Docker client at it, run this in your shell: %s", info)
 }
 
 // If the user has specified a driver, they should not see the flags for all

--- a/commands/env.go
+++ b/commands/env.go
@@ -39,7 +39,7 @@ func cmdEnv(c *cli.Context) {
 
 	t := template.New("envConfig")
 
-	usageHint := generateUsageHint(c.Args().First(), userShell)
+	usageHint := generateUsageHint(c.App.Name, c.Args().First(), userShell)
 
 	shellCfg := ShellConfig{
 		DockerCertPath:  "",
@@ -89,7 +89,7 @@ func cmdEnv(c *cli.Context) {
 	}
 
 	if cfg.machineUrl == "" {
-		log.Fatalf("%s is not running. Please start this with docker-machine start %s", cfg.machineName, cfg.machineName)
+		log.Fatalf("%s is not running. Please start this with %s start %s", cfg.machineName, c.App.Name, cfg.machineName)
 	}
 
 	dockerHost := cfg.machineUrl
@@ -177,28 +177,28 @@ func cmdEnv(c *cli.Context) {
 	}
 }
 
-func generateUsageHint(machineName string, userShell string) string {
+func generateUsageHint(appName, machineName, userShell string) string {
 	cmd := ""
 	switch userShell {
 	case "fish":
 		if machineName != "" {
-			cmd = fmt.Sprintf("eval (docker-machine env %s)", machineName)
+			cmd = fmt.Sprintf("eval (%s env %s)", appName, machineName)
 		} else {
-			cmd = "eval (docker-machine env)"
+			cmd = fmt.Sprintf("eval (%s env)", appName)
 		}
 	case "powershell":
 		if machineName != "" {
-			cmd = fmt.Sprintf("docker-machine env %s | Invoke-Expression", machineName)
+			cmd = fmt.Sprintf("%s env %s | Invoke-Expression", appName, machineName)
 		} else {
-			cmd = "Param(docker-machine env)"
+			cmd = fmt.Sprintf("Param(%s env)", appName)
 		}
 	case "cmd":
 		cmd = "copy and paste the above values into your command prompt"
 	default:
 		if machineName != "" {
-			cmd = fmt.Sprintf("eval \"$(docker-machine env %s)\"", machineName)
+			cmd = fmt.Sprintf("eval \"$(%s env %s)\"", appName, machineName)
 		} else {
-			cmd = "eval \"$(docker-machine env)\""
+			cmd = fmt.Sprintf("eval \"$(%s env)\"", appName)
 		}
 	}
 

--- a/commands/env.go
+++ b/commands/env.go
@@ -151,8 +151,8 @@ func cmdEnv(c *cli.Context) {
 	switch userShell {
 	case "fish":
 		shellCfg.Prefix = "set -x "
-		shellCfg.Suffix = ";\n"
-		shellCfg.Delimiter = " "
+		shellCfg.Suffix = "\";\n"
+		shellCfg.Delimiter = " \""
 	case "powershell":
 		shellCfg.Prefix = "$Env:"
 		shellCfg.Suffix = "\"\n"
@@ -163,8 +163,8 @@ func cmdEnv(c *cli.Context) {
 		shellCfg.Delimiter = "="
 	default:
 		shellCfg.Prefix = "export "
-		shellCfg.Suffix = "\n"
-		shellCfg.Delimiter = "="
+		shellCfg.Suffix = "\"\n"
+		shellCfg.Delimiter = "=\""
 	}
 
 	tmpl, err := t.Parse(envTmpl)

--- a/commands/env.go
+++ b/commands/env.go
@@ -22,6 +22,8 @@ func cmdEnv(c *cli.Context) {
 		switch userShell {
 		case "fish":
 			fmt.Printf("set -e DOCKER_TLS_VERIFY;\nset -e DOCKER_CERT_PATH;\nset -e DOCKER_HOST;\n")
+		case "powershell":
+			fmt.Printf("Remove-Item Env:\\DOCKER_TLS_VERIFY\nRemove-Item Env:\\DOCKER_CERT_PATH\nRemove-Item Env:\\DOCKER_HOST\n")
 		default:
 			fmt.Println("unset DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_HOST")
 		}
@@ -93,8 +95,8 @@ func cmdEnv(c *cli.Context) {
 		fmt.Printf("set -x DOCKER_TLS_VERIFY 1;\nset -x DOCKER_CERT_PATH %q;\nset -x DOCKER_HOST %s;\n\n%s\n",
 			cfg.machineDir, dockerHost, usageHint)
 	case "powershell":
-		fmt.Printf("$env:DOCKER_TLS_VERIFY=1\n$env:DOCKER_CERT_PATH=\"%s\"\n$env:DOCKER_HOST=\"%s\"\n\n%s\n",
-			cfg.machineDir, dockerHost, usageHint)
+		fmt.Printf("$Env:DOCKER_TLS_VERIFY = 1\n$Env:DOCKER_CERT_PATH = \"%s\"\n$Env:DOCKER_HOST = \"%s\"\n",
+			cfg.machineDir, dockerHost)
 	default:
 		fmt.Printf("export DOCKER_TLS_VERIFY=1\nexport DOCKER_CERT_PATH=%q\nexport DOCKER_HOST=%s\n\n%s\n",
 			cfg.machineDir, dockerHost, usageHint)

--- a/commands/env.go
+++ b/commands/env.go
@@ -14,7 +14,10 @@ import (
 )
 
 func cmdEnv(c *cli.Context) {
-	userShell := filepath.Base(os.Getenv("SHELL"))
+	userShell := c.String("shell")
+	if userShell == "" {
+		userShell = filepath.Base(os.Getenv("SHELL"))
+	}
 	if c.Bool("unset") {
 		switch userShell {
 		case "fish":
@@ -89,6 +92,9 @@ func cmdEnv(c *cli.Context) {
 	case "fish":
 		fmt.Printf("set -x DOCKER_TLS_VERIFY 1;\nset -x DOCKER_CERT_PATH %q;\nset -x DOCKER_HOST %s;\n\n%s\n",
 			cfg.machineDir, dockerHost, usageHint)
+	case "powershell":
+		fmt.Printf("$env:DOCKER_TLS_VERIFY=1\n$env:DOCKER_CERT_PATH=\"%s\"\n$env:DOCKER_HOST=\"%s\"\n\n%s\n",
+			cfg.machineDir, dockerHost, usageHint)
 	default:
 		fmt.Printf("export DOCKER_TLS_VERIFY=1\nexport DOCKER_CERT_PATH=%q\nexport DOCKER_HOST=%s\n\n%s\n",
 			cfg.machineDir, dockerHost, usageHint)
@@ -98,6 +104,12 @@ func cmdEnv(c *cli.Context) {
 func generateUsageHint(machineName string, userShell string) string {
 	cmd := ""
 	switch userShell {
+	case "powershell":
+		if machineName != "" {
+			cmd = fmt.Sprintf("Param(docker-machine env %s)", machineName)
+		} else {
+			cmd = "Param(docker-machine env)"
+		}
 	case "fish":
 		if machineName != "" {
 			cmd = fmt.Sprintf("eval (docker-machine env %s)", machineName)

--- a/commands/env.go
+++ b/commands/env.go
@@ -188,9 +188,9 @@ func generateUsageHint(appName, machineName, userShell string) string {
 		}
 	case "powershell":
 		if machineName != "" {
-			cmd = fmt.Sprintf("%s env %s | Invoke-Expression", appName, machineName)
+			cmd = fmt.Sprintf("%s env --shell=powershell %s | Invoke-Expression", appName, machineName)
 		} else {
-			cmd = fmt.Sprintf("Param(%s env)", appName)
+			cmd = fmt.Sprintf("%s env --shell=powershell | Invoke-Expression", appName)
 		}
 	case "cmd":
 		cmd = "copy and paste the above values into your command prompt"

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -103,9 +103,9 @@ func TestCmdEnvBash(t *testing.T) {
 	testMachineDir := filepath.Join(store.GetPath(), "machines", host.Name)
 
 	expected := map[string]string{
-		"DOCKER_TLS_VERIFY": "1",
+		"DOCKER_TLS_VERIFY": "\"1\"",
 		"DOCKER_CERT_PATH":  fmt.Sprintf("\"%s\"", testMachineDir),
-		"DOCKER_HOST":       "unix:///var/run/docker.sock",
+		"DOCKER_HOST":       "\"unix:///var/run/docker.sock\"",
 	}
 
 	for k, v := range envvars {
@@ -201,9 +201,108 @@ func TestCmdEnvFish(t *testing.T) {
 	testMachineDir := filepath.Join(store.GetPath(), "machines", host.Name)
 
 	expected := map[string]string{
-		"DOCKER_TLS_VERIFY": "1",
+		"DOCKER_TLS_VERIFY": "\"1\"",
 		"DOCKER_CERT_PATH":  fmt.Sprintf("\"%s\"", testMachineDir),
-		"DOCKER_HOST":       "unix:///var/run/docker.sock",
+		"DOCKER_HOST":       "\"unix:///var/run/docker.sock\"",
+	}
+
+	for k, v := range envvars {
+		if v != expected[k] {
+			t.Fatalf("Expected %s == <%s>, but was <%s>", k, expected[k], v)
+		}
+	}
+}
+
+func TestCmdEnvPowerShell(t *testing.T) {
+	stdout := os.Stdout
+	shell := os.Getenv("SHELL")
+	r, w, _ := os.Pipe()
+
+	os.Stdout = w
+	os.Setenv("MACHINE_STORAGE_PATH", TestStoreDir)
+	os.Setenv("SHELL", "")
+
+	defer func() {
+		os.Setenv("MACHINE_STORAGE_PATH", "")
+		os.Setenv("SHELL", shell)
+		os.Stdout = stdout
+	}()
+
+	if err := clearHosts(); err != nil {
+		t.Fatal(err)
+	}
+
+	flags := getTestDriverFlags()
+
+	store, sErr := getTestStore()
+	if sErr != nil {
+		t.Fatal(sErr)
+	}
+
+	mcn, err := libmachine.New(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hostOptions := &libmachine.HostOptions{
+		EngineOptions: &engine.EngineOptions{},
+		SwarmOptions: &swarm.SwarmOptions{
+			Master:    false,
+			Discovery: "",
+			Address:   "",
+			Host:      "",
+		},
+		AuthOptions: &auth.AuthOptions{},
+	}
+
+	host, err := mcn.Create("test-a", "none", hostOptions, flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	host, err = mcn.Get("test-a")
+	if err != nil {
+		t.Fatalf("error loading host: %v", err)
+	}
+
+	if err := mcn.SetActive(host); err != nil {
+		t.Fatalf("error setting active host: %v", err)
+	}
+
+	outStr := make(chan string)
+
+	go func() {
+		var testOutput bytes.Buffer
+		io.Copy(&testOutput, r)
+		outStr <- testOutput.String()
+	}()
+
+	set := flag.NewFlagSet("config", 0)
+	set.String("shell", "powershell", "")
+	c := cli.NewContext(nil, set, set)
+	cmdEnv(c)
+
+	w.Close()
+
+	out := <-outStr
+
+	// parse the output into a map of envvar:value for easier testing below
+	envvars := make(map[string]string)
+	for _, e := range strings.Split(strings.TrimSpace(out), "\n") {
+		if !strings.HasPrefix(e, "$Env") {
+			continue
+		}
+		kv := strings.SplitN(e, " = ", 2)
+		key, value := kv[0], kv[1]
+		envvars[strings.Replace(key, "$Env:", "", 1)] = value
+	}
+
+	testMachineDir := filepath.Join(store.GetPath(), "machines", host.Name)
+
+	expected := map[string]string{
+		"DOCKER_TLS_VERIFY": "\"1\"",
+		"DOCKER_CERT_PATH":  fmt.Sprintf("\"%s\"", testMachineDir),
+		"DOCKER_HOST":       "\"unix:///var/run/docker.sock\"",
 	}
 
 	for k, v := range envvars {

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -83,6 +83,9 @@ func TestCmdEnvBash(t *testing.T) {
 
 	set := flag.NewFlagSet("config", 0)
 	c := cli.NewContext(nil, set, set)
+	c.App = &cli.App{
+		Name: "docker-machine-test",
+	}
 	cmdEnv(c)
 
 	w.Close()
@@ -181,6 +184,9 @@ func TestCmdEnvFish(t *testing.T) {
 
 	set := flag.NewFlagSet("config", 0)
 	c := cli.NewContext(nil, set, set)
+	c.App = &cli.App{
+		Name: "docker-machine-test",
+	}
 	cmdEnv(c)
 
 	w.Close()
@@ -280,6 +286,9 @@ func TestCmdEnvPowerShell(t *testing.T) {
 	set := flag.NewFlagSet("config", 0)
 	set.String("shell", "powershell", "")
 	c := cli.NewContext(nil, set, set)
+	c.App = &cli.App{
+		Name: "docker-machine-test",
+	}
 	cmdEnv(c)
 
 	w.Close()

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -424,7 +424,7 @@ func (d *Driver) Remove() error {
 		return err
 	}
 	if s == state.Running {
-		if err := d.Kill(); err != nil {
+		if err := d.Stop(); err != nil {
 			return err
 		}
 	}

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"runtime"
-	"syscall"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -83,9 +82,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 
 		// windows does not support chmod
 		switch runtime.GOOS {
-		case "windows":
-			syscall.Chmod(f.Name(), 0600)
-		default:
+		case "darwin", "linux":
 			if err := f.Chmod(0600); err != nil {
 				return err
 			}

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"syscall"
 
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -82,7 +83,9 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 
 		// windows does not support chmod
 		switch runtime.GOOS {
-		case "darwin", "linux":
+		case "windows":
+			syscall.Chmod(f.Name(), 0600)
+		default:
 			if err := f.Chmod(0600); err != nil {
 				return err
 			}


### PR DESCRIPTION
This adds PowerShell support and shell selection support (to force selection for `bash`, `fish`, etc) for the `env` command.

Refs #906 