### PR TITLE
Add --amazonec2-private-address-only

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -739,6 +739,7 @@ Options:
  - `--amazonec2-subnet-id`: AWS VPC subnet id
  - `--amazonec2-vpc-id`: **required** Your VPC ID to launch the instance in.
  - `--amazonec2-zone`: The AWS zone launch the instance in (i.e. one of a,b,c,d,e). Default: `a`
+ - `--amazonec2-private-address-only`: Use the private IP address only
 
 By default, the Amazon EC2 driver will use a daily image of Ubuntu 14.04 LTS.
 

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -80,6 +80,7 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-ssh-user":              "ubuntu",
 			"amazonec2-request-spot-instance": false,
 			"amazonec2-spot-price":            "",
+			"amazonec2-private-address-only":  false,
 		},
 	}
 }

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -173,7 +173,7 @@ func (e *EC2) awsApiCall(v url.Values) (*http.Response, error) {
 	return resp, nil
 }
 
-func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string) (EC2Instance, error) {
+func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, privateIPOnly bool) (EC2Instance, error) {
 	instance := Instance{}
 	v := url.Values{}
 	v.Set("Action", "RunInstances")
@@ -186,7 +186,11 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 	v.Set("NetworkInterface.0.DeviceIndex", "0")
 	v.Set("NetworkInterface.0.SecurityGroupId.0", securityGroup)
 	v.Set("NetworkInterface.0.SubnetId", subnetId)
-	v.Set("NetworkInterface.0.AssociatePublicIpAddress", "1")
+	if privateIPOnly {
+		v.Set("NetworkInterface.0.AssociatePublicIpAddress", "0")
+	} else {
+		v.Set("NetworkInterface.0.AssociatePublicIpAddress", "1")
+	}
 
 	if len(role) > 0 {
 		v.Set("IamInstanceProfile.Name", role)


### PR DESCRIPTION
For #1036.

I've added `--amazonec2-private-address-only`. This will stop machine from assigning a public address. 
