### PR TITLE
refactor: Extracting a base Driver struct

### DIFF
--- a/commands/inspect_test.go
+++ b/commands/inspect_test.go
@@ -29,7 +29,21 @@ func TestCmdInspectFormat(t *testing.T) {
 	assert.Equal(t, "\"none\"", actual)
 
 	actual, _ = runInspectCommand(t, []string{"--format", "{{prettyjson .Driver}}", "test-a"})
-	assert.Equal(t, "{\n    \"IPAddress\": \"\",\n    \"URL\": \"unix:///var/run/docker.sock\"\n}", actual)
+	type ExpectedDriver struct {
+		CaCertPath     string
+		IPAddress      string
+		MachineName    string
+		PrivateKeyPath string
+		SSHPort        int
+		SSHUser        string
+		SwarmDiscovery string
+		SwarmHost      string
+		SwarmMaster    bool
+		URL            string
+	}
+	expected, err := json.MarshalIndent(&ExpectedDriver{MachineName: "test-a", URL: "unix:///var/run/docker.sock"}, "", "    ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(expected), actual)
 }
 
 func runInspectCommand(t *testing.T, args []string) (string, *libmachine.Host) {

--- a/docs/DRIVER_SPEC.md
+++ b/docs/DRIVER_SPEC.md
@@ -38,7 +38,7 @@ level maintenance.
 
 ## Maintainer
 To be supported as an official driver, it will need to be maintained.  There
-can be multiple driver maintainers and they will be identified in the 
+can be multiple driver maintainers and they will be identified in the
 maintainers file.
 
 # Provider Operations
@@ -102,21 +102,12 @@ operations such as `Create`, `Remove`, `Start`, `Stop` etc.
 
 For details see the [Driver Interface](https://github.com/docker/machine/blob/master/drivers/drivers.go#L24).
 
-To provide this functionality, most drivers use a struct similar to the following:
+To provide this functionality, you should embed the `drivers.BaseDriver` struct, similar to the following:
 
 ```
 type Driver struct {
-    MachineName       string
-    IPAddress         string
-    SSHUser           string
-    SSHPort           int
-    CaCertPath        string
-    PrivateKeyPath    string
-    DriverKeyPath     string
-    SwarmMaster       bool
-    SwarmHost         string
-    SwarmDiscovery    string
-    storePath         string
+    *drivers.BaseDriver
+    DriverSpecificField string
 }
 ```
 
@@ -142,7 +133,7 @@ func GetCreateFlags() []cli.Flag {
             EnvVar: "DRIVERNAME_TOKEN",
             Name:   "drivername-token",
             Usage:  "Provider access token",
-        
+
         },
         cli.StringFlag{
             EnvVar: "DRIVERNAME_IMAGE",

--- a/drivers/base.go
+++ b/drivers/base.go
@@ -1,0 +1,76 @@
+package drivers
+
+import "path/filepath"
+
+// BaseDriver - Embed this struct into drivers to provide the common set
+// of fields and functions.
+type BaseDriver struct {
+	storePath      string
+	IPAddress      string
+	SSHUser        string
+	SSHPort        int
+	MachineName    string
+	CaCertPath     string
+	PrivateKeyPath string
+	SwarmMaster    bool
+	SwarmHost      string
+	SwarmDiscovery string
+}
+
+// NewBaseDriver - Get an instance of a BaseDriver
+func NewBaseDriver(machineName string, storePath string, caCert string, privateKey string) *BaseDriver {
+	return &BaseDriver{
+		MachineName:    machineName,
+		storePath:      storePath,
+		CaCertPath:     caCert,
+		PrivateKeyPath: privateKey,
+	}
+}
+
+// GetSSHKeyPath -
+func (d *BaseDriver) GetSSHKeyPath() string {
+	return d.ResolveStorePath("id_rsa")
+}
+
+// ResolveStorePath -
+func (d *BaseDriver) ResolveStorePath(path string) string {
+	return filepath.Join(d.storePath, path)
+}
+
+// AuthorizePort -
+func (d *BaseDriver) AuthorizePort(ports []*Port) error {
+	return nil
+}
+
+// DeauthorizePort -
+func (d *BaseDriver) DeauthorizePort(ports []*Port) error {
+	return nil
+}
+
+// DriverName - This must be implemented in every driver
+func (d *BaseDriver) DriverName() string {
+	return "unknown"
+}
+
+// GetMachineName -
+func (d *BaseDriver) GetMachineName() string {
+	return d.MachineName
+}
+
+// GetSSHPort -
+func (d *BaseDriver) GetSSHPort() (int, error) {
+	if d.SSHPort == 0 {
+		d.SSHPort = 22
+	}
+
+	return d.SSHPort, nil
+}
+
+// GetSSHUsername -
+func (d *BaseDriver) GetSSHUsername() string {
+	if d.SSHUser == "" {
+		d.SSHUser = "root"
+	}
+
+	return d.SSHUser
+}

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -3,7 +3,6 @@ package digitalocean
 import (
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"time"
 
 	"code.google.com/p/goauth2/oauth"
@@ -16,27 +15,17 @@ import (
 )
 
 type Driver struct {
+	*drivers.BaseDriver
 	AccessToken       string
 	DropletID         int
 	DropletName       string
 	Image             string
-	MachineName       string
-	IPAddress         string
 	Region            string
 	SSHKeyID          int
-	SSHUser           string
-	SSHPort           int
 	Size              string
 	IPv6              bool
 	Backups           bool
 	PrivateNetworking bool
-	CaCertPath        string
-	PrivateKeyPath    string
-	DriverKeyPath     string
-	SwarmMaster       bool
-	SwarmHost         string
-	SwarmDiscovery    string
-	storePath         string
 }
 
 func init() {
@@ -92,43 +81,12 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	if d.SSHPort == 0 {
-		d.SSHPort = 22
-	}
-
-	return d.SSHPort, nil
-}
-
-func (d *Driver) GetSSHUsername() string {
-	if d.SSHUser == "" {
-		d.SSHUser = "root"
-	}
-
-	return d.SSHUser
 }
 
 func (d *Driver) DriverName() string {
@@ -229,7 +187,7 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) createSSHKey() (*godo.Key, error) {
-	if err := ssh.GenerateSSHKey(d.sshKeyPath()); err != nil {
+	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return nil, err
 	}
 
@@ -329,10 +287,6 @@ func (d *Driver) getClient() *godo.Client {
 	return godo.NewClient(t.Client())
 }
 
-func (d *Driver) sshKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
 func (d *Driver) publicSSHKeyPath() string {
-	return d.sshKeyPath() + ".pub"
+	return d.GetSSHKeyPath() + ".pub"
 }

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
@@ -18,6 +17,7 @@ import (
 )
 
 type Driver struct {
+	*drivers.BaseDriver
 	URL              string
 	ApiKey           string
 	ApiSecretKey     string
@@ -26,18 +26,9 @@ type Driver struct {
 	Image            string
 	SecurityGroup    string
 	AvailabilityZone string
-	MachineName      string
 	KeyPair          string
-	IPAddress        string
 	PublicKey        string
 	Id               string
-	CaCertPath       string
-	PrivateKeyPath   string
-	DriverKeyPath    string
-	SwarmMaster      bool
-	SwarmHost        string
-	SwarmDiscovery   string
-	storePath        string
 }
 
 func init() {
@@ -100,31 +91,12 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	return 22, nil
 }
 
 func (d *Driver) GetSSHUsername() string {

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -6,19 +6,12 @@ import (
 )
 
 type FakeDriver struct {
+	*drivers.BaseDriver
 	MockState state.State
 }
 
 func (d *FakeDriver) DriverName() string {
 	return "fakedriver"
-}
-
-func (d *FakeDriver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *FakeDriver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
 }
 
 func (d *FakeDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -40,7 +40,7 @@ const (
 
 // NewComputeUtil creates and initializes a ComputeUtil.
 func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
-	service, err := newGCEService(driver.storePath, driver.AuthTokenPath)
+	service, err := newGCEService(driver.ResolveStorePath("."), driver.AuthTokenPath)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/drivers"
@@ -13,23 +12,14 @@ import (
 
 // Driver is a struct compatible with the docker.hosts.drivers.Driver interface.
 type Driver struct {
-	IPAddress      string
-	MachineName    string
-	SSHUser        string
-	SSHPort        int
-	Zone           string
-	MachineType    string
-	DiskType       string
-	Scopes         string
-	DiskSize       int
-	AuthTokenPath  string
-	storePath      string
-	Project        string
-	CaCertPath     string
-	PrivateKeyPath string
-	SwarmMaster    bool
-	SwarmHost      string
-	SwarmDiscovery string
+	*drivers.BaseDriver
+	Zone          string
+	MachineType   string
+	DiskType      string
+	Scopes        string
+	DiskSize      int
+	AuthTokenPath string
+	Project       string
 }
 
 func init() {
@@ -94,40 +84,12 @@ func GetCreateFlags() []cli.Flag {
 
 // NewDriver creates a Driver with the specified storePath.
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{
-		MachineName:    machineName,
-		storePath:      storePath,
-		CaCertPath:     caCert,
-		PrivateKeyPath: privateKey,
-	}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	if d.SSHPort == 0 {
-		d.SSHPort = 22
-	}
-
-	return d.SSHPort, nil
 }
 
 func (d *Driver) GetSSHUsername() string {

--- a/drivers/none/none.go
+++ b/drivers/none/none.go
@@ -13,8 +13,8 @@ import (
 // connect to existing Docker hosts by specifying the URL of the host as
 // an option.
 type Driver struct {
-	IPAddress string
-	URL       string
+	*drivers.BaseDriver
+	URL string
 }
 
 func init() {
@@ -35,18 +35,11 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{inner, ""}, nil
 }
 
 func (d *Driver) Create() error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
 	return nil
 }
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -3,7 +3,6 @@ package openstack
 import (
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 )
 
 type Driver struct {
+	*drivers.BaseDriver
 	AuthUrl          string
 	Insecure         bool
 	DomainID         string
@@ -27,7 +27,6 @@ type Driver struct {
 	Region           string
 	AvailabilityZone string
 	EndpointType     string
-	MachineName      string
 	MachineId        string
 	FlavorName       string
 	FlavorId         string
@@ -39,15 +38,6 @@ type Driver struct {
 	SecurityGroups   []string
 	FloatingIpPool   string
 	FloatingIpPoolId string
-	SSHUser          string
-	SSHPort          int
-	IPAddress        string
-	CaCertPath       string
-	PrivateKeyPath   string
-	storePath        string
-	SwarmMaster      bool
-	SwarmHost        string
-	SwarmDiscovery   string
 	client           Client
 }
 
@@ -189,49 +179,12 @@ func NewDriver(machineName string, storePath string, caCert string, privateKey s
 }
 
 func NewDerivedDriver(machineName string, storePath string, client Client, caCert string, privateKey string) (*Driver, error) {
-	return &Driver{
-		MachineName:    machineName,
-		storePath:      storePath,
-		client:         client,
-		CaCertPath:     caCert,
-		PrivateKeyPath: privateKey,
-	}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner, client: client}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	if d.SSHPort == 0 {
-		d.SSHPort = 22
-	}
-
-	return d.SSHPort, nil
-}
-
-func (d *Driver) GetSSHUsername() string {
-	if d.SSHUser == "" {
-		d.SSHUser = "root"
-	}
-
-	return d.SSHUser
 }
 
 func (d *Driver) DriverName() string {

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"regexp"
 	"time"
 
@@ -20,20 +19,11 @@ const (
 )
 
 type Driver struct {
-	storePath      string
-	IPAddress      string
-	deviceConfig   *deviceConfig
-	Id             int
-	Client         *Client
-	SSHUser        string
-	SSHPort        int
-	MachineName    string
-	CaCertPath     string
-	PrivateKeyPath string
-	SSHKeyID       int
-	SwarmMaster    bool
-	SwarmHost      string
-	SwarmDiscovery string
+	*drivers.BaseDriver
+	deviceConfig *deviceConfig
+	Id           int
+	Client       *Client
+	SSHKeyID     int
 }
 
 type deviceConfig struct {
@@ -59,43 +49,12 @@ func init() {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	return &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	if d.SSHPort == 0 {
-		d.SSHPort = 22
-	}
-
-	return d.SSHPort, nil
-}
-
-func (d *Driver) GetSSHUsername() string {
-	if d.SSHUser == "" {
-		d.SSHUser = "root"
-	}
-
-	return d.SSHUser
 }
 
 func GetCreateFlags() []cli.Flag {

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -7,7 +7,6 @@ package vmwarevcloudair
 import (
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/vmware/govcloudair"
@@ -21,30 +20,21 @@ import (
 )
 
 type Driver struct {
-	IPAddress      string
-	UserName       string
-	UserPassword   string
-	ComputeID      string
-	VDCID          string
-	OrgVDCNet      string
-	EdgeGateway    string
-	PublicIP       string
-	Catalog        string
-	CatalogItem    string
-	MachineName    string
-	SSHUser        string
-	SSHPort        int
-	DockerPort     int
-	Provision      bool
-	CPUCount       int
-	MemorySize     int
-	CaCertPath     string
-	PrivateKeyPath string
-	SwarmMaster    bool
-	SwarmHost      string
-	SwarmDiscovery string
-	VAppID         string
-	storePath      string
+	*drivers.BaseDriver
+	UserName     string
+	UserPassword string
+	ComputeID    string
+	VDCID        string
+	OrgVDCNet    string
+	EdgeGateway  string
+	PublicIP     string
+	Catalog      string
+	CatalogItem  string
+	DockerPort   int
+	Provision    bool
+	CPUCount     int
+	MemorySize   int
+	VAppID       string
 }
 
 func init() {
@@ -141,44 +131,12 @@ func GetCreateFlags() []cli.Flag {
 }
 
 func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
-	driver := &Driver{MachineName: machineName, storePath: storePath, CaCertPath: caCert, PrivateKeyPath: privateKey}
-	return driver, nil
-}
-
-func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
-	return nil
-}
-
-func (d *Driver) GetMachineName() string {
-	return d.MachineName
+	inner := drivers.NewBaseDriver(machineName, storePath, caCert, privateKey)
+	return &Driver{BaseDriver: inner}, nil
 }
 
 func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
-}
-
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.storePath, "id_rsa")
-}
-
-func (d *Driver) GetSSHPort() (int, error) {
-	if d.SSHPort == 0 {
-		d.SSHPort = 22
-	}
-
-	return d.SSHPort, nil
-}
-
-func (d *Driver) GetSSHUsername() string {
-	if d.SSHUser == "" {
-		d.SSHUser = "root"
-	}
-
-	return d.SSHUser
 }
 
 // Driver interface implementation


### PR DESCRIPTION
This is mainly a de-duplication PR. I've extracted all of the common struct fields and put them into a new `DefaultDriver` struct.

There's been some mention of needing this before, for example in #1220 (and others).

I've tested this manually, but not extensively. There are a few other tweaks I want to make too, but I want to get feedback early to see if I'm on the right trail.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>