### PR TITLE
test: don't invoke docker-machine directly

### DIFF
--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -20,7 +20,7 @@ function quiet_run () {
 }
 
 function cleanup_machines() {
-    if [[ $(docker-machine ls -q | wc -l) -ne 0 ]]; then
+    if [[ $(machine ls -q | wc -l) -ne 0 ]]; then
         quiet_run machine stop $(machine ls -q)
         quiet_run machine rm $(machine ls -q)
     fi


### PR DESCRIPTION
Use `machine` helper for that.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>