### PR TITLE
Check that instance has started before polling SSH

### DIFF
--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -120,6 +120,10 @@ func (h *Host) Create(name string) error {
 
 	// TODO: Not really a fan of just checking "none" here.
 	if h.Driver.DriverName() != "none" {
+		if err := utils.WaitFor(drivers.MachineInState(h.Driver, state.Running)); err != nil {
+			return err
+		}
+
 		if err := WaitForSSH(h); err != nil {
 			return err
 		}


### PR DESCRIPTION
After creating a new instance, we should check that this instance has been started before invoking the `WaitForSSH` method. We should not attempt to TCP connect to a host that is in state stopped/pending.
Typically the console is also spammed with dozens of identical debug messages when that happens:
`Error waiting for TCP waiting for SSH`
...

See also discussion in #1255.

Signed-off-by: Jan Broer <janeczku@yahoo.de>