### PR TITLE
Make timeout for `ls` command configurable

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/log"
@@ -27,7 +28,9 @@ func cmdActive(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	host, err := provider.GetActive()
+	timeout := time.Duration(c.Int("timeout")) * time.Second
+
+	host, err := provider.GetActive(timeout)
 	if err != nil {
 		log.Fatalf("Error getting active host: %s", err)
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -40,6 +40,7 @@ var (
 	ErrUnknownShell       = errors.New("Error: Unknown shell")
 	ErrNoMachineSpecified = errors.New("Error: Expected to get one or more machine names as arguments.")
 	ErrExpectedOneMachine = errors.New("Error: Expected one machine name as an argument.")
+	DefaultTimeout        = 3
 )
 
 type machineConfig struct {
@@ -247,6 +248,13 @@ var Commands = []cli.Command{
 		Name:   "active",
 		Usage:  "Print which machine is active",
 		Action: cmdActive,
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "timeout",
+				Usage: "Timeout for reporting machines state (seconds)",
+				Value: DefaultTimeout,
+			},
+		},
 	},
 	{
 		Name:        "config",
@@ -324,6 +332,11 @@ var Commands = []cli.Command{
 				Name:  "filter",
 				Usage: "Filter output based on conditions provided",
 				Value: &cli.StringSlice{},
+			},
+			cli.IntFlag{
+				Name:  "timeout",
+				Usage: "Timeout for reporting machines state (seconds)",
+				Value: DefaultTimeout,
 			},
 		},
 		Name:   "ls",

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/libmachine"
@@ -61,7 +62,8 @@ func cmdLs(c *cli.Context) {
 		}
 	}
 
-	items := libmachine.GetHostListItems(hostList)
+	timeout := time.Duration(c.Int("timeout")) * time.Second
+	items := libmachine.GetHostListItems(hostList, timeout)
 
 	sortHostListItemsByName(items)
 

--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/libmachine"
@@ -118,7 +119,7 @@ func (s ScpFakeStore) Exists(name string) (bool, error) {
 	return true, nil
 }
 
-func (s ScpFakeStore) GetActive() (*libmachine.Host, error) {
+func (s ScpFakeStore) GetActive(timeout time.Duration) (*libmachine.Host, error) {
 	return nil, nil
 }
 

--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/docker/machine/log"
 	"github.com/docker/machine/utils"
@@ -119,13 +120,13 @@ func (s Filestore) Get(name string) (*Host, error) {
 	return s.loadHost(name)
 }
 
-func (s Filestore) GetActive() (*Host, error) {
+func (s Filestore) GetActive(timeout time.Duration) (*Host, error) {
 	hosts, err := s.List()
 	if err != nil {
 		return nil, err
 	}
 
-	hostListItems := GetHostListItems(hosts)
+	hostListItems := GetHostListItems(hosts, timeout)
 
 	for _, item := range hostListItems {
 		if item.Active {

--- a/libmachine/filestore_test.go
+++ b/libmachine/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "github.com/docker/machine/drivers/none"
 	"github.com/docker/machine/utils"
@@ -198,7 +199,9 @@ func TestStoreGetSetActive(t *testing.T) {
 	}
 
 	// No host set
-	host, err := store.GetActive()
+	timeout := time.Duration(3) * time.Second
+
+	host, err := store.GetActive(timeout)
 	if err == nil {
 		t.Fatal("Expected an error because there is no active host set")
 	}
@@ -224,7 +227,7 @@ func TestStoreGetSetActive(t *testing.T) {
 
 	os.Setenv("DOCKER_HOST", url)
 
-	host, err = store.GetActive()
+	host, err = store.GetActive(timeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -27,7 +27,6 @@ var (
 	validHostNameChars                = `[a-zA-Z0-9\-\.]`
 	validHostNamePattern              = regexp.MustCompile(`^` + validHostNameChars + `+$`)
 	errMachineMustBeRunningForUpgrade = errors.New("Error: machine must be running to upgrade.")
-	stateTimeoutDuration              = time.Second * 3
 )
 
 type Host struct {
@@ -421,7 +420,7 @@ func attemptGetHostState(host Host, stateQueryChan chan<- HostListItem) {
 	}
 }
 
-func getHostState(host Host, hostListItemsChan chan<- HostListItem) {
+func getHostState(host Host, hostListItemsChan chan<- HostListItem, stateTimeoutDuration time.Duration) {
 	// This channel is used to communicate the properties we are querying
 	// about the host in the case of a successful read.
 	stateQueryChan := make(chan HostListItem)
@@ -444,12 +443,12 @@ func getHostState(host Host, hostListItemsChan chan<- HostListItem) {
 	}
 }
 
-func GetHostListItems(hostList []*Host) []HostListItem {
+func GetHostListItems(hostList []*Host, stateTimeoutDuration time.Duration) []HostListItem {
 	hostListItems := []HostListItem{}
 	hostListItemsChan := make(chan HostListItem)
 
 	for _, host := range hostList {
-		go getHostState(*host, hostListItemsChan)
+		go getHostState(*host, hostListItemsChan, stateTimeoutDuration)
 	}
 
 	for _ = range hostList {

--- a/libmachine/host_test.go
+++ b/libmachine/host_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/machine/drivers/fakedriver"
 	_ "github.com/docker/machine/drivers/none"
@@ -298,9 +299,11 @@ func TestGetHostListItems(t *testing.T) {
 		"baz": state.Running,
 	}
 
+	timeout := time.Duration(3) * time.Second
+
 	items := []HostListItem{}
 	for _, host := range hosts {
-		go getHostState(host, hostListItemsChan)
+		go getHostState(host, hostListItemsChan, timeout)
 	}
 
 	for i := 0; i < len(hosts); i++ {

--- a/libmachine/provider.go
+++ b/libmachine/provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/docker/machine/drivers"
 	"github.com/docker/machine/utils"
@@ -67,8 +68,8 @@ func (provider *Provider) Exists(name string) (bool, error) {
 	return provider.store.Exists(name)
 }
 
-func (provider *Provider) GetActive() (*Host, error) {
-	return provider.store.GetActive()
+func (provider *Provider) GetActive(timeout time.Duration) (*Host, error) {
+	return provider.store.GetActive(timeout)
 }
 
 func (provider *Provider) List() ([]*Host, error) {

--- a/libmachine/store.go
+++ b/libmachine/store.go
@@ -1,10 +1,14 @@
 package libmachine
 
+import (
+	"time"
+)
+
 type Store interface {
 	// Exists returns whether a machine exists or not
 	Exists(name string) (bool, error)
 	// GetActive returns the active host
-	GetActive() (*Host, error)
+	GetActive(timeout time.Duration) (*Host, error)
 	// GetPath returns the path to the store
 	GetPath() string
 	// GetCACertPath returns the CA certificate


### PR DESCRIPTION
Fix https://github.com/docker/machine/issues/1696

A previous commit made it so machine would timeout after a set interval
of time per host. This commit makes the timeout time configurable
through a command line flag.

This required a slight architecture change. It also suggested that
perhaps `active` should have a similar timeout method because of the
amount of overlap in methods between `active` and `ls`.

* Add command-line configurable flags for timeout of `active` and `ls`
  command.

Signed-off-by: Matt McNaughton <mattjmcnaughton@gmail.com>