### PR TITLE
Amazon Ec2 - Add the option amazonec2-use-private-address

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -69,6 +69,7 @@ type Driver struct {
 	RequestSpotInstance bool
 	SpotPrice           string
 	PrivateIPOnly       bool
+	UsePrivateIP		bool
 	Monitoring          bool
 }
 
@@ -171,6 +172,10 @@ func GetCreateFlags() []cli.Flag {
 			Usage: "Only use a private IP address",
 		},
 		cli.BoolFlag{
+        			Name:  "amazonec2-use-private-address",
+        			Usage: "Force the usage of private IP address",
+        		},
+		cli.BoolFlag{
 			Name:  "amazonec2-monitoring",
 			Usage: "Set this flag to enable CloudWatch monitoring",
 		},
@@ -228,6 +233,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = flags.String("amazonec2-ssh-user")
 	d.SSHPort = 22
 	d.PrivateIPOnly = flags.Bool("amazonec2-private-address-only")
+	d.UsePrivateIP = flags.Bool("amazonec2-use-private-address")
 	d.Monitoring = flags.Bool("amazonec2-monitoring")
 
 	if d.AccessKey == "" {
@@ -438,6 +444,10 @@ func (d *Driver) GetIP() (string, error) {
 	if d.PrivateIPOnly {
 		return inst.PrivateIpAddress, nil
 	}
+
+	if d.UsePrivateIP {
+    	return inst.PrivateIpAddress, nil
+    }
 
 	return inst.IpAddress, nil
 }

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -81,6 +81,7 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-request-spot-instance": false,
 			"amazonec2-spot-price":            "",
 			"amazonec2-private-address-only":  false,
+			"amazonec2-use-private-address":  false,
 			"amazonec2-monitoring":            false,
 		},
 	}


### PR DESCRIPTION
Fixes #1442 

Adding the option --amazonec2-use-private-address to force the usage of private IP address instead of the public one. Specially useful at cases like described in #1442.
