### PR TITLE
vmwarefusion: force aggressive time synchronization

### DIFF
--- a/drivers/vmwarefusion/vmx_darwin.go
+++ b/drivers/vmwarefusion/vmx_darwin.go
@@ -63,4 +63,6 @@ uuid.action = "create"
 numvcpus = "{{.CPU}}"
 hgfs.mapRootShare = "FALSE"
 hgfs.linkRootShare = "FALSE"
+tools.syncTime = "TRUE"
+tools.syncTime.period = 1
 `


### PR DESCRIPTION
VMWare Fusion's shared folders rely heavily on the time to be kept in sync between the host and guest.
The drift can be significant enough so that shared folders become out of sync.

This ensure that vmware-tools keep the guest time in sync with the host every second.