### PR TITLE
Update Go version to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM golang:1.3-cross
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-client
+FROM golang:1.4.2-cross
 
 # TODO: Vendor these `go get` commands using Godep.
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/aktau/github-release
 RUN go get github.com/tools/godep
-RUN go get code.google.com/p/go.tools/cmd/cover
+RUN go get golang.org/x/tools/cmd/cover
 
 ENV GOPATH /go/src/github.com/docker/machine/Godeps/_workspace:/go
 ENV MACHINE_BINARY /go/src/github.com/docker/machine/docker-machine


### PR DESCRIPTION
There's not really any great hurry on this AFAIK, but it might be nice to have soon, or after the release if we want to play it super super safe.

This style of build optimizes for bandwidth at the cost of some additional time on first compile / environment build.  The `golang:1.4.2-cross` image is quite large, and I have a feeling that bandwidth is a more limited resource than CPU cycles for most.  It looks like first build with this method takes quite a while comparatively on a fast connection, though (~1 minute for pull vs. ~4 for bootstrap on my Ethernet at the office), so we should consider the tradeoff carefully and do some additional benchmarking.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>