### PR TITLE
Adding localhost to the list of alt_names

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -76,7 +76,7 @@ func ConfigureAuth(p Provisioner, authOptions auth.AuthOptions) error {
 	// TODO: Switch to passing just authOptions to this func
 	// instead of all these individual fields
 	err = utils.GenerateCert(
-		[]string{ip},
+		[]string{ip,"localhost"},
 		authOptions.ServerCertPath,
 		authOptions.ServerKeyPath,
 		authOptions.CaCertPath,


### PR DESCRIPTION
When attempting to connect to the docker api from the machine itself,
the TLS verification of the certificate checked against the public
IP address of the primary interface.  This is undesirable on hosts
which have NAT rules that block access to that address by default.

Adding "localhost" to the list of alt_names allows the cert to be
verified and connections to localhost (either 127.0.0.1 or [::1]) to
the port to pass verification. Otherwise one would need to disable
verification just to connect to the local docker instance.