### PR TITLE
exoscale: destroy the SSH keypair when removing the machine

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -132,7 +132,7 @@
 		},
 		{
 			"ImportPath": "github.com/pyr/egoscale/src/egoscale",
-			"Rev": "8bdfe1d0420634bdd37d73d00d51f86f8d08e481"
+			"Rev": "5759f42eb6041d8dbf837a642e6c061c2bb62f47"
 		},
 		{
 			"ImportPath": "github.com/tent/http-link-go",

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/groups.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/groups.go
@@ -2,8 +2,8 @@ package egoscale
 
 import (
 	"encoding/json"
-	"net/url"
 	"fmt"
+	"net/url"
 )
 
 func (exo *Client) CreateEgressRule(rule SecurityGroupRule) (*AuthorizeSecurityGroupEgressResponse, error) {
@@ -16,7 +16,7 @@ func (exo *Client) CreateEgressRule(rule SecurityGroupRule) (*AuthorizeSecurityG
 	if rule.Protocol == "ICMP" {
 		params.Set("icmpcode", fmt.Sprintf("%d", rule.IcmpCode))
 		params.Set("icmptype", fmt.Sprintf("%d", rule.IcmpType))
-	} else if (rule.Protocol == "TCP" || rule.Protocol == "UDP") {
+	} else if rule.Protocol == "TCP" || rule.Protocol == "UDP" {
 		params.Set("startport", fmt.Sprintf("%d", rule.Port))
 		params.Set("endport", fmt.Sprintf("%d", rule.Port))
 	} else {
@@ -46,7 +46,7 @@ func (exo *Client) CreateIngressRule(rule SecurityGroupRule) (*AuthorizeSecurity
 	if rule.Protocol == "ICMP" {
 		params.Set("icmpcode", fmt.Sprintf("%d", rule.IcmpCode))
 		params.Set("icmptype", fmt.Sprintf("%d", rule.IcmpType))
-	} else if (rule.Protocol == "TCP" || rule.Protocol == "UDP") {
+	} else if rule.Protocol == "TCP" || rule.Protocol == "UDP" {
 		params.Set("startport", fmt.Sprintf("%d", rule.Port))
 		params.Set("endport", fmt.Sprintf("%d", rule.Port))
 	} else {
@@ -85,18 +85,18 @@ func (exo *Client) CreateSecurityGroupWithRules(name string, ingress []SecurityG
 
 	sgid := r.Wrapped.Id
 
-	for _, erule := range(egress) {
+	for _, erule := range egress {
 		erule.SecurityGroupId = sgid
 		_, err = exo.CreateEgressRule(erule)
-		if (err != nil) {
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	for _, inrule := range(ingress) {
+	for _, inrule := range ingress {
 		inrule.SecurityGroupId = sgid
 		_, err = exo.CreateIngressRule(inrule)
-		if (err != nil) {
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/init.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/init.go
@@ -1,20 +1,20 @@
 package egoscale
 
 import (
-	"net/http"
 	"crypto/tls"
+	"net/http"
 )
 
 func NewClient(endpoint string, apiKey string, apiSecret string) *Client {
-	cs := &Client {
-		client: &http.Client {
-			Transport: &http.Transport {
-				Proxy: http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config { InsecureSkipVerify: false },
+	cs := &Client{
+		client: &http.Client{
+			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
 			},
 		},
-		endpoint: endpoint,
-		apiKey: apiKey,
+		endpoint:  endpoint,
+		apiKey:    apiKey,
 		apiSecret: apiSecret,
 	}
 	return cs

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/keypair.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/keypair.go
@@ -21,3 +21,21 @@ func (exo *Client) CreateKeypair(name string) (*CreateSSHKeyPairResponse, error)
 
 	return &r.Wrapped, nil
 }
+
+func (exo *Client) DeleteKeypair(name string) (*StandardResponse, error) {
+	params := url.Values{}
+	params.Set("name", name)
+
+	resp, err := exo.Request("deleteSSHKeyPair", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var r StandardResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+
+}

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/request.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/request.go
@@ -23,7 +23,7 @@ func rawValue(b json.RawMessage) (json.RawMessage, error) {
 	return nil, fmt.Errorf("Unable to extract raw value from:\n\n%s\n\n", string(b))
 }
 
-func (exo *Client) Request (command string, params url.Values) (json.RawMessage, error) {
+func (exo *Client) Request(command string, params url.Values) (json.RawMessage, error) {
 
 	mac := hmac.New(sha1.New, []byte(exo.apiSecret))
 

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/topology.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/topology.go
@@ -2,10 +2,10 @@ package egoscale
 
 import (
 	"encoding/json"
-	"net/url"
-	"strings"
 	"fmt"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 func (exo *Client) GetSecurityGroups() (map[string]string, error) {
@@ -23,7 +23,7 @@ func (exo *Client) GetSecurityGroups() (map[string]string, error) {
 	}
 
 	sgs = make(map[string]string)
-	for _, sg := range(r.SecurityGroups) {
+	for _, sg := range r.SecurityGroups {
 		sgs[sg.Name] = sg.Id
 	}
 	return sgs, nil
@@ -44,7 +44,7 @@ func (exo *Client) GetZones() (map[string]string, error) {
 	}
 
 	zones = make(map[string]string)
-	for _, zone := range(r.Zones) {
+	for _, zone := range r.Zones {
 		zones[zone.Name] = zone.Id
 	}
 	return zones, nil
@@ -66,7 +66,7 @@ func (exo *Client) GetProfiles() (map[string]string, error) {
 	}
 
 	profiles = make(map[string]string)
-	for _, offering := range(r.ServiceOfferings) {
+	for _, offering := range r.ServiceOfferings {
 		profiles[strings.ToLower(offering.Name)] = offering.Id
 	}
 
@@ -90,7 +90,7 @@ func (exo *Client) GetKeypairs() ([]string, error) {
 	}
 
 	keypairs = make([]string, r.Count, r.Count)
-	for i, keypair := range(r.SSHKeyPairs) {
+	for i, keypair := range r.SSHKeyPairs {
 		keypairs[i] = keypair.Name
 	}
 	return keypairs, nil
@@ -115,7 +115,7 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 	}
 
 	re := regexp.MustCompile(`^Linux (?P<name>Ubuntu|Debian) (?P<version>[0-9.]+).*$`)
-	for _, template := range(r.Templates) {
+	for _, template := range r.Templates {
 		size := template.Size / (1024 * 1024 * 1024)
 		submatch := re.FindStringSubmatch(template.Name)
 		if len(submatch) > 0 {
@@ -124,7 +124,7 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 			image := fmt.Sprintf("%s-%s", name, version)
 
 			_, present := images[image]
-			if (!present) {
+			if !present {
 				images[image] = make(map[int]string)
 			}
 			images[image][size] = template.Id
@@ -138,31 +138,31 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 func (exo *Client) GetTopology() (*Topology, error) {
 
 	zones, err := exo.GetZones()
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	images, err := exo.GetImages()
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	groups, err := exo.GetSecurityGroups()
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	keypairs, err := exo.GetKeypairs()
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	profiles, err := exo.GetProfiles()
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
 	topo := &Topology{
-		Zones: zones,
-		Profiles: profiles,
-		Images: images,
-		Keypairs: keypairs,
+		Zones:          zones,
+		Profiles:       profiles,
+		Images:         images,
+		Keypairs:       keypairs,
 		SecurityGroups: groups,
 	}
 

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/types.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/types.go
@@ -1,205 +1,208 @@
 package egoscale
 
 import (
-	"net/http"
 	"encoding/json"
+	"net/http"
 )
 
 type Client struct {
-	client *http.Client
-	endpoint string
-	apiKey string
+	client    *http.Client
+	endpoint  string
+	apiKey    string
 	apiSecret string
 }
 
-
 type Error struct {
-	ErrorCode int `json:"errorcode"`
-	CSErrorCode int `json:"cserrorcode"`
-	ErrorText string `json:"errortext"`
+	ErrorCode   int    `json:"errorcode"`
+	CSErrorCode int    `json:"cserrorcode"`
+	ErrorText   string `json:"errortext"`
+}
+
+type StandardResponse struct {
+	Success     string `json:"success"`
+	DisplayText string `json:"displaytext"`
 }
 
 type Topology struct {
-	Zones map[string]string
-	Images map[string]map[int]string
-	Profiles map[string]string
-	Keypairs []string
+	Zones          map[string]string
+	Images         map[string]map[int]string
+	Profiles       map[string]string
+	Keypairs       []string
 	SecurityGroups map[string]string
 }
 
 type SecurityGroupRule struct {
-	Cidr string
-	IcmpType int
-	IcmpCode int
-	Port int
-	Protocol string
+	Cidr            string
+	IcmpType        int
+	IcmpCode        int
+	Port            int
+	Protocol        string
 	SecurityGroupId string
 }
 
 type MachineProfile struct {
-	Name string
-	SecurityGroups []string
-	Keypair string
-	Userdata string
+	Name            string
+	SecurityGroups  []string
+	Keypair         string
+	Userdata        string
 	ServiceOffering string
-	Template string
-	Zone string
+	Template        string
+	Zone            string
 }
 
 type ListZonesResponse struct {
-	Count int `json:"count"`
+	Count int     `json:"count"`
 	Zones []*Zone `json:"zone"`
 }
 
 type Zone struct {
-	Allocationstate string `json:"allocationstate,omitempty"`
-	Description string `json:"description,omitempty"`
-	Displaytext string `json:"displaytext,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Domainname string `json:"domainname,omitempty"`
-	Id string `json:"id,omitempty"`
-	Internaldns1 string `json:"internaldns1,omitempty"`
-	Internaldns2 string `json:"internaldns2,omitempty"`
-	Ip6dns1 string `json:"ip6dns1,omitempty"`
-	Ip6dns2 string `json:"ip6dns2,omitempty"`
-	Localstorageenabled bool `json:"localstorageenabled,omitempty"`
-	Name string `json:"name,omitempty"`
-	Networktype string `json:"networktype,omitempty"`
-	Resourcedetails map[string]string `json:"resourcedetails,omitempty"`
-	Securitygroupsenabled bool `json:"securitygroupsenabled,omitempty"`
-	Vlan string `json:"vlan,omitempty"`
-	Zonetoken string `json:"zonetoken,omitempty"`
+	Allocationstate       string            `json:"allocationstate,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Domainname            string            `json:"domainname,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Internaldns1          string            `json:"internaldns1,omitempty"`
+	Internaldns2          string            `json:"internaldns2,omitempty"`
+	Ip6dns1               string            `json:"ip6dns1,omitempty"`
+	Ip6dns2               string            `json:"ip6dns2,omitempty"`
+	Localstorageenabled   bool              `json:"localstorageenabled,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networktype           string            `json:"networktype,omitempty"`
+	Resourcedetails       map[string]string `json:"resourcedetails,omitempty"`
+	Securitygroupsenabled bool              `json:"securitygroupsenabled,omitempty"`
+	Vlan                  string            `json:"vlan,omitempty"`
+	Zonetoken             string            `json:"zonetoken,omitempty"`
 }
 
 type ListServiceOfferingsResponse struct {
-	Count int `json:"count"`
+	Count            int                `json:"count"`
 	ServiceOfferings []*ServiceOffering `json:"serviceoffering"`
 }
 
 type ServiceOffering struct {
-	Cpunumber int `json:"cpunumber,omitempty"`
-	Cpuspeed int `json:"cpuspeed,omitempty"`
-	Displaytext string `json:"displaytext,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Hosttags string `json:"hosttags,omitempty"`
-	Id string `json:"id,omitempty"`
-	Iscustomized bool `json:"iscustomized,omitempty"`
-	Issystem bool `json:"issystem,omitempty"`
-	Isvolatile bool `json:"isvolatile,omitempty"`
-	Memory int `json:"memory,omitempty"`
-	Name string `json:"name,omitempty"`
-	Networkrate int `json:"networkrate,omitempty"`
+	Cpunumber              int               `json:"cpunumber,omitempty"`
+	Cpuspeed               int               `json:"cpuspeed,omitempty"`
+	Displaytext            string            `json:"displaytext,omitempty"`
+	Domain                 string            `json:"domain,omitempty"`
+	Domainid               string            `json:"domainid,omitempty"`
+	Hosttags               string            `json:"hosttags,omitempty"`
+	Id                     string            `json:"id,omitempty"`
+	Iscustomized           bool              `json:"iscustomized,omitempty"`
+	Issystem               bool              `json:"issystem,omitempty"`
+	Isvolatile             bool              `json:"isvolatile,omitempty"`
+	Memory                 int               `json:"memory,omitempty"`
+	Name                   string            `json:"name,omitempty"`
+	Networkrate            int               `json:"networkrate,omitempty"`
 	Serviceofferingdetails map[string]string `json:"serviceofferingdetails,omitempty"`
 }
 
 type ListTemplatesResponse struct {
-	Count int `json:"count"`
+	Count     int         `json:"count"`
 	Templates []*Template `json:"template"`
 }
 
 type Template struct {
-	Account string `json:"account,omitempty"`
-	Accountid string `json:"accountid,omitempty"`
-	Bootable bool `json:"bootable,omitempty"`
-	Checksum string `json:"checksum,omitempty"`
-	Created string `json:"created,omitempty"`
-	CrossZones bool `json:"crossZones,omitempty"`
-	Details map[string]string `json:"details,omitempty"`
-	Displaytext string `json:"displaytext,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Format string `json:"format,omitempty"`
-	Hostid string `json:"hostid,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Hypervisor string `json:"hypervisor,omitempty"`
-	Id string `json:"id,omitempty"`
-	Isdynamicallyscalable bool `json:"isdynamicallyscalable,omitempty"`
-	Isextractable bool `json:"isextractable,omitempty"`
-	Isfeatured bool `json:"isfeatured,omitempty"`
-	Ispublic bool `json:"ispublic,omitempty"`
-	Isready bool `json:"isready,omitempty"`
-	Name string `json:"name,omitempty"`
-	Ostypeid string `json:"ostypeid,omitempty"`
-	Ostypename string `json:"ostypename,omitempty"`
-	Passwordenabled bool `json:"passwordenabled,omitempty"`
-	Project string `json:"project,omitempty"`
-	Projectid string `json:"projectid,omitempty"`
-	Removed string `json:"removed,omitempty"`
-	Size int `json:"size,omitempty"`
-	Sourcetemplateid string `json:"sourcetemplateid,omitempty"`
-	Sshkeyenabled bool `json:"sshkeyenabled,omitempty"`
-	Status string `json:"status,omitempty"`
-	Zoneid string `json:"zoneid,omitempty"`
-	Zonename string `json:"zonename,omitempty"`
+	Account               string            `json:"account,omitempty"`
+	Accountid             string            `json:"accountid,omitempty"`
+	Bootable              bool              `json:"bootable,omitempty"`
+	Checksum              string            `json:"checksum,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	CrossZones            bool              `json:"crossZones,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Displaytext           string            `json:"displaytext,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Format                string            `json:"format,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isextractable         bool              `json:"isextractable,omitempty"`
+	Isfeatured            bool              `json:"isfeatured,omitempty"`
+	Ispublic              bool              `json:"ispublic,omitempty"`
+	Isready               bool              `json:"isready,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Ostypeid              string            `json:"ostypeid,omitempty"`
+	Ostypename            string            `json:"ostypename,omitempty"`
+	Passwordenabled       bool              `json:"passwordenabled,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	Projectid             string            `json:"projectid,omitempty"`
+	Removed               string            `json:"removed,omitempty"`
+	Size                  int               `json:"size,omitempty"`
+	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
+	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
+	Status                string            `json:"status,omitempty"`
+	Zoneid                string            `json:"zoneid,omitempty"`
+	Zonename              string            `json:"zonename,omitempty"`
 }
 
 type ListSSHKeyPairsResponse struct {
-	Count int `json:"count"`
+	Count       int           `json:"count"`
 	SSHKeyPairs []*SSHKeyPair `json:"sshkeypair"`
 }
 
 type SSHKeyPair struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
 }
 
-
 type ListSecurityGroupsResponse struct {
-	Count int `json:"count"`
+	Count          int              `json:"count"`
 	SecurityGroups []*SecurityGroup `json:"securitygroup"`
 }
 
 type SecurityGroup struct {
-	Account string `json:"account,omitempty"`
+	Account     string `json:"account,omitempty"`
 	Description string `json:"description,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Id string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Project string `json:"project,omitempty"`
-	Projectid string `json:"projectid,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
 }
 
 type CreateSecurityGroupResponseWrapper struct {
 	Wrapped CreateSecurityGroupResponse `json:"securitygroup"`
 }
 type CreateSecurityGroupResponse struct {
-	Account string `json:"account,omitempty"`
+	Account     string `json:"account,omitempty"`
 	Description string `json:"description,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Id string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Project string `json:"project,omitempty"`
-	Projectid string `json:"projectid,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	Domainid    string `json:"domainid,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Projectid   string `json:"projectid,omitempty"`
 }
 
 type AuthorizeSecurityGroupIngressResponse struct {
-	JobID string `json:"jobid,omitempty"`
-	Account string `json:"account,omitempty"`
-	Cidr string `json:"cidr,omitempty"`
-	Endport int `json:"endport,omitempty"`
-	Icmpcode int `json:"icmpcode,omitempty"`
-	Icmptype int `json:"icmptype,omitempty"`
-	Protocol string `json:"protocol,omitempty"`
-	Ruleid string `json:"ruleid,omitempty"`
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Cidr              string `json:"cidr,omitempty"`
+	Endport           int    `json:"endport,omitempty"`
+	Icmpcode          int    `json:"icmpcode,omitempty"`
+	Icmptype          int    `json:"icmptype,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Ruleid            string `json:"ruleid,omitempty"`
 	Securitygroupname string `json:"securitygroupname,omitempty"`
-	Startport int `json:"startport,omitempty"`
+	Startport         int    `json:"startport,omitempty"`
 }
 
 type AuthorizeSecurityGroupEgressResponse struct {
-	JobID string `json:"jobid,omitempty"`
-	Account string `json:"account,omitempty"`
-	Cidr string `json:"cidr,omitempty"`
-	Endport int `json:"endport,omitempty"`
-	Icmpcode int `json:"icmpcode,omitempty"`
-	Icmptype int `json:"icmptype,omitempty"`
-	Protocol string `json:"protocol,omitempty"`
-	Ruleid string `json:"ruleid,omitempty"`
+	JobID             string `json:"jobid,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Cidr              string `json:"cidr,omitempty"`
+	Endport           int    `json:"endport,omitempty"`
+	Icmpcode          int    `json:"icmpcode,omitempty"`
+	Icmptype          int    `json:"icmptype,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Ruleid            string `json:"ruleid,omitempty"`
 	Securitygroupname string `json:"securitygroupname,omitempty"`
-	Startport int `json:"startport,omitempty"`
+	Startport         int    `json:"startport,omitempty"`
 }
 
 type DeployVirtualMachineWrappedResponse struct {
@@ -207,176 +210,173 @@ type DeployVirtualMachineWrappedResponse struct {
 }
 
 type DeployVirtualMachineResponse struct {
-	JobID string `json:"jobid,omitempty"`
-	Account string `json:"account,omitempty"`
+	JobID         string `json:"jobid,omitempty"`
+	Account       string `json:"account,omitempty"`
 	Affinitygroup []struct {
-		Account string `json:"account,omitempty"`
-		Description string `json:"description,omitempty"`
-		Domain string `json:"domain,omitempty"`
-		Domainid string `json:"domainid,omitempty"`
-		Id string `json:"id,omitempty"`
-		Name string `json:"name,omitempty"`
-		Type string `json:"type,omitempty"`
+		Account           string   `json:"account,omitempty"`
+		Description       string   `json:"description,omitempty"`
+		Domain            string   `json:"domain,omitempty"`
+		Domainid          string   `json:"domainid,omitempty"`
+		Id                string   `json:"id,omitempty"`
+		Name              string   `json:"name,omitempty"`
+		Type              string   `json:"type,omitempty"`
 		VirtualmachineIds []string `json:"virtualmachineIds,omitempty"`
-
 	} `json:"affinitygroup,omitempty"`
-	Cpunumber int `json:"cpunumber,omitempty"`
-	Cpuspeed int `json:"cpuspeed,omitempty"`
-	Cpuused string `json:"cpuused,omitempty"`
-	Created string `json:"created,omitempty"`
-	Details map[string]string `json:"details,omitempty"`
-	Diskioread int `json:"diskioread,omitempty"`
-	Diskiowrite int `json:"diskiowrite,omitempty"`
-	Diskkbsread int `json:"diskkbsread,omitempty"`
-	Diskkbswrite int `json:"diskkbswrite,omitempty"`
-	Displayname string `json:"displayname,omitempty"`
-	Displayvm bool `json:"displayvm,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Forvirtualnetwork bool `json:"forvirtualnetwork,omitempty"`
-	Group string `json:"group,omitempty"`
-	Groupid string `json:"groupid,omitempty"`
-	Guestosid string `json:"guestosid,omitempty"`
-	Haenable bool `json:"haenable,omitempty"`
-	Hostid string `json:"hostid,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Hypervisor string `json:"hypervisor,omitempty"`
-	Id string `json:"id,omitempty"`
-	Instancename string `json:"instancename,omitempty"`
-	Isdynamicallyscalable bool `json:"isdynamicallyscalable,omitempty"`
-	Isodisplaytext string `json:"isodisplaytext,omitempty"`
-	Isoid string `json:"isoid,omitempty"`
-	Isoname string `json:"isoname,omitempty"`
-	Keypair string `json:"keypair,omitempty"`
-	Memory int `json:"memory,omitempty"`
-	Name string `json:"name,omitempty"`
-	Networkkbsread int `json:"networkkbsread,omitempty"`
-	Networkkbswrite int `json:"networkkbswrite,omitempty"`
-	Nic []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Gateway string `json:"gateway,omitempty"`
-		Id string `json:"id,omitempty"`
-		Ipaddress string `json:"ipaddress,omitempty"`
-		Isdefault bool `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress string `json:"macaddress,omitempty"`
-		Netmask string `json:"netmask,omitempty"`
-		Networkid string `json:"networkid,omitempty"`
-		Networkname string `json:"networkname,omitempty"`
-		Secondaryip []string `json:"secondaryip,omitempty"`
-		Traffictype string `json:"traffictype,omitempty"`
-		Type string `json:"type,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int               `json:"diskioread,omitempty"`
+	Diskiowrite           int               `json:"diskiowrite,omitempty"`
+	Diskkbsread           int               `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int               `json:"diskkbswrite,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int               `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int               `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string   `json:"broadcasturi,omitempty"`
+		Gateway      string   `json:"gateway,omitempty"`
+		Id           string   `json:"id,omitempty"`
+		Ipaddress    string   `json:"ipaddress,omitempty"`
+		Isdefault    bool     `json:"isdefault,omitempty"`
+		Isolationuri string   `json:"isolationuri,omitempty"`
+		Macaddress   string   `json:"macaddress,omitempty"`
+		Netmask      string   `json:"netmask,omitempty"`
+		Networkid    string   `json:"networkid,omitempty"`
+		Networkname  string   `json:"networkname,omitempty"`
+		Secondaryip  []string `json:"secondaryip,omitempty"`
+		Traffictype  string   `json:"traffictype,omitempty"`
+		Type         string   `json:"type,omitempty"`
 	} `json:"nic,omitempty"`
-	Password string `json:"password,omitempty"`
-	Passwordenabled bool `json:"passwordenabled,omitempty"`
-	Project string `json:"project,omitempty"`
-	Projectid string `json:"projectid,omitempty"`
-	Publicip string `json:"publicip,omitempty"`
-	Publicipid string `json:"publicipid,omitempty"`
-	Rootdeviceid int `json:"rootdeviceid,omitempty"`
-	Rootdevicetype string `json:"rootdevicetype,omitempty"`
-	Serviceofferingid string `json:"serviceofferingid,omitempty"`
+	Password            string `json:"password,omitempty"`
+	Passwordenabled     bool   `json:"passwordenabled,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicipid          string `json:"publicipid,omitempty"`
+	Rootdeviceid        int    `json:"rootdeviceid,omitempty"`
+	Rootdevicetype      string `json:"rootdevicetype,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
-	Servicestate string `json:"servicestate,omitempty"`
-	State string `json:"state,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
 	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
-	Templateid string `json:"templateid,omitempty"`
-	Templatename string `json:"templatename,omitempty"`
-	Zoneid string `json:"zoneid,omitempty"`
-	Zonename string `json:"zonename,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
 }
 
 type QueryAsyncJobResultResponse struct {
-	Accountid string `json:"accountid,omitempty"`
-	Cmd string `json:"cmd,omitempty"`
-	Created string `json:"created,omitempty"`
-	Jobinstanceid string `json:"jobinstanceid,omitempty"`
-	Jobinstancetype string `json:"jobinstancetype,omitempty"`
-	Jobprocstatus int `json:"jobprocstatus,omitempty"`
-	Jobresult json.RawMessage `json:"jobresult,omitempty"`
-	Jobresultcode int `json:"jobresultcode,omitempty"`
-	Jobresulttype string `json:"jobresulttype,omitempty"`
-	Jobstatus int `json:"jobstatus,omitempty"`
-	Userid string `json:"userid,omitempty"`
+	Accountid       string          `json:"accountid,omitempty"`
+	Cmd             string          `json:"cmd,omitempty"`
+	Created         string          `json:"created,omitempty"`
+	Jobinstanceid   string          `json:"jobinstanceid,omitempty"`
+	Jobinstancetype string          `json:"jobinstancetype,omitempty"`
+	Jobprocstatus   int             `json:"jobprocstatus,omitempty"`
+	Jobresult       json.RawMessage `json:"jobresult,omitempty"`
+	Jobresultcode   int             `json:"jobresultcode,omitempty"`
+	Jobresulttype   string          `json:"jobresulttype,omitempty"`
+	Jobstatus       int             `json:"jobstatus,omitempty"`
+	Userid          string          `json:"userid,omitempty"`
 }
 
 type ListVirtualMachinesResponse struct {
-	Count int `json:"count"`
+	Count           int               `json:"count"`
 	VirtualMachines []*VirtualMachine `json:"virtualmachine"`
 }
 
 type VirtualMachine struct {
-	Account string `json:"account,omitempty"`
-	Cpunumber int `json:"cpunumber,omitempty"`
-	Cpuspeed int `json:"cpuspeed,omitempty"`
-	Cpuused string `json:"cpuused,omitempty"`
-	Created string `json:"created,omitempty"`
-	Details map[string]string `json:"details,omitempty"`
-	Diskioread int `json:"diskioread,omitempty"`
-	Diskiowrite int `json:"diskiowrite,omitempty"`
-	Diskkbsread int `json:"diskkbsread,omitempty"`
-	Diskkbswrite int `json:"diskkbswrite,omitempty"`
-	Displayname string `json:"displayname,omitempty"`
-	Displayvm bool `json:"displayvm,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Domainid string `json:"domainid,omitempty"`
-	Forvirtualnetwork bool `json:"forvirtualnetwork,omitempty"`
-	Group string `json:"group,omitempty"`
-	Groupid string `json:"groupid,omitempty"`
-	Guestosid string `json:"guestosid,omitempty"`
-	Haenable bool `json:"haenable,omitempty"`
-	Hostid string `json:"hostid,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Hypervisor string `json:"hypervisor,omitempty"`
-	Id string `json:"id,omitempty"`
-	Instancename string `json:"instancename,omitempty"`
-	Isdynamicallyscalable bool `json:"isdynamicallyscalable,omitempty"`
-	Isodisplaytext string `json:"isodisplaytext,omitempty"`
-	Isoid string `json:"isoid,omitempty"`
-	Isoname string `json:"isoname,omitempty"`
-	Keypair string `json:"keypair,omitempty"`
-	Memory int `json:"memory,omitempty"`
-	Name string `json:"name,omitempty"`
-	Networkkbsread int `json:"networkkbsread,omitempty"`
-	Networkkbswrite int `json:"networkkbswrite,omitempty"`
-	Nic []struct {
-		Broadcasturi string `json:"broadcasturi,omitempty"`
-		Gateway string `json:"gateway,omitempty"`
-		Id string `json:"id,omitempty"`
-		Ip6address string `json:"ip6address,omitempty"`
-		Ip6cidr string `json:"ip6cidr,omitempty"`
-		Ip6gateway string `json:"ip6gateway,omitempty"`
-		Ipaddress string `json:"ipaddress,omitempty"`
-		Isdefault bool `json:"isdefault,omitempty"`
-		Isolationuri string `json:"isolationuri,omitempty"`
-		Macaddress string `json:"macaddress,omitempty"`
-		Netmask string `json:"netmask,omitempty"`
-		Networkid string `json:"networkid,omitempty"`
-		Networkname string `json:"networkname,omitempty"`
-		Secondaryip []string `json:"secondaryip,omitempty"`
-		Traffictype string `json:"traffictype,omitempty"`
-		Type string `json:"type,omitempty"`
-
+	Account               string            `json:"account,omitempty"`
+	Cpunumber             int               `json:"cpunumber,omitempty"`
+	Cpuspeed              int               `json:"cpuspeed,omitempty"`
+	Cpuused               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	Diskioread            int               `json:"diskioread,omitempty"`
+	Diskiowrite           int               `json:"diskiowrite,omitempty"`
+	Diskkbsread           int               `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int               `json:"diskkbswrite,omitempty"`
+	Displayname           string            `json:"displayname,omitempty"`
+	Displayvm             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	Domainid              string            `json:"domainid,omitempty"`
+	Forvirtualnetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	Groupid               string            `json:"groupid,omitempty"`
+	Guestosid             string            `json:"guestosid,omitempty"`
+	Haenable              bool              `json:"haenable,omitempty"`
+	Hostid                string            `json:"hostid,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	Id                    string            `json:"id,omitempty"`
+	Instancename          string            `json:"instancename,omitempty"`
+	Isdynamicallyscalable bool              `json:"isdynamicallyscalable,omitempty"`
+	Isodisplaytext        string            `json:"isodisplaytext,omitempty"`
+	Isoid                 string            `json:"isoid,omitempty"`
+	Isoname               string            `json:"isoname,omitempty"`
+	Keypair               string            `json:"keypair,omitempty"`
+	Memory                int               `json:"memory,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Networkkbsread        int               `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int               `json:"networkkbswrite,omitempty"`
+	Nic                   []struct {
+		Broadcasturi string   `json:"broadcasturi,omitempty"`
+		Gateway      string   `json:"gateway,omitempty"`
+		Id           string   `json:"id,omitempty"`
+		Ip6address   string   `json:"ip6address,omitempty"`
+		Ip6cidr      string   `json:"ip6cidr,omitempty"`
+		Ip6gateway   string   `json:"ip6gateway,omitempty"`
+		Ipaddress    string   `json:"ipaddress,omitempty"`
+		Isdefault    bool     `json:"isdefault,omitempty"`
+		Isolationuri string   `json:"isolationuri,omitempty"`
+		Macaddress   string   `json:"macaddress,omitempty"`
+		Netmask      string   `json:"netmask,omitempty"`
+		Networkid    string   `json:"networkid,omitempty"`
+		Networkname  string   `json:"networkname,omitempty"`
+		Secondaryip  []string `json:"secondaryip,omitempty"`
+		Traffictype  string   `json:"traffictype,omitempty"`
+		Type         string   `json:"type,omitempty"`
 	} `json:"nic,omitempty"`
-	Password string `json:"password,omitempty"`
-	Passwordenabled bool `json:"passwordenabled,omitempty"`
-	Project string `json:"project,omitempty"`
-	Projectid string `json:"projectid,omitempty"`
-	Publicip string `json:"publicip,omitempty"`
-	Publicipid string `json:"publicipid,omitempty"`
-	Rootdeviceid int `json:"rootdeviceid,omitempty"`
-	Rootdevicetype string `json:"rootdevicetype,omitempty"`
-	Serviceofferingid string `json:"serviceofferingid,omitempty"`
+	Password            string `json:"password,omitempty"`
+	Passwordenabled     bool   `json:"passwordenabled,omitempty"`
+	Project             string `json:"project,omitempty"`
+	Projectid           string `json:"projectid,omitempty"`
+	Publicip            string `json:"publicip,omitempty"`
+	Publicipid          string `json:"publicipid,omitempty"`
+	Rootdeviceid        int    `json:"rootdeviceid,omitempty"`
+	Rootdevicetype      string `json:"rootdevicetype,omitempty"`
+	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
-	Servicestate string `json:"servicestate,omitempty"`
-	State string `json:"state,omitempty"`
+	Servicestate        string `json:"servicestate,omitempty"`
+	State               string `json:"state,omitempty"`
 	Templatedisplaytext string `json:"templatedisplaytext,omitempty"`
-	Templateid string `json:"templateid,omitempty"`
-	Templatename string `json:"templatename,omitempty"`
-	Zoneid string `json:"zoneid,omitempty"`
-	Zonename string `json:"zonename,omitempty"`
+	Templateid          string `json:"templateid,omitempty"`
+	Templatename        string `json:"templatename,omitempty"`
+	Zoneid              string `json:"zoneid,omitempty"`
+	Zonename            string `json:"zonename,omitempty"`
 }
-
 
 type StartVirtualMachineResponse struct {
 	JobID string `json:"jobid,omitempty"`
@@ -390,7 +390,6 @@ type DestroyVirtualMachineResponse struct {
 	JobID string `json:"jobid,omitempty"`
 }
 
-
 type RebootVirtualMachineResponse struct {
 	JobID string `json:"jobid,omitempty"`
 }
@@ -400,5 +399,9 @@ type CreateSSHKeyPairWrappedResponse struct {
 }
 
 type CreateSSHKeyPairResponse struct {
+	Privatekey string `json:"privatekey,omitempty"`
+}
+
+type DeleteSSHKeyPairResponse struct {
 	Privatekey string `json:"privatekey,omitempty"`
 }

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/vm.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/vm.go
@@ -3,9 +3,9 @@ package egoscale
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 func (exo *Client) CreateVirtualMachine(p MachineProfile) (string, error) {
@@ -139,4 +139,24 @@ func (exo *Client) GetVirtualMachine(id string) (*VirtualMachine, error) {
 	} else {
 		return nil, fmt.Errorf("cannot retrieve virtualmachine with id %s", id)
 	}
+}
+
+func (exo *Client) ListVirtualMachines(id string) ([]*VirtualMachine, error) {
+
+	params := url.Values{}
+	params.Set("id", id)
+
+	resp, err := exo.Request("listVirtualMachines", params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListVirtualMachinesResponse
+
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return r.VirtualMachines, nil
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1357,7 +1357,7 @@ Options:
  - `--exoscale-disk-size`: Disk size for the host in GB. Default: `50`.
  - `--exoscale-security-group`: Security group. It will be created if it doesn't exist. Default: `docker-machine`.
 
-If a custom security group is provided, you need to ensure that you allow TCP port 2376 in an ingress rule.
+If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule.
 
 ## Release Notes
 

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -96,11 +96,6 @@ func GetCreateFlags() []cli.Flag {
 			Value:  "ch-gva-2",
 			Usage:  "exoscale availibility zone",
 		},
-		cli.StringFlag{
-			EnvVar: "EXOSCALE_KEYPAIR",
-			Name:   "exoscale-keypair",
-			Usage:  "exoscale keypair name",
-		},
 	}
 }
 
@@ -153,7 +148,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Image = flags.String("exoscale-image")
 	d.SecurityGroup = flags.String("exoscale-security-group")
 	d.AvailabilityZone = flags.String("exoscale-availability-zone")
-	d.KeyPair = flags.String("exoscale-keypair")
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")
@@ -290,18 +284,17 @@ func (d *Driver) Create() error {
 	}
 	log.Debugf("Security group %v = %s", d.SecurityGroup, sg)
 
-	if d.KeyPair == "" {
-		log.Infof("Generate an SSH keypair...")
-		kpresp, err := client.CreateKeypair(d.MachineName)
-		if err != nil {
-			return err
-		}
-		err = ioutil.WriteFile(d.GetSSHKeyPath(), []byte(kpresp.Privatekey), 0600)
-		if err != nil {
-			return err
-		}
-		d.KeyPair = d.MachineName
+	log.Infof("Generate an SSH keypair...")
+	keypairName := fmt.Sprintf("docker-machine-%s", d.MachineName)
+	kpresp, err := client.CreateKeypair(keypairName)
+	if err != nil {
+		return err
 	}
+	err = ioutil.WriteFile(d.GetSSHKeyPath(), []byte(kpresp.Privatekey), 0600)
+	if err != nil {
+		return err
+	}
+	d.KeyPair = keypairName
 
 	log.Infof("Spawn exoscale host...")
 
@@ -383,6 +376,14 @@ func (d *Driver) Stop() error {
 
 func (d *Driver) Remove() error {
 	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
+
+	// Destroy the SSH key
+	_, err := client.DeleteKeypair(d.KeyPair)
+	if err != nil {
+		return err
+	}
+
+	// Destroy the virtual machine
 	dvmresp, err := client.DestroyVirtualMachine(d.Id)
 	if err != nil {
 		return err

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -367,8 +367,7 @@ func (d *Driver) Stop() error {
 	if err != nil {
 		return err
 	}
-	_, err = d.waitForVM(client, svmresp)
-	if err != nil {
+	if _, err = d.waitForVM(client, svmresp); err != nil {
 		return err
 	}
 	return nil
@@ -378,8 +377,7 @@ func (d *Driver) Remove() error {
 	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
 
 	// Destroy the SSH key
-	_, err := client.DeleteKeypair(d.KeyPair)
-	if err != nil {
+	if _, err := client.DeleteKeypair(d.KeyPair); err != nil {
 		return err
 	}
 
@@ -409,8 +407,7 @@ func (d *Driver) Restart() error {
 	if err != nil {
 		return err
 	}
-	_, err = d.waitForVM(client, svmresp)
-	if err != nil {
+	if _, err = d.waitForVM(client, svmresp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Otherwise, when recreating a machine with the same name, we would get an
error about this SSH keypair already existing.

To avoid any confusion, let's say that machine will handle all keypairs
and the user cannot provide its own. Therefore, move the keypairs into
their own "namespace" and remove the option to specify a keypair.

This is also what is done by Digital Ocean.

First commit is totally unrelated but I didn't want to do a PR just for it. Second commit is needed to get the appropriate method to destroy keypair.