### PR TITLE
Added generic-ssh-pass and modified sudo commands

### DIFF
--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -12,6 +13,7 @@ type MockHostInfo struct {
 	ip          string
 	sshUsername string
 	sshKeyPath  string
+	sshPass     string
 }
 
 func (h *MockHostInfo) GetMachineName() string {
@@ -24,6 +26,27 @@ func (h *MockHostInfo) GetIP() (string, error) {
 
 func (h *MockHostInfo) GetSSHUsername() string {
 	return h.sshUsername
+}
+
+func (h *MockHostInfo) GetSSHPassword() string {
+	return h.sshPass
+}
+
+func (h *MockHostInfo) SSHSudo(command string) string {
+	sudo := "sudo"
+	// If there is a password given pipe it to sudo to avoid no tty error
+	if h.sshPass != "" {
+		sudo = fmt.Sprintf(
+			"echo %q | sudo -SE",
+			h.sshPass,
+		)
+	}
+	command = fmt.Sprintf(
+		"%s %s",
+		sudo,
+		command,
+	)
+	return command
 }
 
 func (h *MockHostInfo) GetSSHKeyPath() string {

--- a/drivers/errdriver/error.go
+++ b/drivers/errdriver/error.go
@@ -70,6 +70,14 @@ func (d *Driver) GetSSHUsername() string {
 	return ""
 }
 
+func (d *Driver) GetSSHPassword() string {
+	return ""
+}
+
+func (d *Driver) SSHSudo(string) string {
+	return ""
+}
+
 func (d *Driver) GetState() (state.State, error) {
 	return state.Error, ErrDriverNotLoadable{d.Name}
 }

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -43,6 +43,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value: defaultSSHUser,
 		},
 		mcnflag.StringFlag{
+			Name:  "generic-ssh-pass",
+			Usage: "SSH password for user, used for sudo",
+			Value: "",
+		},
+		mcnflag.StringFlag{
 			Name:  "generic-ssh-key",
 			Usage: "SSH private key path",
 			Value: defaultSSHKey,
@@ -83,6 +88,7 @@ func (d *Driver) GetSSHUsername() string {
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.IPAddress = flags.String("generic-ip-address")
 	d.SSHUser = flags.String("generic-ssh-user")
+	d.SSHPass = flags.String("generic-ssh-pass")
 	d.SSHKey = flags.String("generic-ssh-key")
 	d.SSHPort = flags.Int("generic-ssh-port")
 
@@ -159,7 +165,9 @@ func (d *Driver) Remove() error {
 func (d *Driver) Restart() error {
 	log.Debug("Restarting...")
 
-	if _, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -r now"); err != nil {
+	command := "shutdown -r now"
+	command = d.SSHSudo(command)
+	if _, err := drivers.RunSSHCommandFromDriver(d, command); err != nil {
 		return err
 	}
 
@@ -169,7 +177,9 @@ func (d *Driver) Restart() error {
 func (d *Driver) Kill() error {
 	log.Debug("Killing...")
 
-	if _, err := drivers.RunSSHCommandFromDriver(d, "sudo shutdown -P now"); err != nil {
+	command := "shutdown -P now"
+	command = d.SSHSudo(command)
+	if _, err := drivers.RunSSHCommandFromDriver(d, command); err != nil {
 		return err
 	}
 

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -1,12 +1,16 @@
 package drivers
 
-import "path/filepath"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 // BaseDriver - Embed this struct into drivers to provide the common set
 // of fields and functions.
 type BaseDriver struct {
 	IPAddress      string
 	SSHUser        string
+	SSHPass        string
 	SSHPort        int
 	MachineName    string
 	SwarmMaster    bool
@@ -51,6 +55,29 @@ func (d *BaseDriver) GetSSHUsername() string {
 	}
 
 	return d.SSHUser
+}
+
+// GetSSHPassword returns the ssh password
+func (d *BaseDriver) GetSSHPassword() string {
+	return d.SSHPass
+}
+
+// SSHSudo formats the command to pipe the password to sudo
+func (d *BaseDriver) SSHSudo(command string) string {
+	sudo := "sudo"
+	// If there is a password given pipe it to sudo to avoid no tty error
+	if d.SSHPass != "" {
+		sudo = fmt.Sprintf(
+			"echo %q | sudo -SE",
+			d.SSHPass,
+		)
+	}
+	command = fmt.Sprintf(
+		"%s %s",
+		sudo,
+		command,
+	)
+	return command
 }
 
 // PreCreateCheck is called to enforce pre-creation steps

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -41,6 +41,12 @@ type Driver interface {
 	// GetSSHUsername returns username for use with ssh
 	GetSSHUsername() string
 
+	// GetSSHPassword returns password for use with ssh
+	GetSSHPassword() string
+
+	// SSHSudo formats command to be run with sudo
+	SSHSudo(string) string
+
 	// GetURL returns a Docker compatible host URL for connecting to this host
 	// e.g. tcp://1.2.3.4:2376
 	GetURL() (string, error)

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -239,6 +239,25 @@ func (c *RpcClientDriver) GetSSHUsername() string {
 	return username
 }
 
+func (c *RpcClientDriver) GetSSHPassword() string {
+	password, err := c.rpcStringCall("RpcServerDriver.GetSSHPassword")
+	if err != nil {
+		log.Warnf("Error attempting call to get SSH password: %s", err)
+	}
+
+	return password
+}
+
+func (c *RpcClientDriver) SSHSudo(command string) string {
+	var escaped string
+
+	if err := c.Client.Call("RpcServerDriver.SSHSudo", command, &escaped); err != nil {
+		log.Warnf("Error attempting call to get SSHSudo: %s", err)
+	}
+
+	return escaped
+}
+
 func (c *RpcClientDriver) GetState() (state.State, error) {
 	var s state.State
 

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -151,6 +151,15 @@ func (r *RpcServerDriver) GetSSHUsername(_ *struct{}, reply *string) error {
 	return nil
 }
 
+func (r *RpcServerDriver) GetSSHPassword(_ *struct{}, reply *string) error {
+	*reply = r.ActualDriver.GetSSHPassword()
+	return nil
+}
+
+func (r *RpcServerDriver) SSHSudo(command string) string {
+	return r.ActualDriver.SSHSudo(command)
+}
+
 func (r *RpcServerDriver) GetURL(_ *struct{}, reply *string) error {
 	info, err := r.ActualDriver.GetURL()
 	*reply = info

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -28,8 +28,10 @@ func (provisioner *GenericProvisioner) Hostname() (string, error) {
 }
 
 func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
+	command := "sh -c 'hostname %s && echo %q | tee /etc/hostname'"
+	command = provisioner.Driver.SSHSudo(command)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {
@@ -37,8 +39,17 @@ func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
 	}
 
 	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if_then := "sh -c \"sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts\""
+	if_else := "sh -c \"echo '127.0.1.1 %s' | tee -a /etc/hosts\""
+	if_then = provisioner.Driver.SSHSudo(if_then)
+	if_else = provisioner.Driver.SSHSudo(if_else)
+	command = fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then %s; else %s; fi",
+		if_then,
+		if_else,
+	)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -88,10 +88,10 @@ func (provisioner *RedHatProvisioner) SSHCommand(args string) (string, error) {
 }
 
 func (provisioner *RedHatProvisioner) SetHostname(hostname string) error {
-	// we have to have SetHostname here as well to use the RedHat provisioner
-	// SSHCommand to add the tty allocation
+	command := "sh -c 'hostname %s && echo %q | tee /etc/hostname'"
+	command = provisioner.Driver.SSHSudo(command)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"sudo hostname %s && echo %q | sudo tee /etc/hostname",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {
@@ -99,8 +99,17 @@ func (provisioner *RedHatProvisioner) SetHostname(hostname string) error {
 	}
 
 	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+	if_then := "sh -c \"sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts\""
+	if_else := "sh -c \"echo '127.0.1.1 %s' | tee -a /etc/hosts\""
+	if_then = provisioner.Driver.SSHSudo(if_then)
+	if_else = provisioner.Driver.SSHSudo(if_else)
+	command = fmt.Sprintf(
+		"if grep -xq 127.0.1.1.* /etc/hosts; then %s; else %s; fi",
+		if_then,
+		if_else,
+	)
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+		command,
 		hostname,
 		hostname,
 	)); err != nil {
@@ -121,12 +130,14 @@ func (provisioner *RedHatProvisioner) Service(name string, action serviceaction.
 	// be sure exactly when it changes from the provisioner so
 	// we call a reload on every restart to be safe
 	if reloadDaemon {
-		if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
+		reload_command := provisioner.Driver.SSHSudo("systemctl daemon-reload")
+		if _, err := provisioner.SSHCommand(reload_command); err != nil {
 			return err
 		}
 	}
 
-	command := fmt.Sprintf("sudo systemctl %s %s", action.String(), name)
+	systemctl_command := provisioner.Driver.SSHSudo("systemctl %s %s")
+	command := fmt.Sprintf(systemctl_command, action.String(), name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err
@@ -147,7 +158,8 @@ func (provisioner *RedHatProvisioner) Package(name string, action pkgaction.Pack
 		packageAction = "upgrade"
 	}
 
-	command := fmt.Sprintf("sudo -E yum %s -y %s", packageAction, name)
+	yum_command := provisioner.Driver.SSHSudo("yum %s -y %s")
+	command := fmt.Sprintf(yum_command, packageAction, name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err
@@ -179,7 +191,8 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 		return err
 	}
 
-	if _, err := provisioner.SSHCommand("sudo yum install -y docker-engine"); err != nil {
+	engine_install_command := provisioner.Driver.SSHSudo("yum install -y docker-engine")
+	if _, err := provisioner.SSHCommand(engine_install_command); err != nil {
 		return err
 	}
 
@@ -187,8 +200,9 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 }
 
 func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
-		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+	docker_version_command := provisioner.Driver.SSHSudo("docker version")
+	if _, err := provisioner.SSHCommand(docker_version_command); err != nil {
+		log.Warn("Error getting SSH command to check if the daemon is up: %s", err)
 		return false
 	}
 
@@ -218,7 +232,8 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.SwarmOptions,
 	}
 
 	// update OS -- this is needed for libdevicemapper and the docker install
-	if _, err := provisioner.SSHCommand("sudo yum -y update"); err != nil {
+	yum_update_command := provisioner.Driver.SSHSudo("yum -y update")
+	if _, err := provisioner.SSHCommand(yum_update_command); err != nil {
 		return err
 	}
 
@@ -322,7 +337,8 @@ func (provisioner *RedHatProvisioner) ConfigurePackageList() error {
 
 	// we cannot use %q here as it combines the newlines in the formatting
 	// on transport causing yum to not use the repo
-	packageCmd := fmt.Sprintf("echo \"%s\" | sudo tee /etc/yum.repos.d/docker.repo", buf.String())
+	packageCmd := provisioner.Driver.SSHSudo("sh -c 'echo %q | sudo tee /etc/yum.repos.d/docker.repo'")
+	packageCmd = fmt.Sprintf(packageCmd, buf.String())
 	if _, err := provisioner.SSHCommand(packageCmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
I found and fixed an issue I had where there was no way for me to use docker machine as a non root user because I would get an error saying that sudo had no tty or askpass present #1569

I added an option for the generic driver of generic-ssh-pass which is the password of the generic-ssh-user. I modified all the ssh commands that involve sudo (I'm pretty sure I got them all) to pipe the password to sudo -S

I was able to fix my issue and docker compose now works with sudo because I can pass it my password

If you see a bunch of pull requests from me its because I messed up a few times i forgo to run the formatter and stuff but this one should be good.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>