### PR TITLE
[debian] Make enabling docker service work

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -172,6 +172,9 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target
 `
 	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
 	if err != nil {


### PR DESCRIPTION
Fixes #1495
/etc/systemd/system/docker.service was missing the [Install] section
making the enable action fail with:

```
root@jessie:~# systemctl enable docker
Synchronizing state for docker.service with sysvinit using
update-rc.d...
Executing /usr/sbin/update-rc.d docker defaults
Executing /usr/sbin/update-rc.d docker enable
The unit files have no [Install] section. They are not meant to be
enabled
using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another
unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which
has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path,
timer,
   D-Bus, udev, scripted systemctl call, ...).
```

Signed-off-by: Emmanuel Bretelle <chantr4@gmail.com>