### PR TITLE
improve cmd shell support

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -169,7 +169,7 @@ func cmdEnv(c *cli.Context) {
 		shellCfg.Suffix = "\"\n"
 		shellCfg.Delimiter = " = \""
 	case "cmd":
-		shellCfg.Prefix = "set "
+		shellCfg.Prefix = "SET "
 		shellCfg.Suffix = "\n"
 		shellCfg.Delimiter = "="
 	default:
@@ -203,8 +203,8 @@ func generateUsageHint(appName, machineName, userShell string) string {
 	case "powershell":
 		cmd = fmt.Sprintf("%s env --shell=powershell%s | Invoke-Expression", appName, machineNameOrEmpty)
 	case "cmd":
-		cmd = fmt.Sprintf("for /f \"tokens=*\" %%i in ('%s env --shell=cmd%s') do %%i", appName, machineNameOrEmpty)
-		comment = "rem"
+		cmd = fmt.Sprintf("\tFOR /f \"tokens=*\" %%i IN ('%s env --shell=cmd%s') DO %%i", appName, machineNameOrEmpty)
+		comment = "REM"
 	default:
 		cmd = fmt.Sprintf("eval \"$(%s env%s)\"", appName, machineNameOrEmpty)
 	}

--- a/commands/env.go
+++ b/commands/env.go
@@ -190,28 +190,24 @@ func cmdEnv(c *cli.Context) {
 
 func generateUsageHint(appName, machineName, userShell string) string {
 	cmd := ""
-	switch userShell {
-	case "fish":
-		if machineName != "" {
-			cmd = fmt.Sprintf("eval (%s env %s)", appName, machineName)
-		} else {
-			cmd = fmt.Sprintf("eval (%s env)", appName)
-		}
-	case "powershell":
-		if machineName != "" {
-			cmd = fmt.Sprintf("%s env --shell=powershell %s | Invoke-Expression", appName, machineName)
-		} else {
-			cmd = fmt.Sprintf("%s env --shell=powershell | Invoke-Expression", appName)
-		}
-	case "cmd":
-		cmd = "copy and paste the above values into your command prompt"
-	default:
-		if machineName != "" {
-			cmd = fmt.Sprintf("eval \"$(%s env %s)\"", appName, machineName)
-		} else {
-			cmd = fmt.Sprintf("eval \"$(%s env)\"", appName)
-		}
+	comment := "#"
+	machineNameOrEmpty := ""
+
+	if machineName != "" {
+		machineNameOrEmpty = " " + machineName
 	}
 
-	return fmt.Sprintf("# Run this command to configure your shell: \n# %s\n", cmd)
+	switch userShell {
+	case "fish":
+		cmd = fmt.Sprintf("eval (%s env%s)", appName, machineNameOrEmpty)
+	case "powershell":
+		cmd = fmt.Sprintf("%s env --shell=powershell%s | Invoke-Expression", appName, machineNameOrEmpty)
+	case "cmd":
+		cmd = fmt.Sprintf("for /f \"tokens=*\" %%i in ('%s env --shell=cmd%s') do %%i", appName, machineNameOrEmpty)
+		comment = "rem"
+	default:
+		cmd = fmt.Sprintf("eval \"$(%s env%s)\"", appName, machineNameOrEmpty)
+	}
+
+	return fmt.Sprintf("%s Run this command to configure your shell: \n%s %s\n", comment, comment, cmd)
 }


### PR DESCRIPTION
After writing down a proposal in #1033 to improve the cmd.exe shell support of docker-machine I have added it to the sourcecode.

With this change the user has a command how to set the environments in the current shell.

```cmd
C:\> docker-machine.exe env --shell=cmd dev
set DOCKER_TLS_VERIFY=1
set DOCKER_HOST=tcp://192.168.1.123:2376
set DOCKER_CERT_PATH=/Users/stefan/.docker/machine/machines/dev
set DOCKER_MACHINE_NAME=dev
rem Run this command to configure your shell: 
rem for /f "tokens=*" %i in ('docker-machine_darwin-amd64 env --shell=cmd dev') do %i
```

I also have cleaned up the code a little bit to reduce the if-else blocks to a minimum.

Signed-off-by: Stefan Scherer <scherer_stefan@icloud.com>