### PR TITLE
Adding SSHKeyPath to drivers so it's listed in the `inspect` output

### DIFF
--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -157,7 +157,3 @@ func (d *Driver) Kill() error {
 	_, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -P now")
 	return err
 }
-
-func (d *Driver) publicSSHKeyPath() string {
-	return d.GetSSHKeyPath() + ".pub"
-}


### PR DESCRIPTION
Fixes #1207

Signed-off-by: Dave Henderson <dhenderson@gmail.com>