### PR TITLE
exoscale: update egoscale binding for 32-bit compatibility

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -132,7 +132,7 @@
 		},
 		{
 			"ImportPath": "github.com/pyr/egoscale/src/egoscale",
-			"Rev": "5759f42eb6041d8dbf837a642e6c061c2bb62f47"
+			"Rev": "bbaa67324aeeacc90430c1fe0a9c620d3929512e"
 		},
 		{
 			"ImportPath": "github.com/tent/http-link-go",

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/topology.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/topology.go
@@ -116,7 +116,7 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 
 	re := regexp.MustCompile(`^Linux (?P<name>Ubuntu|Debian) (?P<version>[0-9.]+).*$`)
 	for _, template := range r.Templates {
-		size := template.Size / (1024 * 1024 * 1024)
+		size := int(template.Size / (1024 * 1024 * 1024))
 		submatch := re.FindStringSubmatch(template.Name)
 		if len(submatch) > 0 {
 			name := strings.ToLower(submatch[1])

--- a/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/types.go
+++ b/Godeps/_workspace/src/github.com/pyr/egoscale/src/egoscale/types.go
@@ -131,7 +131,7 @@ type Template struct {
 	Project               string            `json:"project,omitempty"`
 	Projectid             string            `json:"projectid,omitempty"`
 	Removed               string            `json:"removed,omitempty"`
-	Size                  int               `json:"size,omitempty"`
+	Size                  int64             `json:"size,omitempty"`
 	Sourcetemplateid      string            `json:"sourcetemplateid,omitempty"`
 	Sshkeyenabled         bool              `json:"sshkeyenabled,omitempty"`
 	Status                string            `json:"status,omitempty"`
@@ -227,10 +227,10 @@ type DeployVirtualMachineResponse struct {
 	Cpuused               string            `json:"cpuused,omitempty"`
 	Created               string            `json:"created,omitempty"`
 	Details               map[string]string `json:"details,omitempty"`
-	Diskioread            int               `json:"diskioread,omitempty"`
-	Diskiowrite           int               `json:"diskiowrite,omitempty"`
-	Diskkbsread           int               `json:"diskkbsread,omitempty"`
-	Diskkbswrite          int               `json:"diskkbswrite,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
 	Displayname           string            `json:"displayname,omitempty"`
 	Displayvm             bool              `json:"displayvm,omitempty"`
 	Domain                string            `json:"domain,omitempty"`
@@ -252,8 +252,8 @@ type DeployVirtualMachineResponse struct {
 	Keypair               string            `json:"keypair,omitempty"`
 	Memory                int               `json:"memory,omitempty"`
 	Name                  string            `json:"name,omitempty"`
-	Networkkbsread        int               `json:"networkkbsread,omitempty"`
-	Networkkbswrite       int               `json:"networkkbswrite,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
 		Broadcasturi string   `json:"broadcasturi,omitempty"`
 		Gateway      string   `json:"gateway,omitempty"`
@@ -275,7 +275,7 @@ type DeployVirtualMachineResponse struct {
 	Projectid           string `json:"projectid,omitempty"`
 	Publicip            string `json:"publicip,omitempty"`
 	Publicipid          string `json:"publicipid,omitempty"`
-	Rootdeviceid        int    `json:"rootdeviceid,omitempty"`
+	Rootdeviceid        int64  `json:"rootdeviceid,omitempty"`
 	Rootdevicetype      string `json:"rootdevicetype,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`
@@ -314,10 +314,10 @@ type VirtualMachine struct {
 	Cpuused               string            `json:"cpuused,omitempty"`
 	Created               string            `json:"created,omitempty"`
 	Details               map[string]string `json:"details,omitempty"`
-	Diskioread            int               `json:"diskioread,omitempty"`
-	Diskiowrite           int               `json:"diskiowrite,omitempty"`
-	Diskkbsread           int               `json:"diskkbsread,omitempty"`
-	Diskkbswrite          int               `json:"diskkbswrite,omitempty"`
+	Diskioread            int64             `json:"diskioread,omitempty"`
+	Diskiowrite           int64             `json:"diskiowrite,omitempty"`
+	Diskkbsread           int64             `json:"diskkbsread,omitempty"`
+	Diskkbswrite          int64             `json:"diskkbswrite,omitempty"`
 	Displayname           string            `json:"displayname,omitempty"`
 	Displayvm             bool              `json:"displayvm,omitempty"`
 	Domain                string            `json:"domain,omitempty"`
@@ -339,8 +339,8 @@ type VirtualMachine struct {
 	Keypair               string            `json:"keypair,omitempty"`
 	Memory                int               `json:"memory,omitempty"`
 	Name                  string            `json:"name,omitempty"`
-	Networkkbsread        int               `json:"networkkbsread,omitempty"`
-	Networkkbswrite       int               `json:"networkkbswrite,omitempty"`
+	Networkkbsread        int64             `json:"networkkbsread,omitempty"`
+	Networkkbswrite       int64             `json:"networkkbswrite,omitempty"`
 	Nic                   []struct {
 		Broadcasturi string   `json:"broadcasturi,omitempty"`
 		Gateway      string   `json:"gateway,omitempty"`
@@ -365,7 +365,7 @@ type VirtualMachine struct {
 	Projectid           string `json:"projectid,omitempty"`
 	Publicip            string `json:"publicip,omitempty"`
 	Publicipid          string `json:"publicipid,omitempty"`
-	Rootdeviceid        int    `json:"rootdeviceid,omitempty"`
+	Rootdeviceid        int64  `json:"rootdeviceid,omitempty"`
 	Rootdevicetype      string `json:"rootdevicetype,omitempty"`
 	Serviceofferingid   string `json:"serviceofferingid,omitempty"`
 	Serviceofferingname string `json:"serviceofferingname,omitempty"`


### PR DESCRIPTION
egoscale is updated to use int64 where it makes sense.

Closes #1212.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>