### PR TITLE
Prioritize using make in build, cleanup a few things in build script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,17 +10,20 @@ Machine is a part of the [Docker](https://www.docker.com) project, and follows
 the same rules and principles. If you're already familiar with the way
 Docker does things, you'll feel right at home.
 
-Otherwise, go read
-[Docker's contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
+Otherwise, please read [Docker's contributions
+guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
+
+# Building
 
 The requirements to build Machine are:
 
 1. A running instance of Docker
 2. The `bash` shell
+3. [Make](https://www.gnu.org/software/make/)
 
 To build, run:
 
-    $ script/build
+    $ make
 
 From the Machine repository's root.  Machine will run the build inside of a
 Docker container and the compiled binaries will appear in the project directory
@@ -28,21 +31,14 @@ on the host.
 
 By default, Machine will run a build which cross-compiles binaries for a variety
 of architectures and operating systems.  If you know that you are only compiling
-for a particular architecture and/or operating system, you can speed up
-compilation by overriding the default argument that the build script passes
-to [gox](https://github.com/mitchellh/gox).  This is very useful if you want
-to iterate quickly on a new feature, bug fix, etc.
+for a particular architecture and/or operating system, you can speed up the
+compile by setting the standard `GOOS` and/or `GOARCH` environment variables to
+deviate from the defaults.
 
 For instance, if you only want to compile for use on OS X with the x86_64 arch,
 run:
 
-    $ script/build -osarch="darwin/amd64"
-
-If you don't need to run the `docker build` to generate the image on each
-compile, i.e. if you have built the image already, you can skip the image build
-using the `SKIP_BUILD` environment variable, for instance:
-
-    $ SKIP_BUILD=1 script/build -osarch="darwin/amd64"
+    $ GOOS=darwin GOARCH=amd64 make
 
 If you have any questions we're in #docker-machine on Freenode.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all test validate-dco validate-gofmt validate build
+.PHONY: test validate-dco validate-gofmt
 
-all: validate test build
+default: build
 
 test:
 	script/test
@@ -11,8 +11,11 @@ validate-dco:
 validate-gofmt:
 	script/validate-gofmt
 
-validate: validate-dco validate-gofmt
+validate: validate-dco validate-gofmt test
 
-build:
+build: clean
 	script/build
 
+clean:
+	rm -f docker-machine_*
+	rm -rf Godeps/_workspace/pkg

--- a/script/build
+++ b/script/build
@@ -1,24 +1,20 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]; then
-    OS_PLATFORM_ARG=(-os="darwin linux windows")
-else
-    OS_PLATFORM_ARG=($1)
+BUILD_IMAGE_NAME="docker-machine-build"
+GOOS=${GOOS:-"darwin linux windows"}
+GOARCH=${GOARCH:-"386 amd64 arm"}
+
+# Build image for compilation if not detected
+if [[ $(docker images -q ${BUILD_IMAGE_NAME} | wc -l) -ne 1 ]]; then
+    docker build -t ${BUILD_IMAGE_NAME} .
 fi
 
-if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64 arm")
-else
-    OS_ARCH_ARG=($2)
-fi
-
-# Build Docker image unless we opt out of it
-if [[ -z "$SKIP_BUILD" ]]; then
-    docker build -t docker-machine .
-fi
-
-# Get rid of existing binaries
-rm -f docker-machine*
-rm -rf Godeps/_workspace/pkg
-docker run --rm -v `pwd`:/go/src/github.com/docker/machine docker-machine gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" -output="docker-machine_{{.OS}}-{{.Arch}}" -ldflags="-w -X github.com/docker/machine/version.GitCommit `git rev-parse --short HEAD`"
+docker run --rm \
+    -v `pwd`:/go/src/github.com/docker/machine \
+    ${BUILD_IMAGE_NAME} \
+    gox \
+    -os "$GOOS" \
+    -arch "$GOARCH" \
+    -output="docker-machine_{{.OS}}-{{.Arch}}" \
+    -ldflags="-w -X github.com/docker/machine/version.GitCommit `git rev-parse --short HEAD`"


### PR DESCRIPTION
cc @ehazlett @tianon @hairyhenderson 

It's such a universal standard that `make` in your project root should build your project, I would really prefer for the build to be done through `make`.  This also reduces the complexity of the `script/build` script by just letting users specifying `GOOS` / `GOARCH` instead of our current `$1`/`$2` parsing weirdness.

This also replaces `SKIP_BUILD` with an automatic check to see if the build image is around already.

WDYT?

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>