### PR TITLE
Proposal: create --force

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -240,6 +240,10 @@ var sharedCreateFlags = []cli.Flag{
 		Usage: "addr to advertise for Swarm (default: detect and use the machine IP)",
 		Value: "",
 	},
+	cli.BoolFlag{
+		Name:  "force",
+		Usage: "Create this machine even if one already exists with the same name. Use with caution!",
+	},
 }
 
 var Commands = []cli.Command{


### PR DESCRIPTION
I've hit a couple scenarios where I want to recreate a machine from scratch, and I don't really care that there's already a machine with the same name. Right now, I do:

```
$ docker-machine rm $NAME || true && docker-machine create -d ... $NAME
...
```

Not a terrible approach, but it feels kludgy. This PR allows the following:

```
$ docker-machine create --force -d ... $NAME
...
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>