### PR TITLE
Rackspace/Openstack - Add/enhance --*-net-* create switches.

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -33,8 +33,8 @@ type Driver struct {
 	ImageName        string
 	ImageId          string
 	KeyPairName      string
-	NetworkName      string
-	NetworkId        string
+	NetworkNames     []string
+	NetworkIds       []string
 	SecurityGroups   []string
 	FloatingIpPool   string
 	FloatingIpPoolId string
@@ -136,12 +136,12 @@ func GetCreateFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "openstack-net-id",
-			Usage: "OpenStack network id the machine will be connected on",
+			Usage: "OpenStack comma separated network ids the machine will be connected on",
 			Value: "",
 		},
 		cli.StringFlag{
 			Name:  "openstack-net-name",
-			Usage: "OpenStack network name the machine will be connected on",
+			Usage: "OpenStack comma separated network names the machine will be connected on",
 			Value: "",
 		},
 		cli.StringFlag{
@@ -151,7 +151,7 @@ func GetCreateFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "openstack-floatingip-pool",
-			Usage: "OpenStack floating IP pool to get an IP from to assign to the instance",
+			Usage: "OpenStack floating IP pool to get an IP from to assign to the instance (first network only)",
 			Value: "",
 		},
 		cli.StringFlag{
@@ -207,8 +207,12 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.FlavorName = flags.String("openstack-flavor-name")
 	d.ImageId = flags.String("openstack-image-id")
 	d.ImageName = flags.String("openstack-image-name")
-	d.NetworkId = flags.String("openstack-net-id")
-	d.NetworkName = flags.String("openstack-net-name")
+	if flags.String("openstack-net-id") != "" {
+		d.NetworkIds = strings.Split(flags.String("openstack-net-id"), ",")
+	}
+	if flags.String("openstack-net-name") != "" {
+		d.NetworkNames = strings.Split(flags.String("openstack-net-name"), ",")
+	}
 	if flags.String("openstack-sec-groups") != "" {
 		d.SecurityGroups = strings.Split(flags.String("openstack-sec-groups"), ",")
 	}
@@ -421,8 +425,8 @@ func (d *Driver) checkConfig() error {
 		return fmt.Errorf(errorExclusiveOptions, "Image name", "Image id")
 	}
 
-	if d.NetworkName != "" && d.NetworkId != "" {
-		return fmt.Errorf(errorExclusiveOptions, "Network name", "Network id")
+	if len(d.NetworkNames) > 0 && len(d.NetworkIds) > 0 {
+		return fmt.Errorf(errorExclusiveOptions, "Network names", "Network ids")
 	}
 	if d.EndpointType != "" && (d.EndpointType != "publicURL" && d.EndpointType != "adminURL" && d.EndpointType != "internalURL") {
 		return fmt.Errorf(errorWrongEndpointType)
@@ -431,26 +435,28 @@ func (d *Driver) checkConfig() error {
 }
 
 func (d *Driver) resolveIds() error {
-	if d.NetworkName != "" {
+	if len(d.NetworkNames) > 0 {
 		if err := d.initNetwork(); err != nil {
 			return err
 		}
 
-		networkId, err := d.client.GetNetworkId(d)
+		networkIds, err := d.client.GetNetworkIds(d)
 
 		if err != nil {
 			return err
 		}
 
-		if networkId == "" {
-			return fmt.Errorf(errorUnknownNetworkName, d.NetworkName)
+		if len(networkIds) == 0 {
+			return fmt.Errorf(errorUnknownNetworkName, strings.Join(d.NetworkNames, ",")) // TODO specific name
 		}
 
-		d.NetworkId = networkId
-		log.WithFields(log.Fields{
-			"Name": d.NetworkName,
-			"ID":   d.NetworkId,
-		}).Debug("Found network id using its name")
+		d.NetworkIds = networkIds
+		for i, networkName := range d.NetworkNames {
+			log.WithFields(log.Fields{
+				"Name": networkName,
+				"ID":   d.NetworkIds[i],
+			}).Debug("Found network id using its name")
+		}
 	}
 
 	if d.FlavorName != "" {

--- a/drivers/rackspace/client.go
+++ b/drivers/rackspace/client.go
@@ -54,6 +54,44 @@ func (c *Client) Authenticate(d *openstack.Driver) error {
 	return nil
 }
 
+func (c *Client) InitNetworkClient(d *openstack.Driver) error {
+	if c.Network != nil {
+		return nil
+	}
+
+	network, err := rackspace.NewNetworkV2(c.Provider, gophercloud.EndpointOpts{
+		Region: d.Region,
+	})
+	if err != nil {
+		return err
+	}
+	c.Network = network
+	return nil
+}
+
+func (c *Client) GetNetworkIds(d *openstack.Driver) ([]string, error) {
+	networkIds := make([]string, len(d.NetworkNames))
+	for i, networkName := range d.NetworkNames {
+		id, err := c.GetNetworkId(d, networkName)
+		if err != nil {
+			return nil, err
+		}
+		networkIds[i] = id
+	}
+	return networkIds, nil
+}
+
+func (c *Client) GetNetworkId(d *openstack.Driver, networkName string) (string, error) {
+	switch networkName {
+	case "public", "PublicNet":
+		return "00000000-0000-0000-0000-000000000000", nil
+	case "private", "ServiceNet":
+		return "11111111-1111-1111-1111-111111111111", nil
+	default:
+		return c.GenericClient.GetNetworkId(d, networkName)
+	}
+}
+
 // StartInstance is unfortunately not supported on Rackspace at this time.
 func (c *Client) StartInstance(d *openstack.Driver) error {
 	return unsupportedOpErr("start")

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -2,6 +2,7 @@ package rackspace
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/drivers"
@@ -60,6 +61,16 @@ func GetCreateFlags() []cli.Flag {
 			Usage:  "Rackspace flavor ID. Default: General Purpose 1GB",
 			Value:  "general1-1",
 			EnvVar: "OS_FLAVOR_ID",
+		},
+		cli.StringFlag{
+			Name:  "rackspace-net-id",
+			Usage: "Rackspace comma separated network ids the machine will be connected on",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "rackspace-net-name",
+			Usage: "Rackspace comma separated network names the machine will be connected on (eg, PublicNet,ServiceNet,MyNet)",
+			Value: "",
 		},
 		cli.StringFlag{
 			Name:  "rackspace-ssh-user",
@@ -121,6 +132,12 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.EndpointType = flags.String("rackspace-endpoint-type")
 	d.ImageId = flags.String("rackspace-image-id")
 	d.FlavorId = flags.String("rackspace-flavor-id")
+	if flags.String("rackspace-net-id") != "" {
+		d.NetworkIds = strings.Split(flags.String("rackspace-net-id"), ",")
+	}
+	if flags.String("rackspace-net-name") != "" {
+		d.NetworkNames = strings.Split(flags.String("rackspace-net-name"), ",")
+	}
 	d.SSHUser = flags.String("rackspace-ssh-user")
 	d.SSHPort = flags.Int("rackspace-ssh-port")
 	d.SwarmMaster = flags.Bool("swarm-master")


### PR DESCRIPTION
This PR addresses #1440 and #1444.

I'm having trouble with the version of gophercloud. When using `--rackspace-net-name`, I get an error with a url that has `.../v2.0/v2.0/...` which looks to be fixed in the latest gophercloud. When I try to run godep update, I get "not know version control system" on many other packages. Suggestions? @hairyhenderson suggested that it might be a conflict with docker/docker dependencies.

Other than that, `--rackspace-net-id`, `--openstack-net-id` and `openstack-net-name` all work with multiple comma separated networks.