### PR TITLE
Fixing panic when d.deviceConfig is nil

### DIFF
--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -301,7 +301,7 @@ func (d *Driver) GetIP() (string, error) {
 	if d.IPAddress != "" {
 		return d.IPAddress, nil
 	}
-	if d.deviceConfig.PrivateNet {
+	if d.deviceConfig != nil && d.deviceConfig.PrivateNet == true {
 		return d.getClient().VirtualGuest().GetPrivateIp(d.Id)
 	} else {
 		return d.getClient().VirtualGuest().GetPublicIp(d.Id)


### PR DESCRIPTION
So I got into a weird state where the deviceConfig was `nil`. Got a real ugly panic something like:

```
error getting state for host dmtest: Error in response: Unable to find object with id of '0'.
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x5a pc=0x12592a]

goroutine 8 [running]:
github.com/docker/machine/drivers/softlayer.(*Driver).GetIP(0xc20807c370, 0x0, 0x0, 0x0, 0x0)
	/Users/epoch/gocode/src/github.com/docker/machine/drivers/softlayer/driver.go:304 +0x7a
github.com/docker/machine/drivers/softlayer.(*Driver).GetURL(0xc20807c370, 0x0, 0x0, 0x0, 0x0)
	/Users/epoch/gocode/src/github.com/docker/machine/drivers/softlayer/driver.go:290 +0x52
github.com/docker/machine/libmachine.(*Host).GetURL(0xc2080bc1a0, 0x0, 0x0, 0x0, 0x0)
	/Users/epoch/gocode/src/github.com/docker/machine/libmachine/host.go:287 +0x68
github.com/docker/machine/libmachine.getHostState(0xc20806ad16, 0x6, 0xc20802b800, 0x9, 0xd12d68, 0xc20807c370, 0xc208085080, 0x2c, 0xc2080b9c40, 0xacbc10, ...)
	/Users/epoch/gocode/src/github.com/docker/machine/libmachine/host.go:394 +0x1c6
created by github.com/docker/machine/libmachine.GetHostListItems
	/Users/epoch/gocode/src/github.com/docker/machine/libmachine/host.go:420 +0x13f
```

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>