### PR TITLE
enable overrides for engine and swarm install

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -166,6 +166,12 @@ var sharedCreateFlags = []cli.Flag{
 		),
 		Value: "none",
 	},
+	cli.StringFlag{
+		Name:   "engine-install-url",
+		Usage:  "Custom URL to use for engine installation",
+		Value:  "https://get.docker.com",
+		EnvVar: "MACHINE_DOCKER_INSTALL_URL",
+	},
 	cli.StringSliceFlag{
 		Name:  "engine-opt",
 		Usage: "Specify arbitrary flags to include with the created engine in the form flag=value",
@@ -193,6 +199,12 @@ var sharedCreateFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:  "swarm",
 		Usage: "Configure Machine with Swarm",
+	},
+	cli.StringFlag{
+		Name:   "swarm-image",
+		Usage:  "Specify Docker image to use for Swarm",
+		Value:  "swarm:latest",
+		EnvVar: "MACHINE_SWARM_IMAGE",
 	},
 	cli.BoolFlag{
 		Name:  "swarm-master",

--- a/commands/create.go
+++ b/commands/create.go
@@ -75,9 +75,11 @@ func cmdCreate(c *cli.Context) {
 			RegistryMirror:   c.StringSlice("engine-registry-mirror"),
 			StorageDriver:    c.String("engine-storage-driver"),
 			TlsVerify:        true,
+			InstallURL:       c.String("engine-install-url"),
 		},
 		SwarmOptions: &swarm.SwarmOptions{
 			IsSwarm:        c.Bool("swarm"),
+			Image:          c.String("swarm-image"),
 			Master:         c.Bool("swarm-master"),
 			Discovery:      c.String("swarm-discovery"),
 			Address:        c.String("swarm-addr"),

--- a/libmachine/engine/engine.go
+++ b/libmachine/engine/engine.go
@@ -15,4 +15,5 @@ type EngineOptions struct {
 	TlsKey           string
 	TlsVerify        bool
 	RegistryMirror   []string
+	InstallURL       string
 }

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -188,10 +188,6 @@ func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.SwarmOpt
 		return err
 	}
 
-	if err := installDockerGeneric(provisioner); err != nil {
-		return err
-	}
-
 	ip, err := provisioner.GetDriver().GetIP()
 	if err != nil {
 		return err

--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -74,11 +74,11 @@ func configureSwarm(p Provisioner, swarmOptions swarm.SwarmOptions, authOptions 
 		Port:          port,
 		AuthOptions:   authOptions,
 		SwarmOptions:  swarmOptions,
-		SwarmImage:    swarm.DockerImage,
+		SwarmImage:    swarmOptions.Image,
 	}
 
 	// First things first, get the swarm image.
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo docker pull %s", swarm.DockerImage)); err != nil {
+	if _, err := p.SSHCommand(fmt.Sprintf("sudo docker pull %s", swarmOptions.Image)); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -128,7 +128,7 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	}
 
 	log.Debug("installing docker")
-	if err := installDockerGeneric(provisioner); err != nil {
+	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -113,7 +113,7 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 		}
 	}
 
-	if err := installDockerGeneric(provisioner); err != nil {
+	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -20,10 +20,10 @@ type DockerOptions struct {
 	EngineOptionsPath string
 }
 
-func installDockerGeneric(p Provisioner) error {
+func installDockerGeneric(p Provisioner, baseURL string) error {
 	// install docker - until cloudinit we use ubuntu everywhere so we
 	// just install it using the docker repos
-	if output, err := p.SSHCommand("if ! type docker; then curl -sSL https://get.docker.com | sh -; fi"); err != nil {
+	if output, err := p.SSHCommand(fmt.Sprintf("if ! type docker; then curl -sSL %s | sh -; fi", baseURL)); err != nil {
 		return fmt.Errorf("error installing docker: %s\n", output)
 	}
 

--- a/libmachine/swarm/swarm.go
+++ b/libmachine/swarm/swarm.go
@@ -1,7 +1,6 @@
 package swarm
 
 const (
-	DockerImage              = "swarm:latest"
 	DiscoveryServiceEndpoint = "https://discovery-stage.hub.docker.com/v1"
 )
 
@@ -11,6 +10,7 @@ type SwarmOptions struct {
 	Discovery      string
 	Master         bool
 	Host           string
+	Image          string
 	Strategy       string
 	Heartbeat      int
 	Overcommit     float64

--- a/libmachine/swarm/swarm_options.go
+++ b/libmachine/swarm/swarm_options.go
@@ -1,1 +1,0 @@
-package swarm


### PR DESCRIPTION
This adds the ability to override the Docker engine install URL and the Swarm image used during provisioning.  This makes it easy to test new versions.

For example:

`MACHINE_SWARM_IMAGE=swarm:0.3.0-rc1 docker-machine create ...`

or Engine:

`MACHINE_DOCKER_INSTALL_URL=https://test.docker.com docker-machine create ...`