### PR TITLE
Default storage driver to "" and let provisioner choose default

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -188,7 +188,6 @@ var sharedCreateFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "engine-storage-driver",
 		Usage: "Specify a storage driver to use with the engine",
-		Value: "aufs",
 	},
 	cli.BoolFlag{
 		Name:  "swarm",

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -191,6 +191,10 @@ func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.SwarmOpt
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
 
+	if provisioner.EngineOptions.StorageDriver == "" {
+		provisioner.EngineOptions.StorageDriver = "aufs"
+	}
+
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
 	}

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -87,6 +87,11 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
+
+	if provisioner.EngineOptions.StorageDriver == "" {
+		provisioner.EngineOptions.StorageDriver = "aufs"
+	}
+
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
 	}

--- a/test/integration/driver-virtualbox.bats
+++ b/test/integration/driver-virtualbox.bats
@@ -307,6 +307,11 @@ buildMachineWithOldIsoCheckUpgrade() {
   [ "$status" -eq 0  ]
 }
 
+@test "$DRIVER: create with no storage driver" {
+  run machine create -d $DRIVER --engine-storage-driver "" $NAME
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: create with custom disk, cpu count and memory size flags" {
   run machine create -d $DRIVER --virtualbox-cpu-count $CUSTOM_CPUCOUNT --virtualbox-disk-size $CUSTOM_DISKSIZE --virtualbox-memory $CUSTOM_MEMSIZE $NAME
   [ "$status" -eq 0  ]


### PR DESCRIPTION
The storage driver will be "" by default an the provisioner must choose
their default provisioner.  If the user chosen storage driver is not
supported the provisioner should return an error.

I changed boot2docker to throw an error if something besides aufs is chosen.  I have no clue what boot2docker supports so that may be wrong.