### PR TITLE
Fix panic when TCP timeout happens on SSH connect

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -77,8 +77,9 @@ func (client *Client) Run(command string) (Output, error) {
 			if i == maxDialAttempts {
 				return output, errors.New("Max SSH/TCP dial attempts exceeded")
 			}
+		} else {
+			break
 		}
-		break
 	}
 
 	session, err := conn.NewSession()


### PR DESCRIPTION
Now with more running and less panicking.

When a TCP dial errored but the maxDialAttempts was not reached, the conn was left nil and the loop exited.