### PR TITLE
Support cloud-init in OpenStack driver

### DIFF
--- a/docs/drivers/openstack.md
+++ b/docs/drivers/openstack.md
@@ -38,6 +38,7 @@ Options:
  - `--openstack-ssh-user`: The username to use for SSH into the machine. If not provided `root` will be used.
  - `--openstack-ssh-port`: Customize the SSH port if the SSH server on the machine does not listen on the default port.
  - `--openstack-active-timeout`: The timeout in seconds until the OpenStack instance must be active.
+ - `--openstack-user-data`: The file path to the user data file for cloud-init system.
 
 Environment variables and default values:
 


### PR DESCRIPTION
It is very useful to do some configuration on the host. For instance, configure hostname, deploy additional SSH public keys, ... Everything supported by cloud-int.

