### PR TITLE
Add more useful error message when possibly getting rate limited by Github

### DIFF
--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -83,7 +83,7 @@ func (b *B2dUtils) GetLatestBoot2DockerReleaseURL() (string, error) {
 		TagName string `json:"tag_name"`
 	}
 	if err := json.NewDecoder(rsp.Body).Decode(&t); err != nil {
-		return "", err
+		return "", fmt.Errorf("Error demarshaling the Github API response: %s\nYou may be getting rate limited by Github.", err)
 	}
 	if len(t) == 0 {
 		return "", fmt.Errorf("no releases found")


### PR DESCRIPTION
cc @ehazlett 

More feedback from KM - at one point they got an error message back which seems to be related to getting rate limited by Github (complaining about demarshaling not working).  This makes the source of the issue more clear.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>