### PR TITLE
Adding SoftLayer support for specifying Public and Private VLAN IDs

### DIFF
--- a/drivers/softlayer/softlayer.go
+++ b/drivers/softlayer/softlayer.go
@@ -16,18 +16,28 @@ type Client struct {
 }
 
 type HostSpec struct {
-	Hostname       string        `json:"hostname"`
-	Domain         string        `json:"domain"`
-	Cpu            int           `json:"startCpus"`
-	Memory         int           `json:"maxMemory"`
-	Datacenter     Datacenter    `json:"datacenter"`
-	SshKeys        []*SshKey     `json:"sshKeys"`
-	BlockDevices   []BlockDevice `json:"blockDevices"`
-	InstallScript  string        `json:"postInstallScriptUri"`
-	PrivateNetOnly bool          `json:"privateNetworkOnlyFlag"`
-	Os             string        `json:"operatingSystemReferenceCode"`
-	HourlyBilling  bool          `json:"hourlyBillingFlag"`
-	LocalDisk      bool          `json:"localDiskFlag"`
+	Hostname                       string            `json:"hostname"`
+	Domain                         string            `json:"domain"`
+	Cpu                            int               `json:"startCpus"`
+	Memory                         int               `json:"maxMemory"`
+	Datacenter                     Datacenter        `json:"datacenter"`
+	SshKeys                        []*SshKey         `json:"sshKeys"`
+	BlockDevices                   []BlockDevice     `json:"blockDevices"`
+	InstallScript                  string            `json:"postInstallScriptUri"`
+	PrivateNetOnly                 bool              `json:"privateNetworkOnlyFlag"`
+	Os                             string            `json:"operatingSystemReferenceCode"`
+	HourlyBilling                  bool              `json:"hourlyBillingFlag"`
+	LocalDisk                      bool              `json:"localDiskFlag"`
+	PrimaryNetworkComponent        *NetworkComponent `json:"primaryNetworkComponent,omitempty"`
+	PrimaryBackendNetworkComponent *NetworkComponent `json:"primaryBackendNetworkComponent,omitempty"`
+}
+
+type NetworkComponent struct {
+	NetworkVLAN *NetworkVLAN `json:"networkVlan"`
+}
+
+type NetworkVLAN struct {
+	Id int `json:"id"`
 }
 
 type SshKey struct {


### PR DESCRIPTION
Fixes #766 

This adds 2 new options:
- `--softlayer-private-vlan-id`
- `--softlayer-public-vlan-id`

These allow the VLAN IDs to be explicitly specified when creating a new VM in SoftLayer.

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>