### PR TITLE
Refactor out common logic in UbuntuProvisioner

### DIFF
--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -1,0 +1,127 @@
+package provision
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/ssh"
+)
+
+type GenericProvisioner struct {
+	OsReleaseId       string
+	DockerOptionsDir  string
+	DaemonOptionsFile string
+	Packages          []string
+	OsReleaseInfo     *OsRelease
+	Driver            drivers.Driver
+	AuthOptions       auth.AuthOptions
+	EngineOptions     engine.EngineOptions
+	SwarmOptions      swarm.SwarmOptions
+}
+
+func (provisioner *GenericProvisioner) Hostname() (string, error) {
+	output, err := provisioner.SSHCommand("hostname")
+	if err != nil {
+		return "", err
+	}
+
+	var so bytes.Buffer
+	if _, err := so.ReadFrom(output.Stdout); err != nil {
+		return "", err
+	}
+
+	return so.String(), nil
+}
+
+func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(
+		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
+		hostname,
+		hostname,
+	)); err != nil {
+		return err
+	}
+
+	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+		hostname,
+		hostname,
+	)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *GenericProvisioner) GetDockerOptionsDir() string {
+	return provisioner.DockerOptionsDir
+}
+
+func (provisioner *GenericProvisioner) SSHCommand(args string) (ssh.Output, error) {
+	return drivers.RunSSHCommandFromDriver(provisioner.Driver, args)
+}
+
+func (provisioner *GenericProvisioner) CompatibleWithHost() bool {
+	return provisioner.OsReleaseInfo.Id == provisioner.OsReleaseId
+}
+
+func (provisioner *GenericProvisioner) GetAuthOptions() auth.AuthOptions {
+	return provisioner.AuthOptions
+}
+
+func (provisioner *GenericProvisioner) SetOsReleaseInfo(info *OsRelease) {
+	provisioner.OsReleaseInfo = info
+}
+
+func (provisioner *GenericProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
+	var (
+		engineCfg bytes.Buffer
+	)
+
+	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
+	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
+
+	engineConfigTmpl := `
+DOCKER_OPTS='
+-H tcp://0.0.0.0:{{.DockerPort}}
+-H unix:///var/run/docker.sock
+--storage-driver {{.EngineOptions.StorageDriver}}
+--tlsverify
+--tlscacert {{.AuthOptions.CaCertRemotePath}}
+--tlscert {{.AuthOptions.ServerCertRemotePath}}
+--tlskey {{.AuthOptions.ServerKeyRemotePath}}
+{{ range .EngineOptions.Labels }}--label {{.}}
+{{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}}
+{{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}}
+{{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}}
+{{ end }}
+'
+`
+	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	engineConfigContext := EngineConfigContext{
+		DockerPort:    dockerPort,
+		AuthOptions:   provisioner.AuthOptions,
+		EngineOptions: provisioner.EngineOptions,
+	}
+
+	t.Execute(&engineCfg, engineConfigContext)
+
+	return &DockerOptions{
+		EngineOptions:     engineCfg.String(),
+		EngineOptionsPath: provisioner.DaemonOptionsFile,
+	}, nil
+}
+
+func (provisioner *GenericProvisioner) GetDriver() drivers.Driver {
+	return provisioner.Driver
+}

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -1,9 +1,7 @@
 package provision
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
@@ -11,7 +9,6 @@ import (
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
-	"github.com/docker/machine/ssh"
 	"github.com/docker/machine/utils"
 )
 
