### PR TITLE
redhat: use engine version 1.7rc1

### DIFF
--- a/libmachine/provision/centos.go
+++ b/libmachine/provision/centos.go
@@ -8,7 +8,7 @@ const (
 	// TODO: eventually the RPM install process will be integrated
 	// into the get.docker.com install script; for now
 	// we install via vendored RPMs
-	dockerCentosRPMPath = "https://docker-mcn.s3.amazonaws.com/public/redhat/rpms/docker-engine-1.6.1-0.0.20150511.171646.git1b47f9f.el7.centos.x86_64.rpm"
+	dockerCentosRPMPath = "https://test.docker.com/rpm/1.7.0-rc1/centos-7/RPMS/x86_64/docker-engine-1.7.0-0.1.rc1.el7.centos.x86_64.rpm"
 )
 
 func init() {

--- a/libmachine/provision/fedora.go
+++ b/libmachine/provision/fedora.go
@@ -8,7 +8,7 @@ const (
 	// TODO: eventually the RPM install process will be integrated
 	// into the get.docker.com install script; for now
 	// we install via vendored RPMs
-	dockerFedoraRPMPath = "https://docker-mcn.s3.amazonaws.com/public/fedora/rpms/docker-engine-1.6.1-0.0.20150511.171646.git1b47f9f.fc21.x86_64.rpm"
+	dockerFedoraRPMPath = "https://test.docker.com/rpm/1.7.0-rc1/fedora-21/RPMS/x86_64/docker-engine-1.7.0-0.1.rc1.fc21.x86_64.rpm"
 )
 
 func init() {

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -19,7 +19,7 @@ const (
 	// TODO: eventually the RPM install process will be integrated
 	// into the get.docker.com install script; for now
 	// we install via vendored RPMs
-	dockerRHELRPMPath = "https://docker-mcn.s3.amazonaws.com/public/redhat/rpms/docker-engine-1.6.1-0.0.20150511.171646.git1b47f9f.el7.centos.x86_64.rpm"
+	dockerRHELRPMPath = "https://test.docker.com/rpm/1.7.0-rc1/centos-7/RPMS/x86_64/docker-engine-1.7.0-0.1.rc1.el7.centos.x86_64.rpm"
 )
 
 func init() {


### PR DESCRIPTION
This upgrades the Docker Engine to the latest RC.  This is a temporary bump until we get an official install process (either via the install script for via an official repo).

We will need to update the final URLs to the 1.7 RPM before releasing the 0.3.0 as well.  This at least will get us testing on 1.7.