### PR TITLE
Fix apt-get error on conf file conflict

### DIFF
--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -111,7 +111,7 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 		}
 	}
 
-	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y -o Dpkg::Options::=\"--force-confnew\" %s", packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 


### PR DESCRIPTION
During provisioning, if there exists a `docker.conf`, you're prompted to perform an action regardless of the noninteractive and `-y` flags.

I've added a flag which forces the prompt to use the old config which, in the case of provisioning a new machine, should prove completely sufficient as it's likely another package being installed that dropped the config in the first place.

Here's a bunch of noise:

```
Selecting previously unselected package liberror-perl.
(Reading database ... 158291 files and directories currently installed.)
Preparing to unpack .../liberror-perl_0.17-1.1_all.deb ...
Unpacking liberror-perl (0.17-1.1) ...
Selecting previously unselected package git-man.
Preparing to unpack .../git-man_1%3a1.9.1-1ubuntu0.1_all.deb ...
Unpacking git-man (1:1.9.1-1ubuntu0.1) ...
Selecting previously unselected package git.
Preparing to unpack .../git_1%3a1.9.1-1ubuntu0.1_amd64.deb ...
Unpacking git (1:1.9.1-1ubuntu0.1) ...
Selecting previously unselected package cgroup-lite.
Preparing to unpack .../cgroup-lite_1.9_all.deb ...
Unpacking cgroup-lite (1.9) ...
Selecting previously unselected package lxc-docker-1.7.1.
Preparing to unpack .../lxc-docker-1.7.1_1.7.1_amd64.deb ...
Unpacking lxc-docker-1.7.1 (1.7.1) ...
Selecting previously unselected package lxc-docker.
Preparing to unpack .../lxc-docker_1.7.1_amd64.deb ...
Unpacking lxc-docker (1.7.1) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Processing triggers for ureadahead (0.100.0-16) ...
Setting up liberror-perl (0.17-1.1) ...
Setting up git-man (1:1.9.1-1ubuntu0.1) ...
Setting up git (1:1.9.1-1ubuntu0.1) ...
Setting up cgroup-lite (1.9) ...
cgroup-lite start/running
Setting up lxc-docker-1.7.1 (1.7.1) ...

Configuration file '/etc/init/docker.conf'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** docker.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package lxc-docker-1.7.1 (--configure):
 EOF on stdin at conffile prompt
dpkg: dependency problems prevent configuration of lxc-docker:
 lxc-docker depends on lxc-docker-1.7.1; however:
  Package lxc-docker-1.7.1 is not configured yet.

dpkg: error processing package lxc-docker (--configure):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 lxc-docker-1.7.1
 lxc-docker
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
