### PR TITLE
Amazon EC2 - Add option to inject Base64-encoded EC2 user data

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -33,6 +33,7 @@ Options:
  - `--amazonec2-spot-price`: Spot instance bid price (in dollars). Require the `--amazonec2-request-spot-instance` flag.
  - `--amazonec2-private-address-only`: Use the private IP address only.
  - `--amazonec2-monitoring`: Enable CloudWatch Monitoring.
+ - `--amazonec2-user-data`: Base64-encoded EC2 user data string to send.
 
 By default, the Amazon EC2 driver will use a daily image of Ubuntu 14.04 LTS.
 
@@ -71,4 +72,5 @@ Environment variables and default values:
 | `--amazonec2-spot-price`            | -                       | `0.50`           |
 | `--amazonec2-private-address-only`  | -                       | `false`          |
 | `--amazonec2-monitoring`            | -                       | `false`          |
+| `--amazonec2-user-data`             | `AWS_USER_DATA`         | -                |
 

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -86,6 +86,7 @@ func getDefaultTestDriverFlags() *DriverOptionsMock {
 			"amazonec2-spot-price":            "",
 			"amazonec2-private-address-only":  false,
 			"amazonec2-monitoring":            false,
+			"amazonec2-user-data":             "",
 		},
 	}
 }

--- a/drivers/amazonec2/amz/ec2.go
+++ b/drivers/amazonec2/amz/ec2.go
@@ -97,6 +97,7 @@ type (
 			} `xml:"privateIpAddressesSet>item"`
 		} `xml:"networkInterfaceSet>item"`
 		EbsOptimized bool `xml:"ebsOptimized"`
+		UserData     string `xml:"userData"`
 	}
 
 	RunInstancesResponse struct {
@@ -177,7 +178,7 @@ func (e *EC2) awsApiCall(v url.Values) (*http.Response, error) {
 	return resp, nil
 }
 
-func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, privateIPOnly bool, monitoring bool) (EC2Instance, error) {
+func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCount int, maxCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, privateIPOnly bool, monitoring bool, userData string) (EC2Instance, error) {
 	instance := Instance{}
 	v := url.Values{}
 	v.Set("Action", "RunInstances")
@@ -216,6 +217,10 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 		}
 		v.Set("BlockDeviceMapping.0.Ebs.DeleteOnTermination", strconv.Itoa(deleteOnTerm))
 	}
+	
+	if userData != "" {
+		v.Set("UserData", userData)
+	}
 
 	resp, err := e.awsApiCall(v)
 
@@ -238,7 +243,7 @@ func (e *EC2) RunInstance(amiId string, instanceType string, zone string, minCou
 	return instance.info, nil
 }
 
-func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone string, instanceCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, spotPrice string, monitoring bool) (string, error) {
+func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone string, instanceCount int, securityGroup string, keyName string, subnetId string, bdm *BlockDeviceMapping, role string, spotPrice string, monitoring bool, userData string) (string, error) {
 	v := url.Values{}
 	v.Set("Action", "RequestSpotInstances")
 	v.Set("LaunchSpecification.ImageId", amiId)
@@ -271,6 +276,10 @@ func (e *EC2) RequestSpotInstances(amiId string, instanceType string, zone strin
 			deleteOnTerm = 1
 		}
 		v.Set("LaunchSpecification.BlockDeviceMapping.0.Ebs.DeleteOnTermination", strconv.Itoa(deleteOnTerm))
+	}
+	
+	if userData != "" {
+		v.Set("UserData", userData)
 	}
 
 	resp, err := e.awsApiCall(v)


### PR DESCRIPTION
I need to be able to inject EC2 user data to instances at launch time for certain configuration tasks. Can you please take this pull request so others can benefit from this functionality as well?

Thanks!