### PR TITLE
Reformatting usage message to look more like docker's

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,19 @@ Commands:
 Run '{{.Name}} COMMAND --help' for more information on a command.
 `
 
+var CommandHelpTemplate = `
+Usage: docker-machine {{.Name}}{{if .Flags}} [OPTIONS]{{end}} [arg...]
+
+{{.Usage}}{{if .Description}}
+
+Description:
+   {{.Description}}{{end}}{{if .Flags}}
+
+Options:
+   {{range .Flags}}{{.}}
+   {{end}}{{ end }}
+`
+
 func main() {
 	for _, f := range os.Args {
 		if f == "-D" || f == "--debug" || f == "-debug" {
@@ -41,6 +54,7 @@ func main() {
 	}
 
 	cli.AppHelpTemplate = AppHelpTemplate
+	cli.CommandHelpTemplate = CommandHelpTemplate
 	app := cli.NewApp()
 	app.Name = path.Base(os.Args[0])
 	app.Author = "Docker Machine Contributors"

--- a/main.go
+++ b/main.go
@@ -12,6 +12,26 @@ import (
 	"github.com/docker/machine/version"
 )
 
+var AppHelpTemplate = `
+Usage: {{.Name}} {{if .Flags}}[OPTIONS] {{end}}COMMAND [arg...]
+
+{{.Usage}}
+
+Version: {{.Version}}{{if or .Author .Email}}
+
+Author:{{if .Author}}
+  {{.Author}}{{if .Email}} - <{{.Email}}>{{end}}{{else}}
+  {{.Email}}{{end}}{{end}}
+{{if .Flags}}
+Options:
+  {{range .Flags}}{{.}}
+  {{end}}{{end}}
+Commands:
+  {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+  {{end}}
+Run '{{.Name}} COMMAND --help' for more information on a command.
+`
+
 func main() {
 	for _, f := range os.Args {
 		if f == "-D" || f == "--debug" || f == "-debug" {
@@ -20,6 +40,7 @@ func main() {
 		}
 	}
 
+	cli.AppHelpTemplate = AppHelpTemplate
 	app := cli.NewApp()
 	app.Name = path.Base(os.Args[0])
 	app.Author = "Docker Machine Contributors"


### PR DESCRIPTION
Addresses part of #1014.

This mimics the way `docker --help` looks, except that we have extra `Version` and `Authors` sections. Not sure if we need to keep either (?)

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>

**Update:**

Some examples with this change:

```
$ docker-machine --help
Usage: docker-machine [OPTIONS] COMMAND [arg...]

Create and manage machines running Docker.

Version: 0.2.0 (HEAD)

Author:
  Docker Machine Contributors - <https://github.com/docker/machine>

Options:
  --debug, -D						Enable debug mode
  --storage-path "/Users/hendersd/.docker/machine"	Configures storage path [$MACHINE_STORAGE_PATH]
  --tls-ca-cert 					CA to verify remotes against [$MACHINE_TLS_CA_CERT]
  --tls-ca-key 						Private key to generate certificates [$MACHINE_TLS_CA_KEY]
  --tls-client-cert 					Client cert to use for TLS [$MACHINE_TLS_CLIENT_CERT]
  --tls-client-key 					Private key used in client TLS auth [$MACHINE_TLS_CLIENT_KEY]
  --help, -h						show help
  --version, -v						print the version
  
Commands:
  active		Get or set the active machine
  config		Print the connection config for machine
  create		Create a machine
  env			Display the commands to set up the environment for the Docker client
  inspect		Inspect information about a machine
  ip			Get the IP address of a machine
  kill			Kill a machine
  ls			List machines
  regenerate-certs	Regenerate TLS Certificates for a machine
  restart		Restart a machine
  rm			Remove a machine
  ssh			Log into or run a command on a machine with SSH
  start			Start a machine
  stop			Stop a machine
  upgrade		Upgrade a machine to the latest version of Docker
  url			Get the URL of a machine
  help, h		Shows a list of commands or help for one command
  
Run 'docker-machine COMMAND --help' for more information on a command.
```

```
$ docker-machine env --help

Usage: docker-machine env [OPTIONS] [arg...]

Display the commands to set up the environment for the Docker client

Description:
   Argument is a machine name. Will use the active machine if none is provided.

Options:
   --swarm	Display the Swarm config instead of the Docker daemon
   --unset, -u	Unset variables instead of setting them
```