### PR TITLE
openstack: New machine active timeout parameter

### DIFF
--- a/docs/drivers/openstack.md
+++ b/docs/drivers/openstack.md
@@ -36,6 +36,7 @@ Options:
    there is no IP address already allocated a new IP will be allocated and assigned to the machine.
  - `--openstack-ssh-user`: The username to use for SSH into the machine. If not provided `root` will be used.
  - `--openstack-ssh-port`: Customize the SSH port if the SSH server on the machine does not listen on the default port.
+ - `--openstack-active-timeout`: The timeout in seconds until the OpenStack instance must be active.
 
 Environment variables and default values:
 
@@ -62,3 +63,4 @@ Environment variables and default values:
 | `--openstack-floatingip-pool`    | -                      | -       |
 | `--openstack-ssh-user`           | -                      | `root`  |
 | `--openstack-ssh-port`           | -                      | `22`    |
+| `--openstack-active-timeout`     | -                      | `200`   |

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -151,7 +151,7 @@ func (c *GenericClient) WaitForInstanceStatus(d *Driver, status string) error {
 		}
 
 		return false, nil
-	}, 50, 4*time.Second)
+	}, (d.ActiveTimeout / 4), 4*time.Second)
 }
 
 func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -17,6 +17,7 @@ import (
 type Driver struct {
 	*drivers.BaseDriver
 	AuthUrl          string
+	ActiveTimeout    int
 	Insecure         bool
 	DomainID         string
 	DomainName       string
@@ -164,6 +165,11 @@ func GetCreateFlags() []cli.Flag {
 			Usage: "OpenStack SSH port",
 			Value: 22,
 		},
+		cli.IntFlag{
+			Name:  "openstack-active-timeout",
+			Usage: "OpenStack active timeout",
+			Value: 200,
+		},
 	}
 }
 
@@ -193,6 +199,7 @@ func (d *Driver) DriverName() string {
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.AuthUrl = flags.String("openstack-auth-url")
+	d.ActiveTimeout = flags.Int("openstack-active-timeout")
 	d.Insecure = flags.Bool("openstack-insecure")
 	d.DomainID = flags.String("openstack-domain-id")
 	d.DomainName = flags.String("openstack-domain-name")


### PR DESCRIPTION
* Adds `--openstack-connection-retries` parameter to set the maximum
  number of retries. Closes #1632

Signed-off-by: David Zerulla <ddaze@outlook.de>