### PR TITLE
If there was an SSH error, log the output

### DIFF
--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -30,7 +30,9 @@ func RunSSHCommandFromDriver(d Driver, command string) (ssh.Output, error) {
 		return output, err
 	}
 
-	return client.Run(command)
+	output, err = client.Run(command)
+	log.Debug(fmt.Sprintf("SSH cmd err, output: %v: %s", err, output))
+	return output, err
 }
 
 func sshAvailableFunc(d Driver) func() bool {


### PR DESCRIPTION
I struggled to figure out why a machine create was failing, and
eventually asked if anyone else had seen the vague error I was getting:
"Error creating machine: Process exited with: 100. Reason was: ()"

It is immensely helpful if we log the command output instead of
just the rc.

It would also have been useful if the driver providers used the output, but
this covers most scenarios since they don't.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>