### PR TITLE
fixes upgrade for debian/ubuntu for new package name

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -92,7 +92,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 		}
 
 		for _, cmd := range commands {
-			command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E %s", cmd)
+			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
 			if _, err := provisioner.SSHCommand(command); err != nil {
 				return err
 			}

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -59,13 +59,11 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	updateMetadata := true
 
 	switch action {
-	case pkgaction.Install:
+	case pkgaction.Install, pkgaction.Upgrade:
 		packageAction = "install"
 	case pkgaction.Remove:
 		packageAction = "remove"
 		updateMetadata = false
-	case pkgaction.Upgrade:
-		packageAction = "upgrade"
 	}
 
 	switch name {

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -70,12 +70,34 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 
 	switch name {
 	case "docker":
-		name = "lxc-docker"
+		name = "docker-engine"
 	}
 
 	if updateMetadata {
 		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
 			return err
+		}
+	}
+
+	// handle the new docker-engine package; we can probably remove this
+	// after we have a few versions
+	if action == pkgaction.Upgrade && name == "docker-engine" {
+		// run the force remove on the existing lxc-docker package
+		// and remove the existing apt source list
+		// also re-run the get.docker.com script to properly setup
+		// the system again
+
+		commands := []string{
+			"rm /etc/apt/sources.list.d/docker.list || true",
+			"apt-get remove -y lxc-docker || true",
+			"curl -sSL https://get.docker.com | sh",
+		}
+
+		for _, cmd := range commands {
+			command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E %s", cmd)
+			if _, err := provisioner.SSHCommand(command); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -47,10 +47,9 @@ func (provisioner *UbuntuProvisioner) Service(name string, action pkgaction.Serv
 }
 
 func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.PackageAction) error {
-	var (
-		packageAction  string
-		updateMetadata = true
-	)
+	var packageAction string
+
+	updateMetadata := true
 
 	switch action {
 	case pkgaction.Install:
@@ -62,20 +61,42 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 		packageAction = "upgrade"
 	}
 
-	// TODO: This should probably have a const
 	switch name {
 	case "docker":
-		name = "lxc-docker"
+		name = "docker-engine"
 	}
 
 	if updateMetadata {
-		// issue apt-get update for metadata
-		if _, err := provisioner.SSHCommand("sudo -E apt-get update"); err != nil {
+		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
 			return err
 		}
 	}
 
+	// handle the new docker-engine package; we can probably remove this
+	// after we have a few versions
+	if action == pkgaction.Upgrade && name == "docker-engine" {
+		// run the force remove on the existing lxc-docker package
+		// and remove the existing apt source list
+		// also re-run the get.docker.com script to properly setup
+		// the system again
+
+		commands := []string{
+			"rm /etc/apt/sources.list.d/docker.list || true",
+			"apt-get remove -y lxc-docker || true",
+			"curl -sSL https://get.docker.com | sh",
+		}
+
+		for _, cmd := range commands {
+			command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E %s", cmd)
+			if _, err := provisioner.SSHCommand(command); err != nil {
+				return err
+			}
+		}
+	}
+
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+
+	log.Debugf("package: action=%s name=%s", action.String(), name)
 
 	if _, err := provisioner.SSHCommand(command); err != nil {
 		return err

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -85,7 +85,7 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 		}
 
 		for _, cmd := range commands {
-			command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E %s", cmd)
+			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
 			if _, err := provisioner.SSHCommand(command); err != nil {
 				return err
 			}

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -52,13 +52,11 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 	updateMetadata := true
 
 	switch action {
-	case pkgaction.Install:
+	case pkgaction.Install, pkgaction.Upgrade:
 		packageAction = "install"
 	case pkgaction.Remove:
 		packageAction = "remove"
 		updateMetadata = false
-	case pkgaction.Upgrade:
-		packageAction = "upgrade"
 	}
 
 	switch name {


### PR DESCRIPTION
This fixes upgrade issue with Debian / Ubuntu and Docker 1.8.

To test, you can create a host using an old install script.  Here is an example for Debian:

```
docker-machine create \
  -d digitalocean \
  --digitalocean-image debian-8-x64 \
  --engine-install-url http://docker-install.evanhazlett.com/docker-old \
  migration-test
```

Then you can upgrade with `docker-machine upgrade migration-test`.  After the upgrade you should end up with Docker 1.8.1.