### PR TITLE
Add docker-machine provision command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -331,6 +331,12 @@ var Commands = []cli.Command{
 		Action: cmdLs,
 	},
 	{
+		Name:        "provision",
+		Usage:       "Run standard Machine provisioning on one or more hosts",
+		Description: "Argument(s) are one or more machine names.",
+		Action:      cmdProvision,
+	},
+	{
 		Name:        "regenerate-certs",
 		Usage:       "Regenerate TLS Certificates for a machine",
 		Description: "Argument(s) are one or more machine names.",
@@ -413,8 +419,10 @@ var Commands = []cli.Command{
 // machineCommand maps the command name to the corresponding machine command.
 // We run commands concurrently and communicate back an error if there was one.
 func machineCommand(actionName string, host *libmachine.Host, errorChan chan<- error) {
+	// TODO: These actions should have their own type.
 	commands := map[string](func() error){
 		"configureAuth": host.ConfigureAuth,
+		"provision":     host.Provision,
 		"start":         host.Start,
 		"stop":          host.Stop,
 		"restart":       host.Restart,

--- a/commands/provision.go
+++ b/commands/provision.go
@@ -1,0 +1,13 @@
+package commands
+
+import (
+	"log"
+
+	"github.com/codegangsta/cli"
+)
+
+func cmdProvision(c *cli.Context) {
+	if err := runActionWithContext("provision", c); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -299,12 +299,21 @@ func (h *Host) LoadConfig() error {
 	return nil
 }
 
-func (h *Host) ConfigureAuth() error {
+func (h *Host) getProvisioner() (provision.Provisioner, error) {
 	if err := h.LoadConfig(); err != nil {
-		return err
+		return nil, fmt.Errorf("Error loading host config: %s", err)
 	}
 
 	provisioner, err := provision.DetectProvisioner(h.Driver)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting provisioner: %s", err)
+	}
+
+	return provisioner, nil
+}
+
+func (h *Host) ConfigureAuth() error {
+	provisioner, err := h.getProvisioner()
 	if err != nil {
 		return err
 	}
@@ -315,6 +324,21 @@ func (h *Host) ConfigureAuth() error {
 	//
 	// Call provision to re-provision the certs properly.
 	if err := provisioner.Provision(swarm.SwarmOptions{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Host) Provision() error {
+	provisioner, err := h.getProvisioner()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Running Docker Machine provisioning on host %s...", h.Name)
+
+	if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This allows users to re-run provisioning on an existing Docker Machine instance.  If something blows up during the ordinary create or provisioning process, this allows users to potentially salvage the machine using `docker-machine provision`.

TODO:

- [ ] Add docs
- [ ] Add tests

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>