### PR TITLE
Match syntax and usage info with Docker

### DIFF
--- a/Godeps/_workspace/src/github.com/codegangsta/cli/flag.go
+++ b/Godeps/_workspace/src/github.com/codegangsta/cli/flag.go
@@ -16,16 +16,16 @@ var BashCompletionFlag = BoolFlag{
 
 // This flag prints the version for the application
 var VersionFlag = BoolFlag{
-	Name:  "version, v",
-	Usage: "print the version",
+	Name:  "v, version=false",
+	Usage: "Print version information and quit",
 }
 
 // This flag prints the help for all commands and subcommands
 // Set to the zero value (BoolFlag{}) to disable flag -- keeps subcommand
 // unless HideHelp is set to true)
 var HelpFlag = BoolFlag{
-	Name:  "help, h",
-	Usage: "show help",
+	Name:  "h, help=false",
+	Usage: "Print usage",
 }
 
 // Flag is a common interface related to parsing flags in cli.

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "debug, D",
+			Name:  "D, debug=false",
 			Usage: "Enable debug mode",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
Display short syntax first and match usage information with Docker.

Ref https://github.com/docker/machine/issues/1014#issuecomment-97851171

Result:

```
Options:
  -D, --debug=false									Enable debug mode
  -s, --storage-path "/home/owner/.docker/machine"	Configures storage path [$MACHINE_STORAGE_PATH]
  --tls-ca-cert 									CA to verify remotes against [$MACHINE_TLS_CA_CERT]
  --tls-ca-key 										Private key to generate certificates [$MACHINE_TLS_CA_KEY]
  --tls-client-cert 								Client cert to use for TLS [$MACHINE_TLS_CLIENT_CERT]
  --tls-client-key 									Private key used in client TLS auth [$MACHINE_TLS_CLIENT_KEY]
  -h, --help=false									Print usage
  -v, --version=false								Print version information and quit
```