### PR TITLE
Fixes for on-premise EC2 endpoints

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -82,6 +82,8 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-spot-price":            "",
 			"amazonec2-private-address-only":  false,
 			"amazonec2-monitoring":            false,
+			"amazonec2-endpoint":              "",
+			"amazonec2-insecure-endpoint":     false,
 		},
 	}
 }


### PR DESCRIPTION
This pull request relates to this issue: #653
This is similar to https://github.com/docker/machine/pull/800 but instead of adding a certificate, added an option to skip certificate checking.
--amazonec2-endpoint=https://myregion.ec2api.mycompany.corp:443
--amazonec2-insecure-endpoint

Also environment variables are supported:
AWS_ENDPOINT=https://myregion.ec2api.mycompany.corp
AWS_INSECURE_ENDPOINT=true
