### PR TITLE
Fix defaulting to native SSH

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -73,10 +73,7 @@ func SetDefaultClient(clientType SSHClientType) {
 func NewClient(user string, host string, port int, auth *Auth) (Client, error) {
 	sshBinaryPath, err := exec.LookPath("ssh")
 	if err != nil {
-		if defaultClientType == External {
-			log.Fatal("Requested shellout SSH client type but no ssh binary available")
-		}
-		log.Debug("ssh binary not found, using native Go implementation")
+		log.Debug("SSH binary not found, using native Go implementation")
 		return NewNativeClient(user, host, port, auth)
 	}
 


### PR DESCRIPTION
cc @ehazlett 

I noticed in some of the KM Windows builds that when SSH is not around, it blows up instead of defaulting to the native SSH client.  That shouldn't happen, this fixes the issue.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>