### PR TITLE
libmachine: check state before returning GetURL() result

### DIFF
--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -146,7 +146,14 @@ func (h *Host) Upgrade() error {
 }
 
 func (h *Host) GetURL() (string, error) {
-	return h.Driver.GetURL()
+	s, err := h.Driver.GetState()
+	if err != nil {
+		return "", err
+	}
+	if s == state.Running {
+		return h.Driver.GetURL()
+	}
+	return "", nil
 }
 
 func (h *Host) ConfigureAuth() error {


### PR DESCRIPTION
The new integration tests check if `env` and `url` return an error when
the machine is stopped. Currently, only virtualbox driver checks
that. Most drivers can return an URL without a problem while the machine
is not running.

We delegate the task of checking if the machine is running to libmachine
instead. libmachine will check the state and if the machine is not
running will return an empty string and
`drivers.ErrHostIsNotRunning`. This is consistent with what is expected
in other parts of the code but may break some drivers.

Tested with the exoscale driver.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>