### PR TITLE
Add quotes to the eval cmdline if there are spaces in the path/name

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -190,6 +190,10 @@ func cmdEnv(c *cli.Context) {
 
 func generateUsageHint(appName, machineName, userShell string) string {
 	cmd := ""
+	if strings.Contains(appName, " ") {
+		// putting quotes around the command works on windows, sh and bash
+		appName = strings.Join([]string{"\"", appName, "\""}, "")
+	}
 	switch userShell {
 	case "fish":
 		if machineName != "" {


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>


```
sven@DESKTOP-Q9P9MVC ~
$ ./test\ this/docker-machine_windows-amd64.exe env dev
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://10.10.10.153:2376"
export DOCKER_CERT_PATH="C:\Users\sven\.docker\machine\machines\dev"
export DOCKER_MACHINE_NAME="dev"
# Run this command to configure your shell:
# eval "$("c:\Users\sven\test this\docker-machine_windows-amd64.exe" env dev)"

sven@DESKTOP-Q9P9MVC ~
$ cp test\ this/docker-machine_windows-amd64.exe .

sven@DESKTOP-Q9P9MVC ~
$ ./do
Documents/                        Downloads/                        docker-machine_windows-amd64.exe

sven@DESKTOP-Q9P9MVC ~
$ ./doc
Documents/                        docker-machine_windows-amd64.exe

sven@DESKTOP-Q9P9MVC ~
$ ./docker-machine_windows-amd64.exe env dev
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://10.10.10.153:2376"
export DOCKER_CERT_PATH="C:\Users\sven\.docker\machine\machines\dev"
export DOCKER_MACHINE_NAME="dev"
# Run this command to configure your shell:
# eval "$(c:\Users\sven\docker-machine_windows-amd64.exe env dev)"

sven@DESKTOP-Q9P9MVC ~
$ mv docker-machine_windows-amd64.exe docker\ machine

sven@DESKTOP-Q9P9MVC ~
$ ./do
Documents/      Downloads/      docker machine

sven@DESKTOP-Q9P9MVC ~
$ ./docker\ machine env dev
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://10.10.10.153:2376"
export DOCKER_CERT_PATH="C:\Users\sven\.docker\machine\machines\dev"
export DOCKER_MACHINE_NAME="dev"
# Run this command to configure your shell:
# eval "$("c:\Users\sven\docker machine" env dev)"

sven@DESKTOP-Q9P9MVC ~
$ eval "$("c:\Users\sven\docker machine" env dev)"
```

it also worked with bash on linux and osx - but I've not tried fish...
whereas using a backslash didn't work on windows.