### PR TITLE
Amazon EC2 - Fixing how the Monitoring.Enabled field is set for spot requests

### DIFF
--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -248,9 +248,9 @@ func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone strin
 	v.Set("LaunchSpecification.NetworkInterface.0.SubnetId", subnetId)
 	v.Set("LaunchSpecification.NetworkInterface.0.AssociatePublicIpAddress", "1")
 	if monitoring {
-		v.Set("Monitoring.Enabled", "1")
+		v.Set("LaunchSpecification.Monitoring.Enabled", "1")
 	} else {
-		v.Set("Monitoring.Enabled", "0")
+		v.Set("LaunchSpecification.Monitoring.Enabled", "0")
 	}
 
 	if len(role) > 0 {


### PR DESCRIPTION
Fixing a bug I ran into earlier where I get this error when using the `--amazonec2-request-spot-instance` option:

```
Error creating machine: Error request spot instance: Problem with AWS API call: Non-200 API response: code=400 message=The parameter Monitoring is not recognized
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>