### PR TITLE
Add status command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -380,6 +380,12 @@ var Commands = []cli.Command{
 		Action:      cmdStart,
 	},
 	{
+		Name:        "status",
+		Usage:       "Get the status of a machine",
+		Description: "Argument is a machine name.",
+		Action:      cmdStatus,
+	},
+	{
 		Name:        "stop",
 		Usage:       "Stop a machine",
 		Description: "Argument(s) are one or more machine names.",

--- a/commands/status.go
+++ b/commands/status.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/machine/log"
+
+	"github.com/codegangsta/cli"
+)
+
+func cmdStatus(c *cli.Context) {
+	host := getHost(c)
+	currentState, err := host.Driver.GetState()
+	if err != nil {
+		log.Errorf("error getting state for host %s: %s", host.Name, err)
+	}
+	fmt.Println(currentState)
+}

--- a/commands/status.go
+++ b/commands/status.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/docker/machine/log"
 
 	"github.com/codegangsta/cli"
@@ -14,5 +12,5 @@ func cmdStatus(c *cli.Context) {
 	if err != nil {
 		log.Errorf("error getting state for host %s: %s", host.Name, err)
 	}
-	fmt.Println(currentState)
+	log.Info(currentState)
 }

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -1,0 +1,1 @@
+package commands

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -27,6 +27,7 @@ parent="smn_machine_ref"
 * [scp](scp.md)
 * [ssh](ssh.md)
 * [start](start.md)
+* [status](status.md)
 * [stop](stop.md)
 * [upgrade](upgrade.md)
 * [url](url.md)

--- a/docs/reference/status.md
+++ b/docs/reference/status.md
@@ -1,0 +1,18 @@
+<!--[metadata]>
++++
+title = "status"
+description = "Get the status of a machine"
+keywords = ["machine, status, subcommand"]
+[menu.main]
+parent="smn_machine_subcmds"
++++
+<![end-metadata]-->
+
+# status
+
+Get the status of a machine.
+
+```
+$ docker-machine status dev
+Running
+```

--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -104,3 +104,9 @@ load ${BASE_TEST_DIR}/helpers.bash
   [ "$status" -eq 0  ]
   [[ ${lines[1]} == *"Running"*  ]]
 }
+
+@test "$DRIVER: status" {
+  run machine status $NAME
+  [ "$status" -eq 0 ]
+  [[ ${output} == *"Running"* ]]
+}


### PR DESCRIPTION
closes #1471 by adding the status command that prints the state of a
machine.

Signed-off-by: Sergio Botero <sergiobuj@gmail.com>