### PR TITLE
Add Firewall Handling to Provisioners

### DIFF
--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/firewallaction"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
@@ -91,6 +92,10 @@ func (provisioner *Boot2DockerProvisioner) Package(name string, action pkgaction
 			return err
 		}
 	}
+	return nil
+}
+
+func (provisioner *Boot2DockerProvisioner) Firewall(action firewallaction.FirewallAction, port int) error {
 	return nil
 }
 

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/firewallaction"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
@@ -87,6 +88,10 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 		return err
 	}
 
+	return nil
+}
+
+func (provisioner *DebianProvisioner) Firewall(action firewallaction.FirewallAction, port int) error {
 	return nil
 }
 

--- a/libmachine/provision/firewallaction/action.go
+++ b/libmachine/provision/firewallaction/action.go
@@ -1,0 +1,13 @@
+package firewallaction
+
+type FirewallAction int
+
+const (
+	Enable FirewallAction = iota
+	Disable
+	Allow
+	Deny
+	Reload
+	Unload
+	Save
+)

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/firewallaction"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
@@ -26,6 +27,9 @@ type Provisioner interface {
 
 	// Run a package action e.g. install
 	Package(name string, action pkgaction.PackageAction) error
+
+	// Run a firewall action (e.g. allow, deny)
+	Firewall(action firewallaction.FirewallAction, port int) error
 
 	// Get Hostname
 	Hostname() (string, error)

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/firewallaction"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
@@ -82,6 +83,10 @@ func (provisioner *RancherProvisioner) Package(name string, action pkgaction.Pac
 		return err
 	}
 
+	return nil
+}
+
+func (provisioner *RancherProvisioner) Firewall(action firewallaction.FirewallAction, port int) error {
 	return nil
 }
 

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/firewallaction"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/log"
@@ -133,6 +134,10 @@ func (provisioner *RedHatProvisioner) Package(name string, action pkgaction.Pack
 		return err
 	}
 
+	return nil
+}
+
+func (provisioner *RedHatProvisioner) Firewall(action firewallaction.FirewallAction, port int) error {
 	return nil
 }
 


### PR DESCRIPTION
If, for example, a cloud image has a strict firewall in place,
machine will not complete provisioning because it will not be
able to communicate with the Docker port (2376).

This patch adds a few firewallaction package, which is modeled
after the packageaction package. It also includes the Unbuntu
provisioner logic.

The decision to use different logic for each provisioner was
made after realizing that manipulating iptables would have to
be done slightly differently for each provisioner (since they
store their rules in different files) -- so there would already
have to be some provisioner awareness. Additionally, using the
provisioners' firewall manipulation packages (ufw, firewall-cmd,
etc.) will provide the extra benefit of persisting rules across
reboots more easily.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>