### PR TITLE
Add check firewall message to WaitForDocker

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -123,6 +123,7 @@ func WaitForDocker(ip string, daemonPort int) error {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ip, daemonPort))
 		if err != nil {
 			log.Debugf("Daemon not responding yet: %s", err)
+			log.Debug("Could a firewall be blocking the docker port? Try 'machine ssh [machine]' to investigate if this message continues.")
 			return false
 		}
 		conn.Close()


### PR DESCRIPTION
If an image has a firewall in place, currently machine doesn't do
anything to open the docker port. It tries forever to connect to
the docker engine and repeats a message that it is still unable
to connect:

    "Daemon not responding yet: dial tcp 129.41.145.211:2376: connection timed out"

While machine comes up with a good strategy for handling the myriad
of provisioners' firewall packages, at least provide a hint about
what might be happening at this point in the machine create:

    "Daemon not responding yet: dial tcp 129.41.145.211:2376: connection timed out
    Could a firewall be blocking the docker port? Try 'machine ssh [machine]' to investigate if this message continues."

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>