### PR TITLE
Update VMware Fusion and vSphere driver to run boot2docker 1.6.0

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -31,7 +31,7 @@ import (
 const (
 	B2D_USER    = "docker"
 	B2D_PASS    = "tcuser"
-	isoFilename = "boot2docker-1.5.0-GH747.iso"
+	isoFilename = "boot2docker-1.6.0-vmw.iso"
 )
 
 // Driver for VMware Fusion
@@ -223,7 +223,7 @@ func (d *Driver) Create() error {
 		//}
 
 		// see https://github.com/boot2docker/boot2docker/pull/747
-		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/1.5.0-GH747/boot2docker-1.5.0-GH747.iso"
+		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.6.0-vmw/boot2docker-1.6.0-vmw.iso"
 
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)
@@ -278,9 +278,8 @@ func (d *Driver) Create() error {
 		}
 	}
 
-	if err := d.Start(); err != nil {
-		return err
-	}
+	log.Infof("Starting %s...", d.MachineName)
+	vmrun("start", d.vmxPath(), "nogui")
 
 	var ip string
 
@@ -320,12 +319,51 @@ func (d *Driver) Create() error {
 	// Expand tar file.
 	vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo /bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar && sudo tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1 && sudo chown -R docker:staff /home/docker")
 
+	// Enable Shared Folders
+	vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "enableSharedFolders", d.vmxPath())
+
+	var shareName, shareDir string // TODO configurable at some point
+	switch runtime.GOOS {
+	case "darwin":
+		shareName = "Users"
+		shareDir = "/Users"
+		// TODO "linux" and "windows"
+	}
+
+	if shareDir != "" {
+		if _, err := os.Stat(shareDir); err != nil && !os.IsNotExist(err) {
+			return err
+		} else if !os.IsNotExist(err) {
+			// add shared folder, create mountpoint and mount it.
+			vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "addSharedFolder", d.vmxPath(), shareName, shareDir)
+			vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo mkdir "+shareDir+" && sudo mount -t vmhgfs .host:/"+shareName+" "+shareDir)
+		}
+	}
 	return nil
 }
 
 func (d *Driver) Start() error {
 	log.Infof("Starting %s...", d.MachineName)
 	vmrun("start", d.vmxPath(), "nogui")
+
+	log.Debugf("Mounting Shared Folders...")
+	var shareName, shareDir string // TODO configurable at some point
+	switch runtime.GOOS {
+	case "darwin":
+		shareName = "Users"
+		shareDir = "/Users"
+		// TODO "linux" and "windows"
+	}
+
+	if shareDir != "" {
+		if _, err := os.Stat(shareDir); err != nil && !os.IsNotExist(err) {
+			return err
+		} else if !os.IsNotExist(err) {
+			// create mountpoint and mount shared folder
+			vmrun("-gu", B2D_USER, "-gp", B2D_PASS, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo mkdir "+shareDir+" && sudo mount -t vmhgfs .host:/"+shareName+" "+shareDir)
+		}
+	}
+
 	return nil
 }
 

--- a/drivers/vmwarefusion/vmx_darwin.go
+++ b/drivers/vmwarefusion/vmx_darwin.go
@@ -61,4 +61,6 @@ virtualHW.version = "10"
 msg.autoanswer = "TRUE"
 uuid.action = "create"
 numvcpus = "{{.CPUs}}"
+hgfs.mapRootShare = "FALSE"
+hgfs.linkRootShare = "FALSE"
 `

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	DATASTORE_DIR      = "boot2docker-iso"
-	isoFilename        = "boot2docker-1.5.0-GH747.iso"
+	isoFilename        = "boot2docker-1.6.0-vmw.iso"
 	B2D_ISO_NAME       = isoFilename
 	DEFAULT_CPU_NUMBER = 2
 	B2D_USER           = "docker"
@@ -302,7 +302,7 @@ func (d *Driver) Create() error {
 		//}
 
 		// see https://github.com/boot2docker/boot2docker/pull/747
-		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/1.5.0-GH747/boot2docker-1.5.0-GH747.iso"
+		isoURL := "https://github.com/cloudnativeapps/boot2docker/releases/download/v1.6.0-vmw/boot2docker-1.6.0-vmw.iso"
 
 		if _, err := os.Stat(commonIsoPath); os.IsNotExist(err) {
 			log.Infof("Downloading boot2docker.iso to %s...", commonIsoPath)

--- a/test/integration/driver-vmwarefusion.bats
+++ b/test/integration/driver-vmwarefusion.bats
@@ -4,106 +4,106 @@ load helpers
 
 export DRIVER=vmwarefusion
 export NAME="bats-$DRIVER-test"
-export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
+export MACHINE_STORAGE_PATH=/tmp/docker-machine-bats-test-$DRIVER
 
 function setup() {
   # add sleep because vbox; ugh
   sleep 1
 }
 
-@test "$DRIVER: machine should not exist" {
-  run machine active $NAME
+@test "$DRIVER: docker-machine should not exist" {
+  run docker-machine active $NAME
   [ "$status" -eq 1  ]
 }
 
 @test "$DRIVER: create" {
-  run machine create -d $DRIVER $NAME
+  run docker-machine create -d $DRIVER $NAME
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: active" {
-  run machine active $NAME
+  run docker-machine active $NAME
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: ls" {
-  run machine ls
+  run docker-machine ls
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"$NAME"*  ]]
 }
 
 @test "$DRIVER: run busybox container" {
-  run docker $(machine config $NAME) run busybox echo hello world
+  run docker $(docker-machine config $NAME) run busybox echo hello world
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: url" {
-  run machine url $NAME
+  run docker-machine url $NAME
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: ip" {
-  run machine ip $NAME
+  run docker-machine ip $NAME
   [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: ssh" {
-  run machine ssh $NAME -- ls -lah /
+  run docker-machine ssh $NAME -- ls -lah /
   [ "$status" -eq 0  ]
   [[ ${lines[0]} =~ "total"  ]]
 }
 
 @test "$DRIVER: stop" {
-  run machine stop $NAME
+  run docker-machine stop $NAME
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: machine should show stopped after stop" {
-  run machine ls
+@test "$DRIVER: docker-machine should show stopped after stop" {
+  run docker-machine ls
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
 @test "$DRIVER: start" {
-  run machine start $NAME
+  run docker-machine start $NAME
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: machine should show running after start" {
-  run machine ls
+@test "$DRIVER: docker-machine should show running after start" {
+  run docker-machine ls
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 
 @test "$DRIVER: kill" {
-  run machine kill $NAME
+  run docker-machine kill $NAME
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: machine should show stopped after kill" {
-  run machine ls
+@test "$DRIVER: docker-machine should show stopped after kill" {
+  run docker-machine ls
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"Stopped"*  ]]
 }
 
 @test "$DRIVER: restart" {
-  run machine restart $NAME
+  run docker-machine restart $NAME
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: machine should show running after restart" {
-  run machine ls
+@test "$DRIVER: docker-machine should show running after restart" {
+  run docker-machine ls
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"Running"*  ]]
 }
 
 @test "$DRIVER: remove" {
-  run machine rm -f $NAME
+  run docker-machine rm -f $NAME
   [ "$status" -eq 0  ]
 }
 
-@test "$DRIVER: machine should not exist" {
-  run machine active $NAME
+@test "$DRIVER: docker-machine should not exist" {
+  run docker-machine active $NAME
   [ "$status" -eq 1  ]
 }
 
@@ -111,4 +111,3 @@ function setup() {
   run rm -rf $MACHINE_STORAGE_PATH
   [ "$status" -eq 0  ]
 }
-


### PR DESCRIPTION
- Update custom ISO to docker 1.6.0.
- Shared folder support for VMware Fusion.
- Updated bats test for Fusion.

```shell
$ bats test/integration/driver-vmwarefusion.bats
 ✓ vmwarefusion: docker-machine should not exist
 ✓ vmwarefusion: create
 ✓ vmwarefusion: active
 ✓ vmwarefusion: ls
 ✓ vmwarefusion: run busybox container
 ✓ vmwarefusion: url
 ✓ vmwarefusion: ip
 ✓ vmwarefusion: ssh
 ✓ vmwarefusion: stop
 ✓ vmwarefusion: docker-machine should show stopped after stop
 ✓ vmwarefusion: start
 ✓ vmwarefusion: docker-machine should show running after start
 ✓ vmwarefusion: kill
 ✓ vmwarefusion: docker-machine should show stopped after kill
 ✓ vmwarefusion: restart
 ✓ vmwarefusion: docker-machine should show running after restart
 ✓ vmwarefusion: remove
 ✓ vmwarefusion: docker-machine should not exist
 ✓ vmwarefusion: cleanup

19 tests, 0 failures
```

Fixes #1021 #1020 #641 #532 #430