### PR TITLE
Fixing Filestore.GetActive to handle the case where `--swarm` is used

### DIFF
--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -122,7 +122,9 @@ func (s Filestore) GetActive() (*Host, error) {
 	hostListItems := GetHostListItems(hosts)
 
 	for _, item := range hostListItems {
-		if dockerHost == item.URL {
+		// TODO: hard-coding the swarm port is a travesty...
+		deSwarmedHost := strings.Replace(dockerHost, ":3376", ":2376", 1)
+		if dockerHost == item.URL || deSwarmedHost == item.URL {
 			host, err := s.Get(item.Name)
 			if err != nil {
 				return nil, err

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -7,6 +7,8 @@ import (
 
 	_ "github.com/docker/machine/drivers/none"
 	"github.com/docker/machine/utils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type DriverOptionsMock struct {
@@ -193,42 +195,25 @@ func TestStoreGetSetActive(t *testing.T) {
 	defer cleanup()
 
 	store, err := getTestStore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	// No host set
 	host, err := store.GetActive()
-	if err == nil {
-		t.Fatal("Expected an error because there is no active host set")
-	}
-
-	if host != nil {
-		t.Fatalf("GetActive: Active host should not exist")
-	}
+	assert.Error(t, err, "Expected an error because there is no active host set")
+	assert.Nil(t, host, "GetActive: Active host should not exist")
 
 	host, err = getDefaultTestHost()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	// Set normal host
-	if err := store.Save(host); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, store.Save(host))
 
 	url, err := host.GetURL()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 
 	os.Setenv("DOCKER_HOST", url)
 
 	host, err = store.GetActive()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if host.Name != host.Name {
-		t.Fatalf("Active host is not 'test', got %s", host.Name)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, hostTestName, host.Name)
 }


### PR DESCRIPTION
Fixes #1311 and fixes #1136

Signed-off-by: Dave Henderson <dhenderson@gmail.com>