### PR TITLE
Add support for building Docker Machine binaries remotely (without bind mount)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ run:
 
 If you have any questions we're in #docker-machine on Freenode.
 
+## Remote Build
+
+You can use Machine to build Machine:
+
+    $ GOOS=darwin GOARCH=amd64 make remote
+
+The difference is this works even if you don't have local docker daemon, but
+instead a docker host that you [set up using Machine](https://github.com/docker/machine).
+
 ## Unit Tests
 
 To run the unit tests for the whole project, using the following script:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 default: build
 
+remote: build-remote
+
 test:
 	script/test
 
@@ -15,6 +17,9 @@ validate: validate-dco validate-gofmt test
 
 build: clean
 	script/build
+
+build-remote: clean
+	script/build-remote
 
 clean:
 	rm -f docker-machine_*

--- a/script/build-remote
+++ b/script/build-remote
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+BUILD_IMAGE_NAME="docker-machine-build"
+GOOS=${GOOS:-"darwin linux windows"}
+GOARCH=${GOARCH:-"386 amd64 arm"}
+
+docker build -t ${BUILD_IMAGE_NAME} .
+
+BUILD_CONTAINER=$(docker run -d \
+    ${BUILD_IMAGE_NAME} \
+    gox \
+    -os "$GOOS" \
+    -arch "$GOARCH" \
+    -output="docker-machine_{{.OS}}-{{.Arch}}" \
+    -ldflags="-w -X github.com/docker/machine/version.GitCommit `git rev-parse --short HEAD`")
+cleanup_container() {
+    docker rm -v ${BUILD_CONTAINER}
+}
+trap cleanup_container EXIT
+
+docker logs -f ${BUILD_CONTAINER} &
+BUILD_STATUS=$(docker wait ${BUILD_CONTAINER})
+if [[ ${BUILD_STATUS} != 0 ]]; then exit ${BUILD_STATUS}; fi
+
+BUILT_IMAGE=$(docker commit ${BUILD_CONTAINER})
+cleanup_image() {
+    cleanup_container
+    docker rmi ${BUILT_IMAGE}
+}
+trap cleanup_image EXIT
+
+echo "Copying built binaries:"
+for f in $(docker run --rm ${BUILT_IMAGE} sh -c 'echo docker-machine_*'); do
+    echo "  "${f}
+    docker cp ${BUILD_CONTAINER}:/go/src/github.com/docker/machine/${f} ./
+done
+echo Done


### PR DESCRIPTION
Build on docker-machine provisioned docker

i.e. in the cloud

Signed-off-by: Ivan Mikushin <i.mikushin@gmail.com>