### PR TITLE
exoscale: ability to specify multiple security groups on instance creation

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -112,6 +112,10 @@ func (d DriverOptionsMock) String(key string) string {
 	return d.Data[key].(string)
 }
 
+func (d DriverOptionsMock) StringSlice(key string) []string {
+	return d.Data[key].([]string)
+}
+
 func (d DriverOptionsMock) Int(key string) int {
 	return d.Data[key].(int)
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1174,7 +1174,7 @@ Options:
  - `--exoscale-instance-profile`: Instance profile.
  - `--exoscale-disk-size`: Disk size for the host in GB.
  - `--exoscale-image`: exoscale disk size. (10, 50, 100, 200, 400)
- - `--exoscale-security-group`: Comma-separated list of security groups. Non-existent groups will be created.
+ - `--exoscale-security-group`: Security group. Non-existent groups will be created. Can be repeated.
  - `--exoscale-availability-zone`: exoscale availability zone.
 
 If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1174,7 +1174,7 @@ Options:
  - `--exoscale-instance-profile`: Instance profile.
  - `--exoscale-disk-size`: Disk size for the host in GB.
  - `--exoscale-image`: exoscale disk size. (10, 50, 100, 200, 400)
- - `--exoscale-security-group`: Security group. It will be created if it doesn't exist.
+ - `--exoscale-security-group`: Comma-separated list of security groups. Non-existent groups will be created.
  - `--exoscale-availability-zone`: exoscale availability zone.
 
 If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -35,6 +35,10 @@ func (d DriverOptionsMock) String(key string) string {
 	return d.Data[key].(string)
 }
 
+func (d DriverOptionsMock) StringSlice(key string) []string {
+	return d.Data[key].([]string)
+}
+
 func (d DriverOptionsMock) Int(key string) int {
 	return d.Data[key].(int)
 }

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -164,6 +164,7 @@ func GetDriverNames() []string {
 
 type DriverOptions interface {
 	String(key string) string
+	StringSlice(key string) []string
 	Int(key string) int
 	Bool(key string) bool
 }

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -84,10 +84,10 @@ func GetCreateFlags() []cli.Flag {
 			Value:  "ubuntu-14.04",
 			Usage:  "exoscale image template",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			EnvVar: "EXOSCALE_SECURITY_GROUP",
 			Name:   "exoscale-security-group",
-			Value:  "docker-machine",
+			Value:  &cli.StringSlice{},
 			Usage:  "exoscale security group",
 		},
 		cli.StringFlag{
@@ -142,8 +142,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.InstanceProfile = flags.String("exoscale-instance-profile")
 	d.DiskSize = flags.Int("exoscale-disk-size")
 	d.Image = flags.String("exoscale-image")
-	if flags.String("exoscale-security-group") != "" {
-		d.SecurityGroups = strings.Split(flags.String("exoscale-security-group"), ",")
+	d.SecurityGroups = flags.StringSlice("exoscale-security-group")
+	if len(d.SecurityGroups) == 0 {
+		d.SecurityGroups = []string{"docker-machine"}
 	}
 	d.AvailabilityZone = flags.String("exoscale-availability-zone")
 	d.SwarmMaster = flags.Bool("swarm-master")

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -24,7 +24,7 @@ type Driver struct {
 	InstanceProfile  string
 	DiskSize         int
 	Image            string
-	SecurityGroups   []string
+	SecurityGroup    string
 	AvailabilityZone string
 	MachineName      string
 	KeyPair          string
@@ -142,10 +142,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.InstanceProfile = flags.String("exoscale-instance-profile")
 	d.DiskSize = flags.Int("exoscale-disk-size")
 	d.Image = flags.String("exoscale-image")
-	d.SecurityGroups = flags.StringSlice("exoscale-security-group")
-	if len(d.SecurityGroups) == 0 {
-		d.SecurityGroups = []string{"docker-machine"}
+	securityGroups := flags.StringSlice("exoscale-security-group")
+	if len(securityGroups) == 0 {
+		securityGroups = []string{"docker-machine"}
 	}
+	d.SecurityGroup = strings.Join(securityGroups, ",")
 	d.AvailabilityZone = flags.String("exoscale-availability-zone")
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
@@ -287,8 +288,9 @@ func (d *Driver) Create() error {
 	log.Debugf("Profile %v = %s", d.InstanceProfile, profile)
 
 	// Security groups
-	sgs := make([]string, len(d.SecurityGroups))
-	for idx, group := range d.SecurityGroups {
+	securityGroups := strings.Split(d.SecurityGroup, ",")
+	sgs := make([]string, len(securityGroups))
+	for idx, group := range securityGroups {
 		sg, ok := topology.SecurityGroups[group]
 		if !ok {
 			log.Infof("Security group %v does not exist, create it",

--- a/drivers/softlayer/driver_test.go
+++ b/drivers/softlayer/driver_test.go
@@ -26,6 +26,13 @@ func (d DriverOptionsMock) String(key string) string {
 	return ""
 }
 
+func (d DriverOptionsMock) StringSlice(key string) []string {
+	if value, ok := d.Data[key]; ok {
+		return value.([]string)
+	}
+	return []string{}
+}
+
 func (d DriverOptionsMock) Int(key string) int {
 	if value, ok := d.Data[key]; ok {
 		return value.(int)

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -17,6 +17,10 @@ func (d DriverOptionsMock) String(key string) string {
 	return d.Data[key].(string)
 }
 
+func (d DriverOptionsMock) StringSlice(key string) []string {
+	return d.Data[key].([]string)
+}
+
 func (d DriverOptionsMock) Int(key string) int {
 	return d.Data[key].(int)
 }


### PR DESCRIPTION
Without this feature, when a user needs a specific security group (i.e
most of the time if they want to expose a service to Internet), they
need to copy the rules needed for Docker itself into each custom
group. With this feature, they can spawn new instances with
`--exoscale-security-group docker-machine,my-custom-group`.

Since the `Driver` struct has been modified (`SecurityGroup string` removed, `SecurityGroups []string` added), machine dies horribly if any exoscale machine has been spawned in the past. How should this be handled? We just ignore it for the moment?