### PR TITLE
CPU count fixes for `vmwarefusion` driver

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -11,10 +11,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -40,7 +42,7 @@ type Driver struct {
 	IPAddress      string
 	Memory         int
 	DiskSize       int
-	CPUs           int
+	CPU            int
 	ISO            string
 	Boot2DockerURL string
 	CaCertPath     string
@@ -70,6 +72,12 @@ func GetCreateFlags() []cli.Flag {
 			EnvVar: "FUSION_BOOT2DOCKER_URL",
 			Name:   "vmwarefusion-boot2docker-url",
 			Usage:  "Fusion URL for boot2docker image",
+		},
+		cli.IntFlag{
+			EnvVar: "FUSION_CPU_COUNT",
+			Name:   "vmwarefusion-cpu-count",
+			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
+			Value:  -1,
 		},
 		cli.IntFlag{
 			EnvVar: "FUSION_MEMORY_SIZE",
@@ -136,21 +144,31 @@ func (d *Driver) DriverName() string {
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Memory = flags.Int("vmwarefusion-memory-size")
+	d.CPU = flags.Int("vmwarefusion-cpu-count")
 	d.DiskSize = flags.Int("vmwarefusion-disk-size")
 	d.Boot2DockerURL = flags.String("vmwarefusion-boot2docker-url")
 	d.ISO = path.Join(d.storePath, isoFilename)
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")
-	d.CPUS = runtime.NumCPU()
 	d.SSHUser = "docker"
 	d.SSHPort = 22
 
 	// We support a maximum of 16 cpu to be consistent with Virtual Hardware 10
 	// specs.
-	d.CPUs = int(runtime.NumCPU())
-	if d.CPUs > 16 {
-		d.CPUs = 16
+
+	cpus := d.CPU
+	if cpus < 1 {
+		// OMG, no easy way to get physical cores with go, resorting to horrible hacks
+		out, err := exec.Command("/usr/sbin/sysctl", "-n", "hw.physicalcpu").Output()
+		if err != nil {
+			log.Fatal(err)
+		}
+		// var cores int
+		d.CPU, _ = strconv.Atoi(stripCtlFromBytes(string(out)))
+	}
+	if cpus > 16 {
+		d.CPU = 16
 	}
 
 	return nil
@@ -576,4 +594,17 @@ func (d *Driver) generateKeyBundle() error {
 
 	return nil
 
+}
+
+func stripCtlFromBytes(str string) string {
+	b := make([]byte, len(str))
+	var bl int
+	for i := 0; i < len(str); i++ {
+		c := str[i]
+		if c >= 32 && c != 127 {
+			b[bl] = c
+			bl++
+		}
+	}
+	return string(b[:bl])
 }

--- a/drivers/vmwarefusion/vmx_darwin.go
+++ b/drivers/vmwarefusion/vmx_darwin.go
@@ -60,7 +60,7 @@ virtualHW.productCompatibility = "hosted"
 virtualHW.version = "10"
 msg.autoanswer = "TRUE"
 uuid.action = "create"
-numvcpus = "{{.CPUs}}"
+numvcpus = "{{.CPU}}"
 hgfs.mapRootShare = "FALSE"
 hgfs.linkRootShare = "FALSE"
 `


### PR DESCRIPTION
- Added `--vmwarefusion-cpu-count` parameter
- Defaults to number of **physical** cores available (calling `sysctl`)

Fixes #1095 

Signed-off-by: Fabio Rapposelli <fabio@vmware.com>