@@ -23,20 +20,20 @@ func init() {
 
 func NewUbuntuProvisioner(d drivers.Driver) Provisioner {
 	return &UbuntuProvisioner{
-		packages: []string{
-			"curl",
+		GenericProvisioner{
+			DockerOptionsDir:  "/etc/docker",
+			DaemonOptionsFile: "/etc/default/docker",
+			OsReleaseId:       "ubuntu",
+			Packages: []string{
+				"curl",
+			},
+			Driver: d,
 		},
-		Driver: d,
 	}
 }
 
 type UbuntuProvisioner struct {
-	packages      []string
-	OsReleaseInfo *OsRelease
-	Driver        drivers.Driver
-	AuthOptions   auth.AuthOptions
-	EngineOptions engine.EngineOptions
-	SwarmOptions  swarm.SwarmOptions
+	GenericProvisioner
 }
 
 func (provisioner *UbuntuProvisioner) Service(name string, action pkgaction.ServiceAction) error {
@@ -94,7 +91,7 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 		return err
 	}
 
-	for _, pkg := range provisioner.packages {
+	for _, pkg := range provisioner.Packages {
 		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
 			return err
 		}
@@ -123,107 +120,4 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	}
 
 	return nil
-}
-
-func (provisioner *UbuntuProvisioner) Hostname() (string, error) {
-	output, err := provisioner.SSHCommand("hostname")
-	if err != nil {
-		return "", err
-	}
-
-	var so bytes.Buffer
-	if _, err := so.ReadFrom(output.Stdout); err != nil {
-		return "", err
-	}
-
-	return so.String(), nil
-}
-
-func (provisioner *UbuntuProvisioner) SetHostname(hostname string) error {
-	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
-		hostname,
-		hostname,
-	)); err != nil {
-		return err
-	}
-
-	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
-	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
-		hostname,
-		hostname,
-	)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (provisioner *UbuntuProvisioner) GetDockerOptionsDir() string {
-	return "/etc/docker"
-}
-
-func (provisioner *UbuntuProvisioner) SSHCommand(args string) (ssh.Output, error) {
-	return drivers.RunSSHCommandFromDriver(provisioner.Driver, args)
-}
-
-func (provisioner *UbuntuProvisioner) CompatibleWithHost() bool {
-	return provisioner.OsReleaseInfo.Id == "ubuntu"
-}
-
-func (provisioner *UbuntuProvisioner) GetAuthOptions() auth.AuthOptions {
-	return provisioner.AuthOptions
-}
-
-func (provisioner *UbuntuProvisioner) SetOsReleaseInfo(info *OsRelease) {
-	provisioner.OsReleaseInfo = info
-}
-
-func (provisioner *UbuntuProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
-	var (
-		engineCfg bytes.Buffer
-	)
-
-	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
-	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
-
-	engineConfigTmpl := `
-DOCKER_OPTS='
--H tcp://0.0.0.0:{{.DockerPort}}
--H unix:///var/run/docker.sock
---storage-driver {{.EngineOptions.StorageDriver}}
---tlsverify
---tlscacert {{.AuthOptions.CaCertRemotePath}}
---tlscert {{.AuthOptions.ServerCertRemotePath}}
---tlskey {{.AuthOptions.ServerKeyRemotePath}}
-{{ range .EngineOptions.Labels }}--label {{.}}
-{{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}}
-{{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}}
-{{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}}
-{{ end }}
-'
-`
-	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
-	if err != nil {
-		return nil, err
-	}
-
-	engineConfigContext := EngineConfigContext{
-		DockerPort:    dockerPort,
-		AuthOptions:   provisioner.AuthOptions,
-		EngineOptions: provisioner.EngineOptions,
-	}
-
-	t.Execute(&engineCfg, engineConfigContext)
-
-	daemonOptsDir := "/etc/default/docker"
-	return &DockerOptions{
-		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: daemonOptsDir,
-	}, nil
-}
-
-func (provisioner *UbuntuProvisioner) GetDriver() drivers.Driver {
-	return provisioner.Driver
 }


### PR DESCRIPTION
This change create GenericProvisioner which is the boilplate or generic Linux functionality that was previously in the UbuntuProvisioner.  This work was done to make it easier to add and maintain RancherOS support.  #1096 was created for RancherOS support that uses this PR.