### PR TITLE
Disable ssh multiplex explicitly

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -54,6 +54,8 @@ var (
 		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails
 		"-o", "ConnectTimeout=10", // timeout after 10 seconds
+		"-o", "ControlMaster=no", // disable ssh multiplexing
+		"-o", "ControlPath=no",
 	}
 	defaultClientType SSHClientType = External
 )


### PR DESCRIPTION
This PR fixes https://github.com/docker/machine/issues/1630 by disabling multiplexing