### PR TITLE
Remove synthcpu flag for Virtualbox 5 support

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -242,7 +242,6 @@ func (d *Driver) Create() error {
 		"--natdnsproxy1", "off",
 		"--cpuhotplug", "off",
 		"--pae", "on",
-		"--synthcpu", "off",
 		"--hpet", "on",
 		"--hwvirtex", "on",
 		"--nestedpaging", "on",


### PR DESCRIPTION
Closes https://github.com/docker/machine/issues/1387

cc @ehazlett 

This option is no longer supported in Virtualbox 5 and creates will fail as long as it is specified.

@SvenDowideit @tianon Do you know if this will affect the experience for users of older versions of VirtualBox (<5)?  Given the nature of the flag (it is meant to help preserve transfer of saved-state VMs across platforms), I'm somewhat surprised that we have to turn it off by default anyway.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>