### PR TITLE
Added command for making the docker binary executable in the docs

### DIFF
--- a/docs/install-machine.md
+++ b/docs/install-machine.md
@@ -47,6 +47,7 @@ sure to install the Docker client as well, e.g.:
 
 ```
 $ curl -L https://get.docker.com/builds/Darwin/x86_64/docker-latest > /usr/local/bin/docker
+$ chmod +x /usr/local/bin/docker
 ```
 
 ### Windows


### PR DESCRIPTION
Just an easy catch:
I just followed your installation instructions and stumbled on the fact that the downloaded Docker client won't be executable the way it is posted.