### PR TITLE
Fix a few issues with certs

### DIFF
--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -312,12 +312,21 @@ func (h *Host) LoadConfig() error {
 }
 
 func (h *Host) ConfigureAuth() error {
+	if err := h.LoadConfig(); err != nil {
+		return err
+	}
+
 	provisioner, err := provision.DetectProvisioner(h.Driver)
 	if err != nil {
 		return err
 	}
 
-	if err := provision.ConfigureAuth(provisioner); err != nil {
+	// TODO: This is kind of a hack (or is it?  I'm not really sure until
+	// we have more clearly defined outlook on what the responsibilities
+	// and modularity of the provisioners should be).
+	//
+	// Call provision to re-provision the certs properly.
+	if err := provisioner.Provision(swarm.SwarmOptions{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -130,15 +130,16 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	if _, err := p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(caCert), authOptions.CaCertRemotePath)); err != nil {
+	// These ones are for Jessie and Mike <3 <3 <3
+	if _, err := p.SSHCommand(fmt.Sprintf("printf \"%s\" | sudo tee %s", string(caCert), authOptions.CaCertRemotePath)); err != nil {
 		return err
 	}
 
-	if _, err := p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverCert), authOptions.ServerCertRemotePath)); err != nil {
+	if _, err := p.SSHCommand(fmt.Sprintf("printf \"%s\" | sudo tee %s", string(serverCert), authOptions.ServerCertRemotePath)); err != nil {
 		return err
 	}
 
-	if _, err := p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", string(serverKey), authOptions.ServerKeyRemotePath)); err != nil {
+	if _, err := p.SSHCommand(fmt.Sprintf("printf \"%s\" | sudo tee %s", string(serverKey), authOptions.ServerKeyRemotePath)); err != nil {
 		return err
 	}
 
@@ -165,7 +166,7 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	if _, err = p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	if _, err = p.SSHCommand(fmt.Sprintf("printf \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 

--- a/test/integration/certs-checksum.bats
+++ b/test/integration/certs-checksum.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load helpers
+
+export DRIVER=virtualbox
+export NAME="bats-$DRIVER-test"
+export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
+
+@test "$DRIVER: create" {
+  run machine create -d $DRIVER $NAME
+}
+
+@test "$DRIVER: verify that server cert checksum matches local checksum" {
+  # TODO: Does this test work OK on Linux? cc @ehazlett
+  # Have to create this directory and file or else the OpenSSL checksum will barf.
+  machine ssh $NAME -- sudo mkdir -p /usr/local/ssl
+  machine ssh $NAME -- sudo touch /usr/local/ssl/openssl.cnf
+  SERVER_CHECKSUM=$(machine ssh $NAME -- openssl dgst -sha256 /var/lib/boot2docker/ca.pem | awk '{ print $2 }')
+  LOCAL_CHECKSUM=$(openssl dgst -sha256 $MACHINE_STORAGE_PATH/certs/ca.pem | awk '{ print $2 }')
+  echo ${SERVER_CHECKSUM}
+  echo ${LOCAL_CHECKSUM}
+  [[ ${SERVER_CHECKSUM} == ${LOCAL_CHECKSUM} ]]
+}
+
+@test "cleanup" {
+  machine rm $NAME
+}

--- a/test/integration/regenerate-certs.bats
+++ b/test/integration/regenerate-certs.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load helpers
+
+export DRIVER=virtualbox
+export NAME="bats-$DRIVER-test"
+export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
+
+@test "$DRIVER: create" {
+  run machine create -d $DRIVER $NAME
+}
+
+@test "$DRIVER: regenerate the certs" {
+  run machine regenerate-certs -f $NAME
+  [[ ${status} -eq 0 ]]
+}
+
+@test "$DRIVER: make sure docker still works" {
+  run docker $(machine config $NAME) version
+  [[ ${status} -eq 0 ]]
+}
+
+@test "cleanup" {
+  machine rm $NAME
+  [[ ${status} -eq 0 ]]
+}


### PR DESCRIPTION
- regenerate-certs was busted, because of recent changes I made to
  Provision() method
- checksum was different between local certs and remote certs

This PR fixes both issues and adds tests to verify that both conditions
are checked in the future.

Closes https://github.com/docker/machine/issues/1144.
Closes https://github.com/docker/machine/issues/1159.

cc @ehazlett @hairyhenderson for review.

Assuming this gets merged, I will update the integration tests refactor to move these tests over to the new format.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>