### PR TITLE
Make some clean ups and fixes to the integration tests

### DIFF
--- a/test/integration/core/supported-engine-options.bats
+++ b/test/integration/core/supported-engine-options.bats
@@ -5,7 +5,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "$DRIVER: create with supported engine options" {
   run machine create -d $DRIVER \
     --engine-label spam=eggs \
-    --engine-storage-driver devicemapper \
+    --engine-storage-driver overlay \
     --engine-insecure-registry registry.myco.com \
     $NAME
   echo "$output"
@@ -19,15 +19,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: check for engine storage driver" {
   storage_driver_info=$(docker $(machine config $NAME) info | grep "Storage Driver")
-  [[ $storage_driver_info =~ "devicemapper" ]]
-}
-
-@test "$DRIVER: rm after supported engine option create" {
-  run machine rm $NAME
-  [ $status -eq 0 ]
-}
-
-@test "$DRIVER: machine should not exist" {
-  run machine inspect $NAME
-  [ "$status" -eq 1  ]
+  [[ $storage_driver_info =~ "overlay" ]]
 }

--- a/test/integration/core/swarm-options.bats
+++ b/test/integration/core/swarm-options.bats
@@ -25,12 +25,3 @@ export TOKEN=$(curl -sS -X POST "https://discovery-stage.hub.docker.com/v1/clust
     echo ${heartbeat_arg}
     [[ "$heartbeat_arg" == "--heartbeat=5" ]]
 }
-
-@test "clean up created nodes" {
-    run machine rm queenbee workerbee
-    [[ "$status" -eq 0 ]]
-}
-
-@test "remove dir" {
-    rm -rf $MACHINE_STORAGE_PATH
-}


### PR DESCRIPTION
cc @ehazlett 

b2d 1.7rc5 doesn't like the `devicemapper` storage driver, but gets along with overlay fine.

While I was at it, took out some extraneous removes that were blowing up the tests.

With these changes the whole suite of `core` integration tests passes for me on Virtualbox driver.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>