### PR TITLE
Use a single function for checking active machine

### DIFF
--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -125,15 +125,10 @@ func (s Filestore) GetActive() (*Host, error) {
 		return nil, err
 	}
 
-	dockerHost := os.Getenv("DOCKER_HOST")
-	if dockerHost == "" {
-		return nil, errors.New("No active host found: DOCKER_HOST not set")
-	}
-
 	hostListItems := GetHostListItems(hosts)
 
 	for _, item := range hostListItems {
-		if dockerHost == item.URL {
+		if item.Active {
 			host, err := s.Get(item.Name)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This is my first time contributing to machine - I tried to follow the `CONTRIBUTING.md` as close as possible, but if I missed anything please let me know. Also, I wasn't sure about adding tests - the code I wrote seems to be covered by the existing tests and it didn't seem like each individual method had it's own test in `host_tests.go` so I ended up not writing any new ones - but I can if that would be good. Thanks all!

Fix https://github.com/docker/machine/issues/1651

As pointed out in the issue above, the `active` and `ls` commands used
different methods for determing the active machine. This commit defines
a single method on the `host` struct called `IsActive` which provides
a uniform check for machine activness. `IsActive` returns true only
if `DOCKER_HOST == url` and the state is not stopped - previously the
`active` command only checked the url.

* Add a single `host` method `IsActive` for determining if a machine is
  active.

Signed-off-by: Matt McNaughton <mattjmcnaughton@gmail.com>