### PR TITLE
Skip and warn on wonky /etc/os-release lines

### DIFF
--- a/libmachine/provision/os_release.go
+++ b/libmachine/provision/os_release.go
@@ -69,7 +69,8 @@ func (osr *OsRelease) ParseOsRelease(osReleaseContents []byte) error {
 	for scanner.Scan() {
 		key, val, err := parseLine(scanner.Text())
 		if err != nil {
-			return err
+			log.Warn("Warning: got an invalid line error parsing /etc/os-release: %s", err)
+			continue
 		}
 		if err := osr.setIfPossible(key, val); err != nil {
 			log.Debug(err)


### PR DESCRIPTION
Closes https://github.com/docker/machine/issues/1596
Closes https://github.com/docker/machine/issues/1481

If the lines don't split cleanly (occasionally STDERR gets mixed in, for
instance, due to our current SSH output setup), we should simply
log.Warn in the output instead of bailing completely.

Longer term we need to separate out STDERR and STDOUT in our SSH command output, but I think this should function as an OK hackaround for now.

cc @ehazlett 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>