### PR TITLE
Add firewall rule for Ubuntu Provisioner

### DIFF
--- a/libmachine/provision/pkgaction/action.go
+++ b/libmachine/provision/pkgaction/action.go
@@ -43,3 +43,23 @@ func (s PackageAction) String() string {
 
 	return ""
 }
+
+type FirewallRuleAction int
+
+const (
+	Allow FirewallRuleAction = iota
+	Disable
+)
+
+var firewallRuleActions = []string{
+	"allow",
+	"disable",
+}
+
+func (s FirewallRuleAction) String() string {
+	if int(s) >= 0 && int(s) < len(firewallRuleActions) {
+		return firewallRuleActions[s]
+	}
+
+	return ""
+}

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -83,6 +83,24 @@ func (provisioner *UbuntuProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
+func (provisioner *UbuntuProvisioner) modifyFirewallRules(action pkgaction.FirewallRuleAction) error {
+
+	var firewallRule string
+
+	switch action {
+	case pkgaction.Allow:
+		firewallRule = "allow"
+	case pkgaction.Disable:
+		firewallRule = "disable"
+	}
+	// TODO: Right now this is hard-coded everywhere (all drivers), so, when they have a query function,
+	// use that instead to get the port (and maybe more).
+	if _, err := provisioner.SSHCommand(fmt.Sprintf("sudo ufw %s 2376/tcp", firewallRule)); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
@@ -115,6 +133,10 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	}
 
 	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
+
+	if err := provisioner.modifyFirewallRules(pkgaction.Allow); err != nil {
+		return err
+	}
 
 	if err := ConfigureAuth(provisioner); err != nil {
 		return err


### PR DESCRIPTION
If the image used has a locked-down OS, docker's port
may not be accessible. This patch simply adds an ssh
command that uses Ubuntu's Uncomplicated Firewall (ufw) to
allow the docker port.

I verified that if the firewall rule already exists, an error
is not returned, and the rc is 0. This may not be the case with
all CLIs, but it is for ufw. This means that just running the
command every time won't be a problem

Also note that this should not interfere the existing
Google Compute Engine firewall capabilities because it is at
the OS-level, whereas the 'Firewalls' API handles traffic
at the network level.

Tested against Ubuntu 14.04 on Digital Ocean and Bluemix
(using the openstack driver).

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>