### PR TITLE
Moves the 'stopping machine' log below error log

### DIFF
--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -50,12 +50,12 @@ func (provisioner *Boot2DockerProvisioner) Service(name string, action pkgaction
 }
 
 func (provisioner *Boot2DockerProvisioner) upgradeIso() error {
-	log.Infof("Stopping machine to do the upgrade...")
-
 	switch provisioner.Driver.DriverName() {
 	case "vmwarefusion", "vmwarevsphere":
 		return errors.New("Upgrade functionality is currently not supported for these providers, as they use a custom ISO.")
 	}
+
+	log.Info("Stopping machine to do the upgrade...")
 
 	if err := provisioner.Driver.Stop(); err != nil {
 		return err


### PR DESCRIPTION
As it doesn't make sense to first tell that the machine will be stopped for upgrade, but then throw an error that it isn't possible at all, I moved the 'stopping machine' info log below the error log.
This seems to be a legit change, as the machine isn't stopped at all...

Fixes #1032.