### PR TITLE
commands: show "-" in ACTIVE column for inactive machines

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -66,7 +66,7 @@ func cmdLs(c *cli.Context) {
 	sortHostListItemsByName(items)
 
 	for _, item := range items {
-		activeString := ""
+		activeString := "-"
 		if item.Active {
 			activeString = "*"
 		}


### PR DESCRIPTION
close #1682 

The output is like this:

```
$ docker-machine ls
NAME            ACTIVE   DRIVER       STATE     URL                         SWARM
dev             *        virtualbox   Running   tcp://192.168.99.100:2376
swarm-master    -        virtualbox   Stopped                               swarm-master (master)
swarm-node-00   -        virtualbox   Stopped                               swarm-master
```

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>