### PR TITLE
Swapped disk/memory env variables for fusion.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1539,8 +1539,8 @@ Environment variables and default values:
 |----------------------------------|--------------------------|--------------------------|
 | `--vmwarefusion-boot2docker-url` | `FUSION_BOOT2DOCKER_URL` | *Latest boot2docker url* |
 | `--vmwarefusion-cpu-count`       | `FUSION_CPU_COUNT`       | `1`                      |
-| `--vmwarefusion-disk-size`       | `FUSION_MEMORY_SIZE`     | `20000`                  |
-| `--vmwarefusion-memory-size`     | `FUSION_DISK_SIZE`       | `1024`                   |
+| `--vmwarefusion-disk-size`       | `FUSION_DISK_SIZE`     | `20000`                  |
+| `--vmwarefusion-memory-size`     | `FUSION_MEMORY_SIZE`       | `1024`                   |
 
 #### VMware vCloud Air
 Creates machines on [vCloud Air](http://vcloud.vmware.com) subscription service. You need an account within an existing subscription of vCloud Air VPC or Dedicated Cloud.


### PR DESCRIPTION
Environment variables `FUSION_MEMORY_SIZE` and `FUSION_DISK_SIZE` was swapped.