### PR TITLE
windows: error message if using powershell/cmd and none specified

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -652,14 +652,18 @@ func getCertPathInfo(c *cli.Context) libmachine.CertPathInfo {
 }
 
 func detectShell() (string, error) {
-	// attempt to get the SHELL env var
-	shell := filepath.Base(os.Getenv("SHELL"))
-	// none detected; check for windows env and not bash (i.e. msysgit, etc)
-	if runtime.GOOS == "windows" && shell == "" {
+	// check for windows env and not bash (i.e. msysgit, etc)
+	// the SHELL env var is not set for processes in msysgit; we check
+	// for TERM instead
+	if runtime.GOOS == "windows" && os.Getenv("TERM") != "cygwin" {
 		log.Printf("On Windows, please specify either 'cmd' or 'powershell' with the --shell flag.\n\n")
 		return "", ErrUnknownShell
 	}
 
+	// attempt to get the SHELL env var
+	shell := filepath.Base(os.Getenv("SHELL"))
+
+	log.Debugf("shell: %s", shell)
 	if shell == "" {
 		return "", ErrUnknownShell
 	}


### PR DESCRIPTION
This will error if using Windows and powershell/cmd and `--shell` is not specified.  The `SHELL` env var is not available to processes in msysgit.  In msysgit, the `TERM` environment variable is set to "cygwin" so this PR checks for that.  If it exists, it continues with the normal detection process.  If not set, it errors with a message asking the user to specify which shell they would like to use.

Fixes #1327 