### PR TITLE
Implemented '--tls-san' global arg for adding extra SANs

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -67,6 +67,7 @@ func cmdCreate(c *cli.Context) {
 			ClientKeyPath:  certInfo.ClientKeyPath,
 			ServerCertPath: filepath.Join(utils.GetMachineDir(), name, "server.pem"),
 			ServerKeyPath:  filepath.Join(utils.GetMachineDir(), name, "server-key.pem"),
+			ServerCertSANs: c.GlobalStringSlice("tls-san"),
 		},
 		EngineOptions: &engine.EngineOptions{
 			ArbitraryFlags:   c.StringSlice("engine-opt"),

--- a/libmachine/auth/auth.go
+++ b/libmachine/auth/auth.go
@@ -11,4 +11,5 @@ type AuthOptions struct {
 	ServerKeyRemotePath  string
 	PrivateKeyPath       string
 	ClientCertPath       string
+	ServerCertSANs       []string
 }

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -83,17 +83,20 @@ func ConfigureAuth(p Provisioner) error {
 		log.Fatalf("Error copying key.pem to machine dir: %s", err)
 	}
 
-	log.Debugf("generating server cert: %s ca-key=%s private-key=%s org=%s",
+	// The Host IP is always added to the certificate's SANs list
+	certSANs := append(authOptions.ServerCertSANs, ip)
+	log.Debugf("generating server cert: %s ca-key=%s private-key=%s org=%s san=%s",
 		authOptions.ServerCertPath,
 		authOptions.CaCertPath,
 		authOptions.PrivateKeyPath,
 		org,
+		certSANs,
 	)
 
 	// TODO: Switch to passing just authOptions to this func
 	// instead of all these individual fields
 	err = utils.GenerateCert(
-		[]string{ip},
+		certSANs,
 		authOptions.ServerCertPath,
 		authOptions.ServerKeyPath,
 		authOptions.CaCertPath,

--- a/main.go
+++ b/main.go
@@ -104,6 +104,12 @@ func main() {
 			Usage:  "Private key used in client TLS auth",
 			Value:  "",
 		},
+		cli.StringSliceFlag{
+			EnvVar: "MACHINE_TLS_SAN",
+			Name:   "tls-san",
+			Usage:  "Support extra SANs for TLS certs",
+			Value:  &cli.StringSlice{},
+		},
 		cli.BoolFlag{
 			EnvVar: "MACHINE_NATIVE_SSH",
 			Name:   "native-ssh",

--- a/test/integration/certs-extra-san.bats
+++ b/test/integration/certs-extra-san.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load helpers
+
+export DRIVER=virtualbox
+export NAME="bats-$DRIVER-test"
+export MACHINE_STORAGE_PATH=/tmp/machine-bats-test-$DRIVER
+
+@test "$DRIVER: create" {
+  run machine --tls-san foo.bar.tld --tls-san 10.42.42.42 create -d $DRIVER $NAME
+}
+
+@test "$DRIVER: verify that server cert contains the extra SANs" {
+    machine ssh $NAME -- openssl x509 -in /var/lib/boot2docker/server.pem -text | grep 'DNS:foo.bar.tld'
+    machine ssh $NAME -- openssl x509 -in /var/lib/boot2docker/server.pem -text | grep 'IP Address:10.42.42.42'
+}
+
+@test "$DRIVER: verify that server cert SANs are still there after 'regenerate-certs'" {
+    machine regenerate-certs -f $NAME
+    machine ssh $NAME -- openssl x509 -in /var/lib/boot2docker/server.pem -text | grep 'DNS:foo.bar.tld'
+    machine ssh $NAME -- openssl x509 -in /var/lib/boot2docker/server.pem -text | grep 'IP Address:10.42.42.42'
+}
+
+@test "cleanup" {
+  machine rm $NAME
+}


### PR DESCRIPTION
Added the ability to add extra SANs to all server-side certificates generated by machine.

Fixes #1227 