### PR TITLE
Fixing bug in GetIP where Public IP would always be returned 

### DIFF
--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -275,7 +275,11 @@ func (d *Driver) GetIP() (string, error) {
 	if d.IPAddress != "" {
 		return d.IPAddress, nil
 	}
-	return d.getClient().VirtualGuest().GetPublicIp(d.Id)
+	if d.deviceConfig.PrivateNet {
+		return d.getClient().VirtualGuest().GetPrivateIp(d.Id)
+	} else {
+		return d.getClient().VirtualGuest().GetPublicIp(d.Id)
+	}
 }
 
 func (d *Driver) GetState() (state.State, error) {


### PR DESCRIPTION
...despite use of `--softlayer-private-net-only`

Fixes #1099

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>