### PR TITLE
provisioner: update metadata before install or upgrade

### DIFF
--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -49,11 +49,14 @@ func (provisioner *UbuntuProvisioner) Service(name string, action pkgaction.Serv
 func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.PackageAction) error {
 	var packageAction string
 
+	updateMetadata := true
+
 	switch action {
 	case pkgaction.Install:
 		packageAction = "install"
 	case pkgaction.Remove:
 		packageAction = "remove"
+		updateMetadata = false
 	case pkgaction.Upgrade:
 		packageAction = "upgrade"
 	}
@@ -62,6 +65,13 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 	switch name {
 	case "docker":
 		name = "lxc-docker"
+	}
+
+	if updateMetadata {
+		// issue apt-get update for metadata
+		if _, err := provisioner.SSHCommand("sudo -E apt-get update"); err != nil {
+			return err
+		}
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -47,9 +47,10 @@ func (provisioner *UbuntuProvisioner) Service(name string, action pkgaction.Serv
 }
 
 func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.PackageAction) error {
-	var packageAction string
-
-	updateMetadata := true
+	var (
+		packageAction  string
+		updateMetadata = true
+	)
 
 	switch action {
 	case pkgaction.Install:


### PR DESCRIPTION
This issues an `apt-get update` for the Ubuntu provisioner so installs and updates do not fail.  This also helps if you package lists are out of date on the base OS.

Closes #1114 