### PR TITLE
Super nit: ProviderType

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,15 +1,19 @@
 package provider
 
+import "fmt"
+
 // ProviderType represents the type of a provider for a machine
-type ProviderType int
+type ProviderType uint
 
 const (
-	None ProviderType = iota
+	Invalid ProviderType = iota
+	None
 	Local
 	Remote
 )
 
-var providerTypes = []string{
+var providerNames = []string{
+	"Invalid",
 	"",
 	"Local",
 	"Remote",
@@ -17,9 +21,8 @@ var providerTypes = []string{
 
 // Given a type, returns its string representation
 func (t ProviderType) String() string {
-	if int(t) >= 0 && int(t) < len(providerTypes) {
-		return providerTypes[t]
-	} else {
-		return ""
+	if int(t) < len(providerNames) {
+		return providerNames[t]
 	}
+	return fmt.Sprintf("ProviderType%d", int(t))
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,10 +1,15 @@
 package provider
 
 import (
+	"fmt"
+	"math"
 	"testing"
 )
 
 func TestProviderType(t *testing.T) {
+	if Invalid.String() != "Invalid" {
+		t.Fatal("Invalid provider type should be 'Invalid'")
+	}
 	if None.String() != "" {
 		t.Fatal("None provider type should be empty string")
 	}
@@ -13,5 +18,9 @@ func TestProviderType(t *testing.T) {
 	}
 	if Remote.String() != "Remote" {
 		t.Fatal("Remote provider type should be 'Remote'")
+	}
+	maxProviderTypeString := fmt.Sprintf("ProviderType%d", math.MaxUint16)
+	if ProviderType(math.MaxUint16).String() != maxProviderTypeString {
+		t.Fatalf("Unknown provider type should be %s", maxProviderTypeString)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

This is a super nit and just because I was poking around, but just making ProviderType a more idiomatic enum iota/string thingy http://golang.org/src/reflect/type.go?s=7521:7535#L405