### PR TITLE
Gather driver flags from env for non-create calls

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -22,7 +22,7 @@ func cmdActive(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	provider, err := newProvider(defaultStore)
+	provider, err := newProvider(defaultStore, c, newGlobalFlagSpecifier(c))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -97,7 +97,7 @@ func getDefaultTestHost() (*libmachine.Host, error) {
 	}
 
 	flags := getTestDriverFlags()
-	if err := host.Driver.SetConfigFromFlags(flags); err != nil {
+	if err := host.SetDriverConfigFromFlags(flags); err != nil {
 		return nil, err
 	}
 
@@ -122,6 +122,11 @@ func (d DriverOptionsMock) Int(key string) int {
 
 func (d DriverOptionsMock) Bool(key string) bool {
 	return d.Data[key].(bool)
+}
+
+func (d DriverOptionsMock) IsSet(key string) bool {
+	_, ok := d.Data[key]
+	return ok
 }
 
 func TestRunActionForeachMachine(t *testing.T) {

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -34,12 +34,13 @@ func TestCmdConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := libmachine.New(store)
+	flags := getTestDriverFlags()
+
+	provider, err := libmachine.New(store, flags, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	flags := getTestDriverFlags()
 	hostOptions := &libmachine.HostOptions{
 		EngineOptions: &engine.EngineOptions{},
 		SwarmOptions: &swarm.SwarmOptions{
@@ -51,7 +52,7 @@ func TestCmdConfig(t *testing.T) {
 		AuthOptions: &auth.AuthOptions{},
 	}
 
-	host, err := provider.Create("test-a", "none", hostOptions, flags)
+	host, err := provider.Create("test-a", "none", hostOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commands/create.go
+++ b/commands/create.go
@@ -54,7 +54,7 @@ func cmdCreate(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	provider, err := newProvider(defaultStore)
+	provider, err := newProvider(defaultStore, c, newGlobalFlagSpecifier(c))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func cmdCreate(c *cli.Context) {
 		},
 	}
 
-	_, err = provider.Create(name, driver, hostOptions, c)
+	_, err = provider.Create(name, driver, hostOptions)
 	if err != nil {
 		log.Errorf("Error creating machine: %s", err)
 		log.Fatal("You will want to check the provider to make sure the machine and associated resources were properly removed.")

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -43,7 +43,7 @@ func TestCmdEnvBash(t *testing.T) {
 		t.Fatal(sErr)
 	}
 
-	provider, err := libmachine.New(store)
+	provider, err := libmachine.New(store, flags, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestCmdEnvBash(t *testing.T) {
 		AuthOptions: &auth.AuthOptions{},
 	}
 
-	host, err := provider.Create("test-a", "none", hostOptions, flags)
+	host, err := provider.Create("test-a", "none", hostOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestCmdEnvFish(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := libmachine.New(store)
+	provider, err := libmachine.New(store, flags, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestCmdEnvFish(t *testing.T) {
 		AuthOptions: &auth.AuthOptions{},
 	}
 
-	host, err := provider.Create("test-a", "none", hostOptions, flags)
+	host, err := provider.Create("test-a", "none", hostOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestCmdEnvPowerShell(t *testing.T) {
 		t.Fatal(sErr)
 	}
 
-	provider, err := libmachine.New(store)
+	provider, err := libmachine.New(store, flags, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestCmdEnvPowerShell(t *testing.T) {
 		AuthOptions: &auth.AuthOptions{},
 	}
 
-	host, err := provider.Create("test-a", "none", hostOptions, flags)
+	host, err := provider.Create("test-a", "none", hostOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commands/inspect_test.go
+++ b/commands/inspect_test.go
@@ -73,7 +73,9 @@ func runInspectCommand(t *testing.T, args []string) (string, *libmachine.Host) {
 		t.Fatal(sErr)
 	}
 
-	provider, err := libmachine.New(store)
+	flags := getTestDriverFlags()
+
+	provider, err := libmachine.New(store, flags, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,8 +91,7 @@ func runInspectCommand(t *testing.T, args []string) (string, *libmachine.Host) {
 		AuthOptions: &auth.AuthOptions{},
 	}
 
-	flags := getTestDriverFlags()
-	_, err = provider.Create("test-a", "none", hostOptions, flags)
+	_, err = provider.Create("test-a", "none", hostOptions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -25,7 +25,7 @@ func cmdRm(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	provider, err := newProvider(defaultStore)
+	provider, err := newProvider(defaultStore, c, newGlobalFlagSpecifier(c))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -118,10 +118,6 @@ func (s ScpFakeStore) Exists(name string) (bool, error) {
 	return true, nil
 }
 
-func (s ScpFakeStore) GetActive() (*libmachine.Host, error) {
-	return nil, nil
-}
-
 func (s ScpFakeStore) GetPath() string {
 	return ""
 }
@@ -157,7 +153,7 @@ func (s ScpFakeStore) Save(host *libmachine.Host) error {
 }
 
 func TestGetInfoForScpArg(t *testing.T) {
-	provider, _ := libmachine.New(ScpFakeStore{})
+	provider, _ := libmachine.New(ScpFakeStore{}, nil, nil)
 
 	expectedPath := "/tmp/foo"
 	host, path, opts, err := getInfoForScpArg("/tmp/foo", *provider)
@@ -224,7 +220,7 @@ func TestGenerateLocationArg(t *testing.T) {
 }
 
 func TestGetScpCmd(t *testing.T) {
-	provider, _ := libmachine.New(ScpFakeStore{})
+	provider, _ := libmachine.New(ScpFakeStore{}, nil, nil)
 
 	// TODO: This is a little "integration-ey".  Perhaps
 	// make an ScpDispatcher (name?) interface so that the reliant

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -29,7 +29,7 @@ func cmdSsh(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	provider, err := newProvider(defaultStore)
+	provider, err := newProvider(defaultStore, c, newGlobalFlagSpecifier(c))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -47,6 +47,11 @@ func (d DriverOptionsMock) Bool(key string) bool {
 	return d.Data[key].(bool)
 }
 
+func (d DriverOptionsMock) IsSet(key string) bool {
+	_, ok := d.Data[key]
+	return ok
+}
+
 func cleanup() error {
 	return os.RemoveAll(testStoreDir)
 }

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -167,6 +167,11 @@ type DriverOptions interface {
 	StringSlice(key string) []string
 	Int(key string) int
 	Bool(key string) bool
+	IsSet(key string) bool
+}
+
+type OptionsSpecifier interface {
+	SpecifyFlags(driver string, driverOptions DriverOptions) (DriverOptions, error)
 }
 
 func MachineInState(d Driver, desiredState state.State) func() bool {

--- a/drivers/softlayer/driver_test.go
+++ b/drivers/softlayer/driver_test.go
@@ -47,6 +47,11 @@ func (d DriverOptionsMock) Bool(key string) bool {
 	return false
 }
 
+func (d DriverOptionsMock) IsSet(key string) bool {
+	_, ok := d.Data[key]
+	return ok
+}
+
 func cleanup() error {
 	return os.RemoveAll(testStoreDir)
 }

--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -2,7 +2,6 @@ package libmachine
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -110,26 +109,4 @@ func (s Filestore) Exists(name string) (bool, error) {
 
 func (s Filestore) Get(name string) (*Host, error) {
 	return s.loadHost(name)
-}
-
-func (s Filestore) GetActive() (*Host, error) {
-	hosts, err := s.List()
-	if err != nil {
-		return nil, err
-	}
-
-	dockerHost := os.Getenv("DOCKER_HOST")
-	hostListItems := GetHostListItems(hosts)
-
-	for _, item := range hostListItems {
-		if dockerHost == item.URL {
-			host, err := s.Get(item.Name)
-			if err != nil {
-				return nil, err
-			}
-			return host, nil
-		}
-	}
-
-	return nil, errors.New("Active host not found")
 }

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -29,6 +29,11 @@ func (d DriverOptionsMock) Bool(key string) bool {
 	return d.Data[key].(bool)
 }
 
+func (d DriverOptionsMock) IsSet(key string) bool {
+	_, ok := d.Data[key]
+	return ok
+}
+
 func TestStoreSave(t *testing.T) {
 	defer cleanup()
 
@@ -167,7 +172,7 @@ func TestStoreLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := host.Driver.SetConfigFromFlags(flags); err != nil {
+	if err := host.SetDriverConfigFromFlags(flags); err != nil {
 		t.Fatal(err)
 	}
 
@@ -186,49 +191,5 @@ func TestStoreLoad(t *testing.T) {
 
 	if actualURL != expectedURL {
 		t.Fatalf("GetURL is not %q, got %q", expectedURL, actualURL)
-	}
-}
-
-func TestStoreGetSetActive(t *testing.T) {
-	defer cleanup()
-
-	store, err := getTestStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// No host set
-	host, err := store.GetActive()
-	if err == nil {
-		t.Fatal("Expected an error because there is no active host set")
-	}
-
-	if host != nil {
-		t.Fatalf("GetActive: Active host should not exist")
-	}
-
-	host, err = getDefaultTestHost()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set normal host
-	if err := store.Save(host); err != nil {
-		t.Fatal(err)
-	}
-
-	url, err := host.GetURL()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	os.Setenv("DOCKER_HOST", url)
-
-	host, err = store.GetActive()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if host.Name != host.Name {
-		t.Fatalf("Active host is not 'test', got %s", host.Name)
 	}
 }

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -290,6 +290,7 @@ func (h *Host) LoadConfig() error {
 	}
 
 	h.Driver = driver
+	h.DriverName = driver.DriverName()
 
 	// Second pass: unmarshal driver config into correct driver
 	if err := json.Unmarshal(data, &h); err != nil {
@@ -330,6 +331,27 @@ func (h *Host) SaveConfig() error {
 	if err := ioutil.WriteFile(filepath.Join(h.StorePath, "config.json"), data, 0600); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (h *Host) SetDriverConfigFromFlags(driverConfig drivers.DriverOptions) error {
+	if driverConfig != nil {
+		return h.Driver.SetConfigFromFlags(driverConfig)
+	}
+	return nil
+}
+
+func (h *Host) Prepare() error {
+	if err := h.Driver.PreCreateCheck(); err != nil {
+		return err
+	}
+
+	hostPath := filepath.Join(utils.GetMachineDir(), h.Name)
+
+	if err := os.MkdirAll(hostPath, 0700); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/libmachine/host_test.go
+++ b/libmachine/host_test.go
@@ -89,7 +89,7 @@ func getDefaultTestHost() (*Host, error) {
 	}
 
 	flags := getTestDriverFlags()
-	if err := host.Driver.SetConfigFromFlags(flags); err != nil {
+	if err := host.SetDriverConfigFromFlags(flags); err != nil {
 		return nil, err
 	}
 

--- a/libmachine/provider_test.go
+++ b/libmachine/provider_test.go
@@ -1,1 +1,57 @@
 package libmachine
+
+import (
+	"os"
+	"testing"
+)
+
+func getCustomTestProvider(store Store) (*Provider, error) {
+	flags := getTestDriverFlags()
+	return New(store, flags, nil)
+}
+
+func TestProviderGetSetActive(t *testing.T) {
+	defer cleanup()
+
+	store, err := getTestStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider, err := getCustomTestProvider(store)
+
+	// No host set
+	host, err := provider.GetActive()
+	if err == nil {
+		t.Fatal("Expected an error because there is no active host set")
+	}
+
+	if host != nil {
+		t.Fatalf("GetActive: Active host should not exist")
+	}
+
+	host, err = getDefaultTestHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set normal host
+	if err := store.Save(host); err != nil {
+		t.Fatal(err)
+	}
+
+	url, err := host.GetURL()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv("DOCKER_HOST", url)
+
+	active, err := provider.GetActive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active.Name != host.Name {
+		t.Fatalf("Active host is not '%s', got '%s'", active.Name, host.Name)
+	}
+}

--- a/libmachine/store.go
+++ b/libmachine/store.go
@@ -3,8 +3,6 @@ package libmachine
 type Store interface {
 	// Exists returns whether a machine exists or not
 	Exists(name string) (bool, error)
-	// GetActive returns the active host
-	GetActive() (*Host, error)
 	// GetPath returns the path to the store
 	GetPath() string
 	// GetCACertPath returns the CA certificate


### PR DESCRIPTION
This permits passing driver flags (especially for authentication) required by the libmachine/host that may not otherwise be available because flags are strictly enforced at the subcommand level.

Addresses #1511