### PR TITLE
Disable problematic VirtualBox DNS proxy

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -260,6 +260,13 @@ func (d *Driver) Create() error {
 		"--cpus", fmt.Sprintf("%d", cpus),
 		"--memory", fmt.Sprintf("%d", d.Memory),
 
+		// the DNS Host Resolver doesn't support SRV records
+		// the DNS proxy has performance issues
+		// direct DNS pass-through doesn't support roaming laptops well
+		// we can't win, so let's go direct and at least get performance
+		"--natdnshostresolver1", "off",
+		"--natdnsproxy1", "off",
+
 		"--acpi", "on",
 		"--ioapic", "on",
 		"--rtcuseutc", "on",


### PR DESCRIPTION
Ran into DNS problems, research found them identified and corrected in boot2docker.

References:

* https://github.com/boot2docker/boot2docker/issues/451
* https://github.com/boot2docker/boot2docker-cli/pull/320
* https://www.virtualbox.org/ticket/11911
