### PR TITLE
vbox: use intel driver for nic

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -273,7 +273,7 @@ func (d *Driver) Create() error {
 
 	if err := vbm("modifyvm", d.MachineName,
 		"--nic1", "nat",
-		"--nictype1", "virtio",
+		"--nictype1", "82540EM",
 		"--cableconnected1", "on"); err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (d *Driver) Create() error {
 	}
 	if err := vbm("modifyvm", d.MachineName,
 		"--nic2", "hostonly",
-		"--nictype2", "virtio",
+		"--nictype2", "82540EM",
 		"--hostonlyadapter2", hostOnlyNetwork.Name,
 		"--cableconnected2", "on"); err != nil {
 		return err


### PR DESCRIPTION
This changes the driver in vbox to use intel.  This adds a bunch of network stability to the VM.  See https://github.com/docker/machine/issues/986#issuecomment-103963797

Closes #986 