### PR TITLE
vbox: fix vbox race with unregistervm

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -462,6 +462,8 @@ func (d *Driver) Remove() error {
 			return err
 		}
 	}
+	// vbox will not release it's lock immediately after the stop
+	time.Sleep(1 * time.Second)
 	return vbm("unregistervm", "--delete", d.MachineName)
 }
 


### PR DESCRIPTION
There is a random race with VirtualBox where it will not release its internal lock in time before we issue the `unregistervm` command.  This adds a sleep as a workaround.

I've been hitting this more and more lately.  I think we need it in for 0.3.