### PR TITLE
Added homebrew cask support for VMware Fusion

### DIFF
--- a/drivers/vmwarefusion/vmrun_darwin.go
+++ b/drivers/vmwarefusion/vmrun_darwin.go
@@ -10,14 +10,26 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/machine/log"
 )
 
+var vmfusionapp string
+
+usr, _ := user.Current()
+usr_vmfusionapp := filepath.Join(usr.HomeDir, "Applications/VMware Fusion.app")
+if _, err := os.Stat(usr_vmfusionapp); err == nil {
+	vmfusionapp = usr_vmfusionapp
+} else {
+	vmfusionapp = "/Applications/VMware Fusion.app"
+}
+
 var (
-	vmrunbin    = "/Applications/VMware Fusion.app/Contents/Library/vmrun"
-	vdiskmanbin = "/Applications/VMware Fusion.app/Contents/Library/vmware-vdiskmanager"
+	vmrunbin    = filepath.Join(vmfusionapp, "Contents/Library/vmrun")
+	vdiskmanbin = filepath.Join(vmfusionapp, "Contents/Library/vmware-vdiskmanager")
 )
 
 var (


### PR DESCRIPTION
This pull request relates to #685 and attempts to add homebrew cask support for VMware Fusion users.

I had some difficulty in setting up a full test environment but have tested the code that was altered by simply using `go run` in a separate script.

This is my first dabble in Go, so I would love any feedback or critique if necessary.

Cheers
Fotis