### PR TITLE
Add DRIVER_OPTS variable in integration tests

### DIFF
--- a/test/integration/core/arbitrary-engine-envs.bats
+++ b/test/integration/core/arbitrary-engine-envs.bats
@@ -5,7 +5,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create with arbitrary engine envs" {
 
-run machine create -d $DRIVER \
+run machine create -d $DRIVER $DRIVER_OPTS \
   --engine-env=TEST=VALUE \
   $NAME
   [ $status -eq 0  ]

--- a/test/integration/core/arbitrary-engine-options.bats
+++ b/test/integration/core/arbitrary-engine-options.bats
@@ -3,7 +3,7 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create with arbitrary engine option" {
-  run machine create -d $DRIVER \
+  run machine create -d $DRIVER $DRIVER_OPTS \
     --engine-opt log-driver=none \
     $NAME
   [ $status -eq 0 ]

--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -9,7 +9,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 }
 
 @test "$DRIVER: create" {
-  run machine create -d $DRIVER $NAME
+  run machine create -d $DRIVER $DRIVER_OPTS $NAME
   [ "$status" -eq 0  ]
 }
 

--- a/test/integration/core/regenerate-certs.bats
+++ b/test/integration/core/regenerate-certs.bats
@@ -3,7 +3,7 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create" {
-  run machine create -d $DRIVER $NAME
+  run machine create -d $DRIVER $DRIVER_OPTS $NAME
 }
 
 @test "$DRIVER: regenerate the certs" {

--- a/test/integration/core/scp.bats
+++ b/test/integration/core/scp.bats
@@ -5,7 +5,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 export SECOND_MACHINE="$NAME-2"
 
 @test "$DRIVER: create" {
-  run machine create -d $DRIVER $NAME
+  run machine create -d $DRIVER $DRIVER_OPTS $NAME
   [[ ${status} -eq 0 ]]
 }
 
@@ -25,7 +25,7 @@ export SECOND_MACHINE="$NAME-2"
 }
 
 @test "$DRIVER: create machine to test transferring files from machine to machine" {
-  run machine create -d $DRIVER $SECOND_MACHINE
+  run machine create -d $DRIVER $DRIVER_OPTS $SECOND_MACHINE
   [[ ${status} -eq 0 ]]
 }
 

--- a/test/integration/core/ssh-backends.bats
+++ b/test/integration/core/ssh-backends.bats
@@ -5,7 +5,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 # Basic smoke test for SSH backends
 
 @test "$DRIVER: create SSH test box" {
-  run machine create -d $DRIVER $NAME
+  run machine create -d $DRIVER $DRIVER_OPTS $NAME
   [[ "$status" -eq 0  ]]
 }
 

--- a/test/integration/core/supported-engine-options.bats
+++ b/test/integration/core/supported-engine-options.bats
@@ -3,7 +3,7 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create with supported engine options" {
-  run machine create -d $DRIVER \
+  run machine create -d $DRIVER $DRIVER_OPTS \
     --engine-label spam=eggs \
     --engine-storage-driver overlay \
     --engine-insecure-registry registry.myco.com \

--- a/test/integration/core/swarm-options.bats
+++ b/test/integration/core/swarm-options.bats
@@ -4,13 +4,13 @@ load ${BASE_TEST_DIR}/helpers.bash
 export TOKEN=$(curl -sS -X POST "https://discovery-stage.hub.docker.com/v1/clusters")
 
 @test "create swarm master" {
-    run machine create -d $DRIVER --swarm --swarm-master --swarm-discovery "token://$TOKEN" --swarm-strategy binpack --swarm-opt heartbeat=5s queenbee
+    run machine create -d $DRIVER $DRIVER_OPTS --swarm --swarm-master --swarm-discovery "token://$TOKEN" --swarm-strategy binpack --swarm-opt heartbeat=5s queenbee
     echo ${output}
     [[ "$status" -eq 0 ]]
 }
 
 @test "create swarm node" {
-    run machine create -d $DRIVER --swarm --swarm-discovery "token://$TOKEN" workerbee
+    run machine create -d $DRIVER $DRIVER_OPTS --swarm --swarm-discovery "token://$TOKEN" workerbee
     [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
Some drivers need configuration that can be set only using specific command line flags. This is what the `DRIVER_OPTS` variable is for. Now, `core` tests can be run with any driver.

For instance, we can run the `core` tests on the OpenStack driver

```bash
$ export OS_USERNAME=user
$ export OS_PASSWORD=password
$ export OS_AUTH_URL=https://openstack/identity/v2.0
$ export OS_TENANT_ID=6d7fce9fee471194aa8b5b6e47267f03
$ export OS_REGION_NAME=region
$
$ export DRIVER=openstack
$ export DRIVER_OPTS='
    --openstack-image-name      ubuntu-14.04_x86_64
    --openstack-flavor-name     2_vCPU_RAM_4G_HD_10G
    --openstack-net-name        net
    --openstack-floatingip-pool PublicNetwork
    --openstack-ssh-user        ubuntu'
$
$ ./run-bats.sh core
```