### PR TITLE
libmachine: Filestore#GetActive() should return an error if DOCKER_HOST is empty

### DIFF
--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -126,6 +126,10 @@ func (s Filestore) GetActive() (*Host, error) {
 	}
 
 	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost == "" {
+		return nil, errors.New("DOCKER_HOST not set")
+	}
+
 	hostListItems := GetHostListItems(hosts)
 
 	for _, item := range hostListItems {

--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -127,7 +127,7 @@ func (s Filestore) GetActive() (*Host, error) {
 
 	dockerHost := os.Getenv("DOCKER_HOST")
 	if dockerHost == "" {
-		return nil, errors.New("DOCKER_HOST not set")
+		return nil, errors.New("No active host found: DOCKER_HOST not set")
 	}
 
 	hostListItems := GetHostListItems(hosts)


### PR DESCRIPTION
Currently `docker-machine active` returns a stopped machine name randomly if `DOCKER_HOST` is not set, because both `DOCKER_HOST` and `item.URL` are empty and `dockerHost == item.URL` is satisfied.

I think this behavior is very confusing so I suggest the command should return an error in that case.
(Please give me comments on the error message.)

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>