### PR TITLE
SSH password issue

### DIFF
--- a/drivers/base.go
+++ b/drivers/base.go
@@ -1,6 +1,9 @@
 package drivers
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"fmt"
+)
 
 // BaseDriver - Embed this struct into drivers to provide the common set
 // of fields and functions.
@@ -8,6 +11,7 @@ type BaseDriver struct {
 	storePath      string
 	IPAddress      string
 	SSHUser        string
+	SSHPass        string
 	SSHPort        int
 	MachineName    string
 	CaCertPath     string
@@ -73,4 +77,27 @@ func (d *BaseDriver) GetSSHUsername() string {
 	}
 
 	return d.SSHUser
+}
+
+// GetSSHPassword -
+func (d *BaseDriver) GetSSHPassword() string {
+	return d.SSHPass
+}
+
+// SSHSudo -
+func (d *BaseDriver) SSHSudo(command string) string {
+	sudo := "sudo"
+	// If there is a password given pipe it to sudo to avoid no tty error
+	if d.SSHPass != "" {
+		sudo = fmt.Sprintf(
+			"echo %q | sudo -S",
+			d.SSHPass,
+		)
+	}
+	command = fmt.Sprintf(
+		"%s %s",
+		sudo,
+		command,
+	);
+	return command
 }

--- a/drivers/base.go
+++ b/drivers/base.go
@@ -90,7 +90,7 @@ func (d *BaseDriver) SSHSudo(command string) string {
 	// If there is a password given pipe it to sudo to avoid no tty error
 	if d.SSHPass != "" {
 		sudo = fmt.Sprintf(
-			"echo %q | sudo -S",
+			"echo %q | sudo -SE",
 			d.SSHPass,
 		)
 	}

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -50,6 +50,12 @@ type Driver interface {
 	// GetSSHUsername returns username for use with ssh
 	GetSSHUsername() string
 
+	// GetSSHPassword returns password for use with ssh
+	GetSSHPassword() string
+
+	// SSHSudo formats command to be run with sudo
+	SSHSudo(string) string
+
 	// GetURL returns a Docker compatible host URL for connecting to this host
 	// e.g. tcp://1.2.3.4:2376
 	GetURL() (string, error)

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -159,7 +159,9 @@ func (d *Driver) Remove() error {
 func (d *Driver) Restart() error {
 	log.Debug("Restarting...")
 
-	if _, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -r now"); err != nil {
+	command := "shutdown -r now"
+	command = d.SSHSudo(command)
+	if _, err := drivers.RunSSHCommandFromDriver(d, command); err != nil {
 		return err
 	}
 
@@ -169,7 +171,9 @@ func (d *Driver) Restart() error {
 func (d *Driver) Kill() error {
 	log.Debug("Killing...")
 
-	if _, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -P now"); err != nil {
+	command := "shutdown -P now"
+	command = d.SSHSudo(command)
+	if _, err := drivers.RunSSHCommandFromDriver(d, command); err != nil {
 		return err
 	}
 

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -45,6 +45,11 @@ func GetCreateFlags() []cli.Flag {
 			Value: "root",
 		},
 		cli.StringFlag{
+			Name:  "generic-ssh-pass",
+			Usage: "SSH password for user, used for sudo",
+			Value: "",
+		},
+		cli.StringFlag{
 			Name:  "generic-ssh-key",
 			Usage: "SSH private key path",
 			Value: filepath.Join(utils.GetHomeDir(), ".ssh", "id_rsa"),
@@ -77,6 +82,7 @@ func (d *Driver) GetSSHUsername() string {
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.IPAddress = flags.String("generic-ip-address")
 	d.SSHUser = flags.String("generic-ssh-user")
+	d.SSHPass = flags.String("generic-ssh-pass")
 	d.SSHKey = flags.String("generic-ssh-key")
 	d.SSHPort = flags.Int("generic-ssh-port")
 

--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -79,7 +79,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.SwarmOptions, authOptions 
 
 	// First things first, get the swarm image.
 	pull_command := "docker pull %s"
-	pull_command = p.Driver.SSHSudo(pull_command)
+	pull_command = p.GetDriver().SSHSudo(pull_command)
 	if _, err := p.SSHCommand(fmt.Sprintf(
 		pull_command,
 		swarmOptions.Image,
@@ -101,7 +101,7 @@ manage \
 -H {{.SwarmOptions.Host}} \
 --strategy {{.SwarmOptions.Strategy}} {{range .SwarmOptions.ArbitraryFlags}} --{{.}}{{end}} {{.SwarmOptions.Discovery}}
 `
-	swarmMasterCmdTemplate = p.Driver.SSHSudo(swarmMasterCmdTemplate)
+	swarmMasterCmdTemplate = p.GetDriver().SSHSudo(swarmMasterCmdTemplate)
 
 	swarmWorkerCmdTemplate := `docker run -d \
 --restart=always \
@@ -109,7 +109,7 @@ manage \
 {{.SwarmImage}} \
 join --advertise {{.Ip}}:{{.DockerPort}} {{.SwarmOptions.Discovery}}
 `
-	swarmWorkerCmdTemplate = p.Driver.SSHSudo(swarmWorkerCmdTemplate)
+	swarmWorkerCmdTemplate = p.GetDriver().SSHSudo(swarmWorkerCmdTemplate)
 
 	if swarmOptions.Master {
 		log.Debug("Launching swarm master")

--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -78,11 +78,16 @@ func configureSwarm(p Provisioner, swarmOptions swarm.SwarmOptions, authOptions 
 	}
 
 	// First things first, get the swarm image.
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo docker pull %s", swarmOptions.Image)); err != nil {
+	pull_command := "docker pull %s"
+	pull_command = p.Driver.SSHSudo(pull_command)
+	if _, err := p.SSHCommand(fmt.Sprintf(
+		pull_command,
+		swarmOptions.Image,
+	)); err != nil {
 		return err
 	}
 
-	swarmMasterCmdTemplate := `sudo docker run -d \
+	swarmMasterCmdTemplate := `docker run -d \
 --restart=always \
 --name swarm-agent-master \
 -p {{.Port}}:{{.Port}} \
@@ -96,13 +101,15 @@ manage \
 -H {{.SwarmOptions.Host}} \
 --strategy {{.SwarmOptions.Strategy}} {{range .SwarmOptions.ArbitraryFlags}} --{{.}}{{end}} {{.SwarmOptions.Discovery}}
 `
+	swarmMasterCmdTemplate = p.Driver.SSHSudo(swarmMasterCmdTemplate)
 
-	swarmWorkerCmdTemplate := `sudo docker run -d \
+	swarmWorkerCmdTemplate := `docker run -d \
 --restart=always \
 --name swarm-agent \
 {{.SwarmImage}} \
 join --advertise {{.Ip}}:{{.DockerPort}} {{.SwarmOptions.Discovery}}
 `
+	swarmWorkerCmdTemplate = p.Driver.SSHSudo(swarmWorkerCmdTemplate)
 
 	if swarmOptions.Master {
 		log.Debug("Launching swarm master")

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -40,11 +40,13 @@ type DebianProvisioner struct {
 
 func (provisioner *DebianProvisioner) Service(name string, action pkgaction.ServiceAction) error {
 	// daemon-reload to catch config updates; systemd -- ugh
-	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
+	systemctl_reload := provisioner.Driver.SSHSudo("systemctl daemon-reload")
+	if _, err := provisioner.SSHCommand(systemctl_reload); err != nil {
 		return err
 	}
 
-	command := fmt.Sprintf("sudo systemctl %s %s", action.String(), name)
+	systemctl_command := provisioner.Driver.SSHSudo("systemctl %s %s")
+	command := fmt.Sprintf(systemctl_command, action.String(), name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err
@@ -74,12 +76,14 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+		apt_update := provisioner.Driver.SSHSudo("apt-get update")
+		if _, err := provisioner.SSHCommand(apt_update); err != nil {
 			return err
 		}
 	}
 
-	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+	apt_action := provisioner.Driver.SSHSudo("sh -c \"DEBIAN_FRONTEND=noninteractive && apt-get %s -y %s\"")
+	command := fmt.Sprintf(apt_action, packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 
@@ -91,7 +95,8 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 }
 
 func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	docker_version := provisioner.Driver.SSHSudo("docker version")
+	if _, err := provisioner.SSHCommand(docker_version); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
 		return false
 	}

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -28,8 +28,10 @@ func (provisioner *GenericProvisioner) Hostname() (string, error) {
 }
 
 func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
+	command := "sh -c 'hostname %s && echo %q | tee /etc/hostname'"
+	command = provisioner.Driver.SSHSudo(command)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {
@@ -37,8 +39,17 @@ func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
 	}
 
 	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if_then := "sh -c \"sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts\""
+	if_else := "sh -c \"echo '127.0.1.1 %s' | tee -a /etc/hosts\""
+	if_then = provisioner.Driver.SSHSudo(if_then)
+	if_else = provisioner.Driver.SSHSudo(if_else)
+	command = fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then %s; else %s; fi",
+		if_then,
+		if_else,
+	)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -127,12 +127,14 @@ func (provisioner *RedHatProvisioner) Service(name string, action pkgaction.Serv
 	// be sure exactly when it changes from the provisioner so
 	// we call a reload on every restart to be safe
 	if reloadDaemon {
-		if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
+		reload_command := provisioner.Driver.SSHSudo("systemctl daemon-reload")
+		if _, err := provisioner.SSHCommand(reload_command); err != nil {
 			return err
 		}
 	}
 
-	command := fmt.Sprintf("sudo systemctl %s %s", action.String(), name)
+	systemctl_command := provisioner.Driver.SSHSudo("systemctl %s %s")
+	command := fmt.Sprintf(systemctl_command, action.String(), name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err
@@ -153,7 +155,8 @@ func (provisioner *RedHatProvisioner) Package(name string, action pkgaction.Pack
 		packageAction = "upgrade"
 	}
 
-	command := fmt.Sprintf("sudo -E yum %s -y %s", packageAction, name)
+	yum_command := provisioner.Driver.SSHSudo("yum %s -y %s")
+	command := fmt.Sprintf(yum_command, packageAction, name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err
@@ -185,7 +188,8 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 		return err
 	}
 
-	if _, err := provisioner.SSHCommand("sudo yum install -y docker-engine"); err != nil {
+	engine_install_command := provisioner.Driver.SSHSudo("yum install -y docker-engine")
+	if _, err := provisioner.SSHCommand(engine_install_command); err != nil {
 		return err
 	}
 
@@ -193,7 +197,8 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 }
 
 func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	docker_version_command := provisioner.Driver.SSHSudo("docker version")
+	if _, err := provisioner.SSHCommand(docker_version_command); err != nil {
 		log.Warn("Error getting SSH command to check if the daemon is up: %s", err)
 		return false
 	}
@@ -224,7 +229,8 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	}
 
 	// update OS -- this is needed for libdevicemapper and the docker install
-	if _, err := provisioner.SSHCommand("sudo yum -y update"); err != nil {
+	yum_update_command := provisioner.Driver.SSHSudo("yum -y update")
+	if _, err := provisioner.SSHCommand(yum_update_command); err != nil {
 		return err
 	}
 
@@ -328,7 +334,8 @@ func (provisioner *RedHatProvisioner) ConfigurePackageList() error {
 
 	// we cannot use %q here as it combines the newlines in the formatting
 	// on transport causing yum to not use the repo
-	packageCmd := fmt.Sprintf("echo \"%s\" | sudo tee /etc/yum.repos.d/docker.repo", buf.String())
+	packageCmd := provisioner.Driver.SSHSudo("sh -c 'echo %q | sudo tee /etc/yum.repos.d/docker.repo'")
+	packageCmd = fmt.Sprintf(packageCmd, buf.String())
 	if _, err := provisioner.SSHCommand(packageCmd); err != nil {
 		return err
 	}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -32,7 +32,8 @@ func installDockerGeneric(p Provisioner, baseURL string) error {
 
 func makeDockerOptionsDir(p Provisioner) error {
 	dockerDir := p.GetDockerOptionsDir()
-	if _, err := p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s", dockerDir)); err != nil {
+	mkdir_command := p.Driver.SHHSudo("mkdir -p %s")
+	if _, err := p.SSHCommand(fmt.Sprintf(mkdir_command, dockerDir)); err != nil {
 		return err
 	}
 
@@ -126,7 +127,7 @@ func ConfigureAuth(p Provisioner) error {
 
 	// printf will choke if we don't pass a format string because of the
 	// dashes, so that's the reason for the '%%s'
-	certTransferCmdFmt := "printf '%%s' '%s' | sudo tee %s"
+	certTransferCmdFmt := p.Driver.SHHSudo("sh -c \"printf '%%s' '%s' | tee %s\"")
 
 	// These ones are for Jessie and Mike <3 <3 <3
 	if _, err := p.SSHCommand(fmt.Sprintf(certTransferCmdFmt, string(caCert), authOptions.CaCertRemotePath)); err != nil {
@@ -164,7 +165,8 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	if _, err = p.SSHCommand(fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	print_and_tee := p.Driver.SHHSudo("sh -c 'printf %%s \"%s\" | sudo tee %s'")
+	if _, err = p.SSHCommand(fmt.Sprintf(print_and_tee, dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -32,7 +32,7 @@ func installDockerGeneric(p Provisioner, baseURL string) error {
 
 func makeDockerOptionsDir(p Provisioner) error {
 	dockerDir := p.GetDockerOptionsDir()
-	mkdir_command := p.Driver.SHHSudo("mkdir -p %s")
+	mkdir_command := p.GetDriver().SSHSudo("mkdir -p %s")
 	if _, err := p.SSHCommand(fmt.Sprintf(mkdir_command, dockerDir)); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func ConfigureAuth(p Provisioner) error {
 
 	// printf will choke if we don't pass a format string because of the
 	// dashes, so that's the reason for the '%%s'
-	certTransferCmdFmt := p.Driver.SHHSudo("sh -c \"printf '%%s' '%s' | tee %s\"")
+	certTransferCmdFmt := p.GetDriver().SSHSudo("sh -c \"printf '%%s' '%s' | tee %s\"")
 
 	// These ones are for Jessie and Mike <3 <3 <3
 	if _, err := p.SSHCommand(fmt.Sprintf(certTransferCmdFmt, string(caCert), authOptions.CaCertRemotePath)); err != nil {
@@ -165,7 +165,7 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	print_and_tee := p.Driver.SHHSudo("sh -c 'printf %%s \"%s\" | sudo tee %s'")
+	print_and_tee := p.GetDriver().SSHSudo("sh -c 'printf %%s \"%s\" | sudo tee %s'")
 	if _, err = p.SSHCommand(fmt.Sprintf(print_and_tee, dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}


### PR DESCRIPTION
I fixed an issue I had where there was no way for me to use docker machine as a non root user because I would get an error saying that sudo had no tty or askpass present https://github.com/docker/machine/issues/1569

I added an option for the generic driver of generic-ssh-pass which is the password of the generic-ssh-user. I modified all the ssh commands that involve sudo (I'm pretty sure I got them all) to pipe the password to `sudo -S`

I was able to fix my issue and docker compose now works with sudo because I can pass it my password