### PR TITLE
Add some helpers and patch ups to the integration tests

### DIFF
--- a/test/integration/core/regenerate-certs.bats
+++ b/test/integration/core/regenerate-certs.bats
@@ -15,8 +15,3 @@ load ${BASE_TEST_DIR}/helpers.bash
   run docker $(machine config $NAME) version
   [[ ${status} -eq 0 ]]
 }
-
-@test "cleanup" {
-  machine rm $NAME
-  [[ ${status} -eq 0 ]]
-}

--- a/test/integration/core/scp.bats
+++ b/test/integration/core/scp.bats
@@ -16,6 +16,9 @@ export SECOND_MACHINE="$NAME-2"
 }
 
 @test "$DRIVER: test machine scp command from host to remote" {
+  teardown () {
+    rm foo.txt
+  }
   echo A file created locally! >foo.txt
   machine scp foo.txt $NAME:/tmp/foo.txt
   [[ $(machine ssh $NAME cat /tmp/foo.txt) == "A file created locally!" ]]

--- a/test/integration/drivers/virtualbox/bad-create-iso.bats
+++ b/test/integration/drivers/virtualbox/bad-create-iso.bats
@@ -2,6 +2,8 @@
 
 load ${BASE_TEST_DIR}/helpers.bash
 
+force_env DRIVER virtualbox
+
 export BAD_URL="http://dev.null:9111/bad.iso"
 
 @test "$DRIVER: Should not allow machine creation with bad ISO" {

--- a/test/integration/drivers/virtualbox/certs-checksum.bats
+++ b/test/integration/drivers/virtualbox/certs-checksum.bats
@@ -2,22 +2,25 @@
 
 load ${BASE_TEST_DIR}/helpers.bash
 
+force_env DRIVER virtualbox
+
 @test "$DRIVER: create" {
   run machine create -d $DRIVER $NAME
 }
 
 @test "$DRIVER: verify that server cert checksum matches local checksum" {
+  # TODO: This test is tightly coupled to VirtualBox right now, but should be
+  # available for all providers ideally.
+  #
   # TODO: Does this test work OK on Linux? cc @ehazlett
+  #
   # Have to create this directory and file or else the OpenSSL checksum will barf.
   machine ssh $NAME -- sudo mkdir -p /usr/local/ssl
   machine ssh $NAME -- sudo touch /usr/local/ssl/openssl.cnf
+
   SERVER_CHECKSUM=$(machine ssh $NAME -- openssl dgst -sha256 /var/lib/boot2docker/ca.pem | awk '{ print $2 }')
   LOCAL_CHECKSUM=$(openssl dgst -sha256 $MACHINE_STORAGE_PATH/certs/ca.pem | awk '{ print $2 }')
   echo ${SERVER_CHECKSUM}
   echo ${LOCAL_CHECKSUM}
   [[ ${SERVER_CHECKSUM} == ${LOCAL_CHECKSUM} ]]
-}
-
-@test "cleanup" {
-  machine rm $NAME
 }

--- a/test/integration/drivers/virtualbox/custom-mem-disk.bats
+++ b/test/integration/drivers/virtualbox/custom-mem-disk.bats
@@ -2,6 +2,8 @@
 
 load ${BASE_TEST_DIR}/helpers.bash
 
+force_env DRIVER virtualbox
+
 # Default memsize is 1024MB and disksize is 20000MB
 # These values are defined in drivers/virtualbox/virtualbox.go
 export DEFAULT_MEMSIZE=1024

--- a/test/integration/drivers/virtualbox/pause-save-start.bats
+++ b/test/integration/drivers/virtualbox/pause-save-start.bats
@@ -2,6 +2,8 @@
 
 load ${BASE_TEST_DIR}/helpers.bash
 
+force_env DRIVER virtualbox
+
 @test "$DRIVER: create" {
   run machine create -d $DRIVER $NAME
   [ "$status" -eq 0  ]

--- a/test/integration/drivers/virtualbox/upgrade.bats
+++ b/test/integration/drivers/virtualbox/upgrade.bats
@@ -2,6 +2,8 @@
 
 load ${BASE_TEST_DIR}/helpers.bash
 
+force_env DRIVER virtualbox
+
 export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.4.1/boot2docker.iso"
 
 @test "$DRIVER: create for upgrade" {

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -1,10 +1,28 @@
 #!/bin/bash
 
 teardown() {
-  echo "$BATS_TEST_NAME
+    echo "$BATS_TEST_NAME
 ----------
 $output
 ----------
 
-" >> ${BATS_LOG}
+"   >> ${BATS_LOG}
+}
+
+function errecho () {
+    >&2 echo "$@"
+}
+
+function force_env () {
+    if [[ ${!1} != "$2" ]]; then
+        errecho "This test requires the $1 environment variable to be set to $2 in order to run properly."
+        exit 1
+    fi
+}
+
+function require_env () {
+    if [[ -z ${!1} ]]; then
+        errecho "This test requires the $1 environment variable to be set in order to run."
+        exit 1
+    fi
 }

--- a/test/integration/provision/os/rancheros.bats
+++ b/test/integration/provision/os/rancheros.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+force_env DRIVER virtualbox
+
+export RANCHEROS_VERSION="v0.3.1"
+export RANCHEROS_ISO="https://github.com/rancherio/os/releases/download/$RANCHEROS_VERSION/machine-rancheros.iso"
+
+@test "$DRIVER: create with RancherOS ISO" {
+  VIRTUALBOX_BOOT2DOCKER_URL="$RANCHEROS_ISO" run ${BASE_TEST_DIR}/run-bats.sh ${BASE_TEST_DIR}/core
+  echo ${output}
+  [ ${status} -eq 0 ]
+}

--- a/test/integration/provision/os/redhat.bats
+++ b/test/integration/provision/os/redhat.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+force_env DRIVER amazonec2
+
+require_env AWS_VPC_ID
+require_env AWS_ACCESS_KEY_ID
+require_env AWS_SECRET_ACCESS_KEY
+
+@test "$DRIVER: create using RedHat AMI" {
+  # Oh snap, recursive stuff!!
+  AWS_AMI=ami-12663b7a AWS_SSH_USER=ec2-user run ${BASE_TEST_DIR}/run-bats.sh ${BASE_TEST_DIR}/core
+  echo ${output}
+  [ ${status} -eq 0 ]
+}

--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -35,11 +35,13 @@ function run_bats() {
         # BATS returns non-zero to indicate the tests have failed, we shouldn't
         # neccesarily bail in this case, so that's the reason for the e toggle.
         set +e
+        echo "=> $bats_file"
         bats "$bats_file"
         if [[ $? -ne 0 ]]; then
             EXIT_STATUS=1
         fi
         set -e
+        echo
         cleanup_machines
     done
 }
@@ -71,7 +73,7 @@ if [ ! -e "$MACHINE_ROOT"/"$MACHINE_BIN_NAME" ]; then
 fi
 
 if [[ -z "$DRIVER" ]]; then
-    echo "The DRIVER environment variable must be set."
+    echo "You must specify the DRIVER environment variable."
     exit 1
 fi
 


### PR DESCRIPTION
cc @ehazlett @hairyhenderson 

This PR:

1. Cleans up some existing integration test issues
2. Introduces some new helpers to enforce test conditions
3. Adds experimental tests for RancherOS and RedHat
4. Displays test name in the wrapper script output - it was a kind of hard to follow before

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>