### PR TITLE
docs: more info about supported base operating systems

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1596,26 +1596,22 @@ Environment variables and default values:
 | `--vmwarevsphere-compute-ip`      | `VSPHERE_COMPUTE_IP`      | -                        |
 
 ## Base Operating Systems
-The default base operating system for Machine is Boot2Docker on local providers
+The Machine provisioning system supports several base operating systems.
+The default base operating system is Boot2Docker on local providers
 (VirtualBox, Fusion, Hyper-V, etc) and the latest Ubuntu LTS supported
-by the cloud provider.  RedHat Enterprise Linux is also supported.  To use
-RHEL, you will need to select the image accordingly with the provider.  For
-example, in Amazon EC2, you could use a RedHat 7.1 AMI ("ami-12663b7a") as the
-`--amazonec2-ami` option which create an instance using RHEL 7.1 64-bit.
+by the cloud provider.
 
-## Release Notes
+| Operating System           | Version          | Notes                   |
+|----------------------------|------------------|-------------------------|
+| Boot2Docker                | 1.5+             | default for local       |
+| Ubuntu                     | 12.04+           | default for remote      |
+| Rancher                    | 0.3+             |                         |
+| Debian                     | 8.0+             | experimental            |
+| RedHat Enterprise Linux    | 7.0+             | experimental            |
+| CentOS                     | 7+               | experimental            |
+| Fedora                     | 21+              | experimental            |
 
-### Version 0.2.0 (April 16, 2015)
-
-For complete information on this release, see the [0.2.0 Milestone project page](https://github.com/docker/machine/wiki/0.2.0-Milestone-Project-Page).
-In addition to bug fixes and refinements, this release adds the following:
-
-* Updated and refactored Driver interface For details, see
-[PR #694](https://github.com/docker/machine/pull/694).
-
-* Initial creation of an internal API, so Machine can be used as a library. For
-details, see [PR #553](https://github.com/docker/machine/issues/553).
-
-* Improvements and isolation of provisioning functionality, so Machine can
-provision and configure the Docker Engine based on OS detection. For details,
-see [PR #553](https://github.com/docker/machine/issues/553).
+If you want to use a different base operating system on a remote provider,
+you will need to select the image accordingly for that provider.  For
+example, on DigitalOcean you would use the `--digitalocean-image` flag.
+For Amazon AWS, you would use the `--amazonec2-ami` flag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -359,9 +359,6 @@ custombox   *        none      Running   tcp://50.134.234.20:2376
 Docker Machine can also provision [Swarm](https://github.com/docker/swarm)
 clusters. This can be used with any driver and will be secured with TLS.
 
-> **Note**: This is an experimental feature so the subcommands and
-> options are likely to change in future versions.
-
 First, create a Swarm token.  Optionally, you can use another discovery service.
 See the Swarm docs for details.
 
@@ -1605,7 +1602,7 @@ by the cloud provider.
 |----------------------------|------------------|-------------------------|
 | Boot2Docker                | 1.5+             | default for local       |
 | Ubuntu                     | 12.04+           | default for remote      |
-| Rancher                    | 0.3+             |                         |
+| RancherOS                  | 0.3+             |                         |
 | Debian                     | 8.0+             | experimental            |
 | RedHat Enterprise Linux    | 7.0+             | experimental            |
 | CentOS                     | 7+               | experimental            |
@@ -1615,3 +1612,8 @@ If you want to use a different base operating system on a remote provider,
 you will need to select the image accordingly for that provider.  For
 example, on DigitalOcean you would use the `--digitalocean-image` flag.
 For Amazon AWS, you would use the `--amazonec2-ami` flag.
+
+> Note: if you change the base image for a provider you may also need to change
+the SSH user as well. For example, the default Red Hat AMI on EC2 expects the 
+SSH user to be ec2-user, so you would have to specify this with 
+`--amazonec2-ssh-user ec2-user`.


### PR DESCRIPTION
This documents the supported base OS versions supported by Machine.  It also removes the changelog from being embedded in the docs.

Added note about changing SSH user for provider image.

Closes #1237 

Refs #1204 