### PR TITLE
Fixing cli.bats tests

### DIFF
--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -5,92 +5,92 @@ load helpers
 @test "cli: show info" {
   run machine
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "NAME:"  ]]
+  [[ ${lines[0]} =~ "Usage:"  ]]
   [[ ${lines[1]} =~ "Create and manage machines running Docker"  ]]
 }
 
 @test "cli: show active help" {
   run machine active -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command active"  ]]
+  [[ ${lines[0]} =~ "machine active"  ]]
 }
 
 @test "cli: show config help" {
   run machine config -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command config"  ]]
+  [[ ${lines[0]} =~ "machine config"  ]]
 }
 
 @test "cli: show inspect help" {
   run machine inspect -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command inspect"  ]]
+  [[ ${lines[0]} =~ "machine inspect"  ]]
 }
 
 @test "cli: show ip help" {
   run machine ip -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command ip"  ]]
+  [[ ${lines[0]} =~ "machine ip"  ]]
 }
 
 @test "cli: show kill help" {
   run machine kill -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command kill"  ]]
+  [[ ${lines[0]} =~ "machine kill"  ]]
 }
 
 @test "cli: show ls help" {
   run machine ls -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command ls"  ]]
+  [[ ${lines[0]} =~ "machine ls"  ]]
 }
 
 @test "cli: show restart help" {
   run machine restart -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command restart"  ]]
+  [[ ${lines[0]} =~ "machine restart"  ]]
 }
 
 @test "cli: show rm help" {
   run machine rm -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command rm"  ]]
+  [[ ${lines[0]} =~ "machine rm"  ]]
 }
 
 @test "cli: show env help" {
   run machine env -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command env"  ]]
+  [[ ${lines[0]} =~ "machine env"  ]]
 }
 
 @test "cli: show ssh help" {
   run machine ssh -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command ssh"  ]]
+  [[ ${lines[0]} =~ "machine ssh"  ]]
 }
 
 @test "cli: show start help" {
   run machine start -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command start"  ]]
+  [[ ${lines[0]} =~ "machine start"  ]]
 }
 
 @test "cli: show stop help" {
   run machine stop -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command stop"  ]]
+  [[ ${lines[0]} =~ "machine stop"  ]]
 }
 
 @test "cli: show upgrade help" {
   run machine upgrade -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command upgrade"  ]]
+  [[ ${lines[0]} =~ "machine upgrade"  ]]
 }
 
 @test "cli: show url help" {
   run machine url -h
   [ "$status" -eq 0  ]
-  [[ ${lines[3]} =~ "command url"  ]]
+  [[ ${lines[0]} =~ "machine url"  ]]
 }
 
 @test "flag: show version" {
@@ -102,5 +102,5 @@ load helpers
 @test "flag: show help" {
   run machine --help
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "NAME"  ]]
+  [[ ${lines[0]} =~ "Usage:"  ]]
 }


### PR DESCRIPTION
I broke the integration tests in #1065 :disappointed: 

This PR fixes them :smile: 

Before:
```
$ bats test/integration/cli.bats        
 ✓ cli: show info
 ✗ cli: show active help
   (in test file test/integration/cli.bats, line 14)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show config help
   (in test file test/integration/cli.bats, line 20)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show inspect help
   (in test file test/integration/cli.bats, line 26)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show ip help
   (in test file test/integration/cli.bats, line 32)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show kill help
   (in test file test/integration/cli.bats, line 38)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show ls help
   (in test file test/integration/cli.bats, line 44)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show restart help
   (in test file test/integration/cli.bats, line 50)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show rm help
   (in test file test/integration/cli.bats, line 56)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show env help
   (in test file test/integration/cli.bats, line 62)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show ssh help
   (in test file test/integration/cli.bats, line 68)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show start help
   (in test file test/integration/cli.bats, line 74)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show stop help
   (in test file test/integration/cli.bats, line 80)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show upgrade help
   (in test file test/integration/cli.bats, line 86)
     `[ "$status" -eq 0  ]' failed
 ✗ cli: show url help
   (in test file test/integration/cli.bats, line 92)
     `[ "$status" -eq 0  ]' failed
 ✓ flag: show version
 ✗ flag: show help
   (in test file test/integration/cli.bats, line 104)
     `[ "$status" -eq 0  ]' failed

17 tests, 15 failures
```

And with this PR:
```
$ bats test/integration/cli.bats         
 ✓ cli: show info
 ✓ cli: show active help
 ✓ cli: show config help
 ✓ cli: show inspect help
 ✓ cli: show ip help
 ✓ cli: show kill help
 ✓ cli: show ls help
 ✓ cli: show restart help
 ✓ cli: show rm help
 ✓ cli: show env help
 ✓ cli: show ssh help
 ✓ cli: show start help
 ✓ cli: show stop help
 ✓ cli: show upgrade help
 ✓ cli: show url help
 ✓ flag: show version
 ✓ flag: show help

17 tests, 0 failures
```

Signed-off-by: Dave Henderson <Dave.Henderson@ca.ibm.com>