### PR TITLE
Fix formatting and non-returning of error

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -543,6 +543,9 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 	}
 
 	m, err := mcn.Get(name)
+	if err != nil {
+		return nil, err
+	}
 
 	machineDir := filepath.Join(utils.GetMachineDir(), m.Name)
 	caCert := filepath.Join(machineDir, "ca.pem")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -112,7 +112,7 @@ func WaitForDocker(ip string, daemonPort int) error {
 	return WaitFor(func() bool {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ip, daemonPort))
 		if err != nil {
-			log.Debugf("Daemon not responding yet: ", err)
+			log.Debugf("Daemon not responding yet: %s", err)
 			return false
 		}
 		conn.Close()


### PR DESCRIPTION
This PR fixes a few issues that I identified:

1. Error wasn't being checked from `mcn.Get`, so things were blowing up if user tried to operate on a machine name that didn't exist
2. Formatting in the daemon dial was wonky

cc @ehazlett 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>