### PR TITLE
Adding/Renaming IPAddress properties for consistency across drivers

### DIFF
--- a/commands/inspect_test.go
+++ b/commands/inspect_test.go
@@ -29,7 +29,7 @@ func TestCmdInspectFormat(t *testing.T) {
 	assert.Equal(t, "\"none\"", actual)
 
 	actual, _ = runInspectCommand(t, []string{"--format", "{{prettyjson .Driver}}"})
-	assert.Equal(t, "{\n    \"URL\": \"unix:///var/run/docker.sock\"\n}", actual)
+	assert.Equal(t, "{\n    \"IPAddress\": \"\",\n    \"URL\": \"unix:///var/run/docker.sock\"\n}", actual)
 }
 
 func runInspectCommand(t *testing.T, args []string) (string, *libmachine.Host) {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -21,6 +21,7 @@ import (
 )
 
 type Driver struct {
+	IPAddress               string
 	MachineName             string
 	SubscriptionID          string
 	SubscriptionCert        string
@@ -312,7 +313,9 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	return nil
+	var err error
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Stop() error {
@@ -329,7 +332,12 @@ func (d *Driver) Stop() error {
 
 	log.Debugf("stopping %s", d.MachineName)
 
-	return vmClient.ShutdownRole(d.MachineName, d.MachineName, d.MachineName)
+	if err := vmClient.ShutdownRole(d.MachineName, d.MachineName, d.MachineName); err != nil {
+		return err
+	}
+
+	d.IPAddress = ""
+	return nil
 }
 
 func (d *Driver) Remove() error {
@@ -364,7 +372,8 @@ func (d *Driver) Restart() error {
 		return err
 	}
 
-	return nil
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Kill() error {
@@ -381,7 +390,12 @@ func (d *Driver) Kill() error {
 
 	log.Debugf("killing %s", d.MachineName)
 
-	return vmClient.ShutdownRole(d.MachineName, d.MachineName, d.MachineName)
+	if err := vmClient.ShutdownRole(d.MachineName, d.MachineName, d.MachineName); err != nil {
+		return err
+	}
+
+	d.IPAddress = ""
+	return nil
 }
 
 func generateVMName() string {

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -14,6 +14,7 @@ import (
 
 // Driver is a struct compatible with the docker.hosts.drivers.Driver interface.
 type Driver struct {
+	IPAddress      string
 	MachineName    string
 	SSHUser        string
 	SSHPort        int
@@ -250,7 +251,11 @@ func (d *Driver) Start() error {
 	if err != nil {
 		return err
 	}
-	return c.createInstance(d)
+	if err = c.createInstance(d); err != nil {
+		return err
+	}
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 // Stop deletes the GCE instance, but keeps the disk.
@@ -259,7 +264,11 @@ func (d *Driver) Stop() error {
 	if err != nil {
 		return err
 	}
-	return c.deleteInstance()
+	if err = c.deleteInstance(); err != nil {
+		return err
+	}
+	d.IPAddress = ""
+	return nil
 }
 
 // Remove deletes the GCE instance and the disk.

--- a/drivers/hyperv/hyperv_windows.go
+++ b/drivers/hyperv/hyperv_windows.go
@@ -19,6 +19,7 @@ import (
 )
 
 type Driver struct {
+	IPAddress      string
 	SSHUser        string
 	SSHPort        int
 	storePath      string
@@ -334,7 +335,13 @@ func (d *Driver) Start() error {
 	if err != nil {
 		return err
 	}
-	return d.wait()
+
+	if err := d.wait(); err != nil {
+		return err
+	}
+
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Stop() error {
@@ -356,6 +363,7 @@ func (d *Driver) Stop() error {
 			break
 		}
 	}
+	d.IPAddress = ""
 	return nil
 }
 
@@ -406,6 +414,7 @@ func (d *Driver) Kill() error {
 			break
 		}
 	}
+	d.IPAddress = ""
 	return nil
 }
 

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -2,6 +2,7 @@ package none
 
 import (
 	"fmt"
+	neturl "net/url"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/drivers"
@@ -13,7 +14,8 @@ import (
 // connect to existing Docker hosts by specifying the URL of the host as
 // an option.
 type Driver struct {
-	URL string
+	IPAddress string
+	URL       string
 }
 
 func init() {
@@ -54,7 +56,7 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	return "", nil
+	return d.IPAddress, nil
 }
 
 func (d *Driver) GetMachineName() string {
@@ -113,6 +115,12 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	d.URL = url
+	u, err := neturl.Parse(url)
+	if err != nil {
+		return err
+	}
+
+	d.IPAddress = u.Host
 	return nil
 }
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -41,7 +41,7 @@ type Driver struct {
 	FloatingIpPoolId string
 	SSHUser          string
 	SSHPort          int
-	Ip               string
+	IPAddress        string
 	CaCertPath       string
 	PrivateKeyPath   string
 	storePath        string
@@ -278,8 +278,8 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetIP() (string, error) {
-	if d.Ip != "" {
-		return d.Ip, nil
+	if d.IPAddress != "" {
+		return d.IPAddress, nil
 	}
 
 	log.WithField("MachineId", d.MachineId).Debug("Looking for the IP address...")
@@ -663,7 +663,7 @@ func (d *Driver) assignFloatingIp() error {
 	if err := d.client.AssignFloatingIP(d, floatingIp, portId); err != nil {
 		return err
 	}
-	d.Ip = floatingIp.Ip
+	d.IPAddress = floatingIp.Ip
 	return nil
 }
 
@@ -680,7 +680,7 @@ func (d *Driver) lookForIpAddress() error {
 	if err != nil {
 		return err
 	}
-	d.Ip = ip
+	d.IPAddress = ip
 	log.WithFields(log.Fields{
 		"IP":        ip,
 		"MachineId": d.MachineId,

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -30,6 +30,7 @@ const (
 )
 
 type Driver struct {
+	IPAddress           string
 	CPU                 int
 	MachineName         string
 	SSHUser             string
@@ -392,7 +393,8 @@ func (d *Driver) Start() error {
 		log.Infof("VM not in restartable state")
 	}
 
-	return nil
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Stop() error {
@@ -410,6 +412,9 @@ func (d *Driver) Stop() error {
 			break
 		}
 	}
+
+	d.IPAddress = ""
+
 	return nil
 }
 

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -22,6 +22,7 @@ import (
 )
 
 type Driver struct {
+	IPAddress      string
 	UserName       string
 	UserPassword   string
 	ComputeID      string
@@ -418,8 +419,8 @@ func (d *Driver) Create() error {
 	// Set VAppID with ID of the created VApp
 	d.VAppID = vapp.VApp.ID
 
-	return nil
-
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Remove() error {
@@ -497,7 +498,6 @@ func (d *Driver) Remove() error {
 	}
 
 	return nil
-
 }
 
 func (d *Driver) Start() error {
@@ -540,8 +540,8 @@ func (d *Driver) Start() error {
 		return err
 	}
 
-	return nil
-
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Stop() error {
@@ -584,8 +584,9 @@ func (d *Driver) Stop() error {
 		return err
 	}
 
-	return nil
+	d.IPAddress = ""
 
+	return nil
 }
 
 func (d *Driver) Restart() error {
@@ -640,8 +641,8 @@ func (d *Driver) Restart() error {
 		return err
 	}
 
-	return nil
-
+	d.IPAddress, err = d.GetIP()
+	return err
 }
 
 func (d *Driver) Kill() error {
@@ -683,8 +684,9 @@ func (d *Driver) Kill() error {
 		return err
 	}
 
-	return nil
+	d.IPAddress = ""
 
+	return nil
 }
 
 // Helpers

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -37,6 +37,7 @@ const (
 )
 
 type Driver struct {
+	IPAddress      string
 	MachineName    string
 	SSHUser        string
 	SSHPort        int
@@ -406,7 +407,8 @@ func (d *Driver) Start() error {
 			return err
 		}
 
-		return nil
+		d.IPAddress, err = d.GetIP()
+		return err
 	}
 	return errors.NewInvalidStateError(d.MachineName)
 }
@@ -416,6 +418,8 @@ func (d *Driver) Stop() error {
 	if err := vcConn.VMShutdown(); err != nil {
 		return err
 	}
+
+	d.IPAddress = ""
 
 	return nil
 }
@@ -473,6 +477,8 @@ func (d *Driver) Kill() error {
 	if err := vcConn.VMPowerOff(); err != nil {
 		return err
 	}
+
+	d.IPAddress = ""
 
 	return nil
 }


### PR DESCRIPTION
Addresses #1041, and vaguely mentioned during #921...

This is primarily for consistent UX on `docker inspect` commands. Specifically, I should be able to retrieve a host's IP address for any driver with `docker-machine inspect -f '{{.Driver.IPAddress}}'`

For each driver (except probably `fakedriver` and `none`), an `IPAddress` field should be added to the `Driver` struct.

I'll update this list as I get the different drivers updated:
- [x] amazonec2 _(previously done)_
- [x] azure
- [x] digitalocean _(previously done)_
- [x] google
- [x] hyperv
- [x] none
- [x] openstack _(named `Ip` instead)_
- [x] softlayer _(previously done)_
- [x] virtualbox
- [x] vmwarefusion _(previously done)_
- [x] vmwarevcloudair _(named `PublicIP` instead)_
- [x] vmwarevsphere

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>