### PR TITLE
Additional validation on virtualbox-hostonly-cidr

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -620,6 +620,13 @@ func (d *Driver) setupHostOnlyNetwork(machineName string) error {
 
 	nAddr := network.IP.To4()
 
+	if ip.Equal(nAddr) {
+		err := errors.New("virtualbox-hostonly-cidr must be specified with a host address, not a network address")
+		if err != nil {
+			return err
+		}
+	}
+
 	dhcpAddr, err := getRandomIPinSubnet(network.IP)
 	if err != nil {
 		return err


### PR DESCRIPTION
Check that the CIDR provided for a virtualbox host only CIDR is specified as a host IP and netmask, e.g., 192.168.100.1/24, and not a network IP and netmask, e.g., 192.168.100.0/24. This will help prevent confusion like #1383

Signed-off-by: Chris Abernethy cabernet@chrisabernethy.com