### PR TITLE
Fix build for mac with golang 1.4 after doing godep go install ./...

### DIFF
--- a/script/build
+++ b/script/build
@@ -20,4 +20,5 @@ fi
 
 # Get rid of existing binaries
 rm -f docker-machine*
+rm -rf Godeps/_workspace/pkg
 docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}" -ldflags="-w -X github.com/docker/machine/version.GITCOMMIT `git rev-parse --short HEAD`"


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

```
peter$ godep go install ./...
[~/go/src/github.com/docker/machine]
peter$ make build
script/build
Sending build context to Docker daemon 23.95 MB
Sending build context to Docker daemon
Step 0 : FROM golang:1.3-cross
 ---> 8e48d3b7a010
Step 1 : RUN apt-get update && apt-get install -y --no-install-recommends openssh-client
 ---> Using cache
 ---> ee897cd06685
Step 2 : RUN go get github.com/mitchellh/gox
 ---> Using cache
 ---> 36d5baaefab2
Step 3 : RUN go get github.com/aktau/github-release
 ---> Using cache
 ---> 8aa622ae34ec
Step 4 : RUN go get github.com/tools/godep
 ---> Using cache
 ---> 9a6d350c8a46
Step 5 : RUN go get code.google.com/p/go.tools/cmd/cover
 ---> Using cache
 ---> 1315f591fcae
Step 6 : ENV GOPATH /go/src/github.com/docker/machine/Godeps/_workspace:/go
 ---> Using cache
 ---> d3127fd2805d
Step 7 : ENV MACHINE_BINARY /go/src/github.com/docker/machine/docker-machine
 ---> Using cache
 ---> 6050bb7dbbd5
Step 8 : ENV USER root
 ---> Using cache
 ---> 0232c99fa788
Step 9 : WORKDIR /go/src/github.com/docker/machine
 ---> Using cache
 ---> d45f0f4b4082
Step 10 : ADD . /go/src/github.com/docker/machine
 ---> f1516c77bcb5
Removing intermediate container 81a713d4b6ac
Successfully built f1516c77bcb5
Number of parallel builds: 8

-->      darwin/386: github.com/docker/machine
-->    darwin/amd64: github.com/docker/machine
-->       linux/386: github.com/docker/machine
-->     linux/amd64: github.com/docker/machine
-->     windows/386: github.com/docker/machine
-->   windows/amd64: github.com/docker/machine

1 errors occurred:
--> darwin/amd64 error: exit status 2
Stderr: # github.com/docker/machine/ssh
ssh/client.go:10: import /go/src/github.com/docker/machine/Godeps/_workspace/pkg/darwin_amd64/github.com/docker/docker/pkg/term.a: object is [darwin amd64 go1.4.2 X:precisestack] expected [darwin amd64 go1.3.3 X:precisestack]
# github.com/docker/machine/drivers/amazonec2/amz
drivers/amazonec2/amz/ec2.go:12: import /go/src/github.com/docker/machine/Godeps/_workspace/pkg/darwin_amd64/github.com/smartystreets/go-aws-auth.a: object is [darwin amd64 go1.4.2 X:precisestack] expected [darwin amd64 go1.3.3 X:precisestack]

make: *** [build] Error 1
[~/go/src/github.com/docker/machine]
peter$ rm -rf Godeps/_workspace/pkg
[~/go/src/github.com/docker/machine]
peter$ make build
script/build
Sending build context to Docker daemon 7.722 MB
Sending build context to Docker daemon
Step 0 : FROM golang:1.3-cross
 ---> 8e48d3b7a010
Step 1 : RUN apt-get update && apt-get install -y --no-install-recommends openssh-client
 ---> Using cache
 ---> ee897cd06685
Step 2 : RUN go get github.com/mitchellh/gox
 ---> Using cache
 ---> 36d5baaefab2
Step 3 : RUN go get github.com/aktau/github-release
 ---> Using cache
 ---> 8aa622ae34ec
Step 4 : RUN go get github.com/tools/godep
 ---> Using cache
 ---> 9a6d350c8a46
Step 5 : RUN go get code.google.com/p/go.tools/cmd/cover
 ---> Using cache
 ---> 1315f591fcae
Step 6 : ENV GOPATH /go/src/github.com/docker/machine/Godeps/_workspace:/go
 ---> Using cache
 ---> d3127fd2805d
Step 7 : ENV MACHINE_BINARY /go/src/github.com/docker/machine/docker-machine
 ---> Using cache
 ---> 6050bb7dbbd5
Step 8 : ENV USER root
 ---> Using cache
 ---> 0232c99fa788
Step 9 : WORKDIR /go/src/github.com/docker/machine
 ---> Using cache
 ---> d45f0f4b4082
Step 10 : ADD . /go/src/github.com/docker/machine
 ---> 47234bdd0887
Removing intermediate container fb71ca1b8a20
Successfully built 47234bdd0887
Number of parallel builds: 8

-->      darwin/386: github.com/docker/machine
-->    darwin/amd64: github.com/docker/machine
-->       linux/386: github.com/docker/machine
-->     linux/amd64: github.com/docker/machine
-->     windows/386: github.com/docker/machine
-->   windows/amd64: github.com/docker/machine
```