### PR TITLE
libmachine: fix a test to check a host name is the same as expected

### DIFF
--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -228,7 +228,7 @@ func TestStoreGetSetActive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if host.Name != host.Name {
+	if host.Name != hostTestName {
 		t.Fatalf("Active host is not 'test', got %s", host.Name)
 	}
 }

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -229,6 +229,6 @@ func TestStoreGetSetActive(t *testing.T) {
 		t.Fatal(err)
 	}
 	if host.Name != hostTestName {
-		t.Fatalf("Active host is not 'test', got %s", host.Name)
+		t.Fatalf("Active host is not '%s', got %s", hostTestName, host.Name)
 	}
 }


### PR DESCRIPTION
fixed #1614 

I fixed the test to check `host.Name` is the same as an expected host name.