### PR TITLE
Add RESPONSE time column to ls output

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -46,7 +46,7 @@ func cmdLs(c *cli.Context) {
 	swarmInfo := make(map[string]string)
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
-	fmt.Fprintln(w, "NAME\tACTIVE\tDRIVER\tSTATE\tURL\tSWARM")
+	fmt.Fprintln(w, "NAME\tACTIVE\tDRIVER\tSTATE\tURL\tSWARM\tRESPONSE")
 
 	for _, host := range hostList {
 		swarmOptions := host.HostOptions.SwarmOptions
@@ -77,8 +77,9 @@ func cmdLs(c *cli.Context) {
 				swarmInfo = fmt.Sprintf("%s (master)", swarmInfo)
 			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			item.Name, activeString, item.DriverName, item.State, item.URL, swarmInfo)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			item.Name, activeString, item.DriverName, item.State, item.URL, swarmInfo, item.ApiResponseTime)
 	}
 
 	w.Flush()


### PR DESCRIPTION
If `docker-machine ls` lags, I like to know which call took the longest to respond so I can know which machines are problematic.

This adds support for a "RESPONSE" column which shows how long each goroutine took.

I'm not sure if this is the exact form it should take, but I definitely want some functionality like this somewhere, even if we have to move it into a `--extra` option for `ls` or something.

WDYT @ehazlett @sthulb @hairyhenderson @clnperez ??

![image](https://cloud.githubusercontent.com/assets/1476820/8535067/4d7e90f6-23f7-11e5-9a13-66fe9db8ac41.png)


Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>