### PR TITLE
`docker-machine status` should return non-0 for errors

### DIFF
--- a/commands/status.go
+++ b/commands/status.go
@@ -10,7 +10,7 @@ func cmdStatus(c *cli.Context) {
 	host := getHost(c)
 	currentState, err := host.Driver.GetState()
 	if err != nil {
-		log.Errorf("error getting state for host %s: %s", host.Name, err)
+		log.Fatal(err)
 	}
 	log.Info(currentState)
 }


### PR DESCRIPTION
Without this patch:

```
❯ docker-machine status foo
error getting state for host foo: machine does not exist
Error

❯ echo $?
0
```