### PR TITLE
vbox: use single cpu by default

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -954,7 +954,7 @@ Options:
  - `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
  - `--virtualbox-disk-size`: Size of disk for the host in MB. Default: `20000`
  - `--virtualbox-memory`: Size of memory for the host in MB. Default: `1024`
- - `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to number of available CPUs.
+ - `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to single CPU.
 
 The `--virtualbox-boot2docker-url` flag takes a few different forms.  By
 default, if no value is specified for this flag, Machine will check locally for

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -67,7 +67,7 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "VIRTUALBOX_CPU_COUNT",
 			Name:   "virtualbox-cpu-count",
 			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
-			Value:  -1,
+			Value:  1,
 		},
 		cli.IntFlag{
 			EnvVar: "VIRTUALBOX_DISK_SIZE",


### PR DESCRIPTION
This configures VirtualBox to use a single CPU by default. 

Closes #1062 