### PR TITLE
logger: fix error logger writing to stdout instead of stderr

### DIFF
--- a/log/terminal.go
+++ b/log/terminal.go
@@ -31,7 +31,7 @@ func (t TerminalLogger) err(args ...interface{}) {
 
 func (t TerminalLogger) errf(fmtString string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, fmtString, args...)
-	fmt.Print(t.fieldOut, "\n")
+	fmt.Fprint(os.Stderr, t.fieldOut, "\n")
 	t.fieldOut = ""
 }
 


### PR DESCRIPTION
Signed-off-by: Jan Broer <janeczku@yahoo.de>