### PR TITLE
env: enable easier usage display

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -210,5 +210,5 @@ func generateUsageHint(appName, machineName, userShell string) string {
 		}
 	}
 
-	return fmt.Sprintf("# Run this command to configure your shell: %s\n", cmd)
+	return fmt.Sprintf("# Run this command to configure your shell: \n# %s\n", cmd)
 }


### PR DESCRIPTION
This makes it easier to see the `env` usage:

```
ehazlett machine> docker-machine env test-vbox
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.99.100:2376"
export DOCKER_CERT_PATH="/home/ehazlett/.docker/machine/machines/test-vbox"
# Run this command to configure your shell: 
  eval "$(docker-machine_linux-amd64 env test-vbox)"
```

Refs https://github.com/docker/machine/issues/1078#issuecomment-98879185
Closes #1078 