### PR TITLE
virtualbox: more flexibility with networking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1464,6 +1464,7 @@ Options:
  - `--virtualbox-disk-size`: Size of disk for the host in MB.
  - `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
  - `--virtualbox-import-boot2docker-vm`: The name of a Boot2Docker VM to import.
+ - `--virtualbox-hostonly-cidr`: The CIDR of the host only adapter.
 
 The `--virtualbox-boot2docker-url` flag takes a few different forms.  By
 default, if no value is specified for this flag, Machine will check locally for
@@ -1482,6 +1483,15 @@ file://$HOME/Downloads/rc.iso` to test out a release candidate ISO that you have
 downloaded already.  You could also just get an ISO straight from the Internet
 using the `http://` form.
 
+To customize the host only adapter, you can use the `--virtualbox-hostonly-cidr`
+flag.  This will specify the host IP and Machine will calculate the VirtualBox
+DHCP server address (a random IP on the subnet between `.1` and `.25`) so 
+it does not clash with the specified host IP.
+Machine will also specify the DHCP lower bound to `.100` and the upper bound
+to `.254`.  For example, a specified CIDR of `192.168.24.1/24` would have a
+DHCP server between `192.168.24.2-25`, a lower bound of `192.168.24.100` and 
+upper bound of `192.168.24.254`.
+
 Environment variables and default values:
 
 | CLI option                           | Environment variable         | Default                  |
@@ -1491,6 +1501,7 @@ Environment variables and default values:
 | `--virtualbox-disk-size`             | `VIRTUALBOX_DISK_SIZE`       | `20000`                  |
 | `--virtualbox-boot2docker-url`       | `VIRTUALBOX_BOOT2DOCKER_URL` | *Latest boot2docker url* |
 | `--virtualbox-import-boot2docker-vm` | -                            | `boot2docker-vm`         |
+| `--virtualbox-hostonly-cidr`         | `VIRTUALBOX_HOSTONLY_CIDR`   | `192.168.99.1/24`        |
 
 #### VMware Fusion
 Creates machines locally on [VMware Fusion](http://www.vmware.com/products/fusion). Requires VMware Fusion to be installed.

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -1,1 +1,31 @@
 package virtualbox
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetRandomIPinSubnet(t *testing.T) {
+	// test IP 1.2.3.4
+	testIP := net.IPv4(byte(1), byte(2), byte(3), byte(4))
+	newIP, err := getRandomIPinSubnet(testIP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if testIP.Equal(newIP) {
+		t.Fatalf("expected different IP (source %s); received %s", testIP.String(), newIP.String())
+	}
+
+	if newIP[0] != testIP[0] {
+		t.Fatalf("expected first octet of %d; received %d", testIP[0], newIP[0])
+	}
+
+	if newIP[1] != testIP[1] {
+		t.Fatalf("expected second octet of %d; received %d", testIP[1], newIP[1])
+	}
+
+	if newIP[2] != testIP[2] {
+		t.Fatalf("expected third octet of %d; received %d", testIP[2], newIP[2])
+	}
+}


### PR DESCRIPTION
This checks for the hostonly interface upon machine start and creates if needed.

This also adds the ability to specify the hostonly CIDR.

To customize the host only adapter, you can use the `--virtualbox-hostonly-cidr`
flag.  This will specify the host IP and Machine will calculate the VirtualBox
DHCP server address (a random IP on the subnet between `.1` and `.25`) so 
it does not clash with the specified host IP.
Machine will also specify the DHCP lower bound to `.100` and the upper bound
to `.254`.  For example, a specified CIDR of `192.168.24.1/24` would have a
DHCP server between `192.168.24.2-25`, a lower bound of `192.168.24.100` and 
upper bound of `192.168.24.254`.

Closes #1290
Closes #24