### PR TITLE
Allow the default user of an EC2 Instance to be set at creation time.

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -166,9 +166,9 @@ func GetCreateFlags() []cli.Flag {
 			Usage: "Set this flag to enable CloudWatch monitoring",
 		},
 		cli.StringFlag{
-			Name:  "amazonec2-default-user",
-			Usage: "Set the name of the default user for the AMI",
-			Value: "",
+			Name:   "amazonec2-default-user",
+			Usage:  "Set the name of the default user for the AMI",
+			Value:  "",
 			EnvVar: "AWS_DEFAULT_USER",
 		},
 	}
@@ -229,7 +229,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	if d.SubnetId == "" && d.VpcId == "" {
 		return fmt.Errorf("amazonec2 driver requires either the --amazonec2-subnet-id or --amazonec2-vpc-id option")
 	}
-	
+
 	if d.isSwarmMaster() {
 		u, err := url.Parse(d.SwarmHost)
 		if err != nil {

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -168,6 +168,7 @@ func GetCreateFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  "amazonec2-default-user",
 			Usage: "Set the name of the default user for the AMI",
+			Value: "",
 			EnvVar: "AWS_DEFAULT_USER",
 		},
 	}

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -86,6 +86,7 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-spot-price":            "",
 			"amazonec2-private-address-only":  false,
 			"amazonec2-monitoring":            false,
+			"amazonec2-default-user":          "",
 		},
 	}
 }

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -97,6 +97,7 @@ type (
 			} `xml:"privateIpAddressesSet>item"`
 		} `xml:"networkInterfaceSet>item"`
 		EbsOptimized bool `xml:"ebsOptimized"`
+		UserData string `xml:"userData"`
 	}
 
 	RunInstancesResponse struct {
@@ -177,7 +178,7 @@ func (e *EC2) awsApiCall(v url.Values) (*http.Response, error) {
 	return resp, nil
 }
 
-func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, privateIPOnly bool, monitoring bool) (EC2Instance, error) {
+func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, privateIPOnly bool, monitoring bool, defaultUser string) (EC2Instance, error) {
 	instance := Instance{}
 	v := url.Values{}
 	v.Set("Action", "RunInstances")
@@ -217,6 +218,14 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 		v.Set("BlockDeviceMapping.0.Ebs.DeleteOnTermination", strconv.Itoa(deleteOnTerm))
 	}
 
+	if defaultUser != "" {
+		userData := "#cloud-config\n" +
+	                "  system_info:\n" +
+	                "    default_user:\n" +
+	                "      name: " + defaultUser + "\n"
+		v.Set("UserData", base64.StdEncoding.EncodeToString([]byte(userData)))
+	}
+
 	resp, err := e.awsApiCall(v)
 
 	if err != nil {
@@ -238,7 +247,7 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 	return instance.info, nil
 }
 
-func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone string, instanceCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, spotPrice string, monitoring bool) (string, error) {
+func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone string, instanceCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, spotPrice string, monitoring bool, defaultUser string) (string, error) {
 	v := url.Values{}
 	v.Set("Action", "RequestSpotInstances")
 	v.Set("LaunchSpecification.ImageId", amiId)
@@ -271,6 +280,14 @@ func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone strin
 			deleteOnTerm = 1
 		}
 		v.Set("LaunchSpecification.BlockDeviceMapping.0.Ebs.DeleteOnTermination", strconv.Itoa(deleteOnTerm))
+	}
+
+	if defaultUser != "" {
+		userData := "#cloud-config\n" +
+	                "  system_info:\n" +
+	                "    default_user:\n" +
+	                "      name: " + defaultUser + "\n"
+		v.Set("UserData", base64.StdEncoding.EncodeToString([]byte(userData)))
 	}
 
 	resp, err := e.awsApiCall(v)

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -96,8 +96,8 @@ type (
 				Primary          bool   `xml:"primary"`
 			} `xml:"privateIpAddressesSet>item"`
 		} `xml:"networkInterfaceSet>item"`
-		EbsOptimized bool `xml:"ebsOptimized"`
-		UserData string `xml:"userData"`
+		EbsOptimized bool   `xml:"ebsOptimized"`
+		UserData     string `xml:"userData"`
 	}
 
 	RunInstancesResponse struct {
@@ -220,9 +220,9 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 
 	if defaultUser != "" {
 		userData := "#cloud-config\n" +
-	                "  system_info:\n" +
-	                "    default_user:\n" +
-	                "      name: " + defaultUser + "\n"
+			"  system_info:\n" +
+			"    default_user:\n" +
+			"      name: " + defaultUser + "\n"
 		v.Set("UserData", base64.StdEncoding.EncodeToString([]byte(userData)))
 	}
 
@@ -284,9 +284,9 @@ func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone strin
 
 	if defaultUser != "" {
 		userData := "#cloud-config\n" +
-	                "  system_info:\n" +
-	                "    default_user:\n" +
-	                "      name: " + defaultUser + "\n"
+			"  system_info:\n" +
+			"    default_user:\n" +
+			"      name: " + defaultUser + "\n"
 		v.Set("UserData", base64.StdEncoding.EncodeToString([]byte(userData)))
 	}
 


### PR DESCRIPTION
This adds the ability for you to change the default user for an EC2 instance via UserData. Allows a user to change the the user to which the default SSH key gets installed to on the machine. 

Use Case: Some users, like myself, use custom AMIs that do not have the default user accounts like ubuntu and ec2-user, this PR allows docker-machine to utilize customer user accounts as the default user by providing a cloud config via UserData.