### PR TITLE
Proposal: support to use GitHub API token to fetch the latest version of Boot2Docker

### DIFF
--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -73,7 +73,15 @@ func NewB2dUtils(githubApiBaseUrl, githubBaseUrl string) *B2dUtils {
 func (b *B2dUtils) GetLatestBoot2DockerReleaseURL() (string, error) {
 	client := getClient()
 	apiUrl := fmt.Sprintf("%s/repos/boot2docker/boot2docker/releases", b.githubApiBaseUrl)
-	rsp, err := client.Get(apiUrl)
+	req, err := http.NewRequest("GET", apiUrl, nil)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing a GitHub API URL: %s", err)
+	}
+	token := os.Getenv("MACHINE_GITHUB_API_TOKEN")
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+	rsp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR is a proposal that temporally resolves #1483 until we find a better way to fetch the latest version of Boot2Docker.
(I really want Machine to support this kind of feature because in my workplace GitHub API rate limit is frequently exceeded 😩)

I suggest that, like Homebrew's `HOMEBREW_GITHUB_API_TOKEN`, Machine supports to use an env var such as `MACHINE_GITHUB_API_TOKEN` when calling GitHub API to fetch the latest version of Boot2Docker.

issues:
- env var or flag? (I think an implicit env var is better because this feature is used only when a host is B2D)
- what env var name / flag name?
- test

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>