### PR TITLE
check github for latest b2d release

### DIFF
--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	//"encoding/json"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -70,41 +70,35 @@ func NewB2dUtils(githubApiBaseUrl, githubBaseUrl, isoFilename string) *B2dUtils 
 // Get the latest boot2docker release tag name (e.g. "v0.6.0").
 // FIXME: find or create some other way to get the "latest release" of boot2docker since the GitHub API has a pretty low rate limit on API requests
 func (b *B2dUtils) GetLatestBoot2DockerReleaseURL() (string, error) {
-	//client := getClient()
-	//apiUrl := fmt.Sprintf("%s/repos/boot2docker/boot2docker/releases", b.githubApiBaseUrl)
-	//rsp, err := client.Get(apiUrl)
-	//if err != nil {
-	//	return "", err
-	//}
-	//defer rsp.Body.Close()
+	client := getClient()
+	apiUrl := fmt.Sprintf("%s/repos/docker/boot2docker/releases", b.githubApiBaseUrl)
+	rsp, err := client.Get(apiUrl)
+	if err != nil {
+		return "", err
+	}
+	defer rsp.Body.Close()
 
-	//var t []struct {
-	//	TagName    string `json:"tag_name"`
-	//	PreRelease bool   `json:"prerelease"`
-	//}
-	//if err := json.NewDecoder(rsp.Body).Decode(&t); err != nil {
-	//	return "", fmt.Errorf("Error demarshaling the Github API response: %s\nYou may be getting rate limited by Github.", err)
-	//}
-	//if len(t) == 0 {
-	//	return "", fmt.Errorf("no releases found")
-	//}
+	var t []struct {
+		TagName    string `json:"tag_name"`
+		PreRelease bool   `json:"prerelease"`
+	}
+	if err := json.NewDecoder(rsp.Body).Decode(&t); err != nil {
+		return "", fmt.Errorf("Error demarshaling the Github API response: %s\nYou may be getting rate limited by Github.", err)
+	}
+	if len(t) == 0 {
+		return "", fmt.Errorf("no releases found")
+	}
 
-	//// find the latest "released" release (i.e. not pre-release)
-	//isoUrl := ""
-	//for _, r := range t {
-	//	if !r.PreRelease {
-	//		tag := r.TagName
-	//		isoUrl = fmt.Sprintf("%s/boot2docker/boot2docker/releases/download/%s/boot2docker.iso", b.githubBaseUrl, tag)
-	//		break
-	//	}
-	//}
-	//return isoUrl, nil
-
-	// TODO: once we decide on the final versioning and location we will
-	// enable the above "check for latest"
-	u := fmt.Sprintf("https://s3.amazonaws.com/docker-mcn/public/b2d-next/%s", b.isoFilename)
-	return u, nil
-
+	// find the latest "released" release (i.e. not pre-release)
+	isoUrl := ""
+	for _, r := range t {
+		if !r.PreRelease {
+			tag := r.TagName
+			isoUrl = fmt.Sprintf("%s/docker/boot2docker/releases/download/%s/boot2docker.iso", b.githubBaseUrl, tag)
+			break
+		}
+	}
+	return isoUrl, nil
 }
 
 func removeFileIfExists(name string) error {


### PR DESCRIPTION
This enables checking for the latest release on the new b2d-ng repo.

Note: once merged, to test you will need to specify an existing ISO url (`--virtualbox-boot2docker-url`) until there is an official release.

Current Builds:

VirtualBox: https://s3.amazonaws.com/docker-mcn/public/b2d-next/boot2docker-virtualbox.iso
VMware: https://s3.amazonaws.com/docker-mcn/public/b2d-next/boot2docker-vmware.iso
Hyperv: https://s3.amazonaws.com/docker-mcn/public/b2d-next/boot2docker-hyperv.iso