### PR TITLE
exoscale: ensure we sleep a bit while waiting for the VM to be ready

### DIFF
--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -433,13 +433,11 @@ WaitLoop:
 		}
 		switch resp.Jobstatus {
 		case 0: // Job is still in progress
-			continue
 		case 1: // Job has successfully completed
 			break WaitLoop
 		case 2: // Job has failed to complete
 			return nil, fmt.Errorf("Operation failed to complete")
 		default: // Some other code
-			continue
 		}
 		time.Sleep(2 * time.Second)
 	}


### PR DESCRIPTION
Otherwise, the timeout is reached far too soon: instead of waiting for
the VM for two minutes, we wait only for a couple of seconds.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>