### PR TITLE
correct digitalocean.go errors :

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -144,20 +144,23 @@ func (d *Driver) Create() error {
 	}
 
 	d.SSHKeyID = key.ID
-
+	
+    var sshKey *godo.DropletCreateSSHKey
+	sshKey = &godo.DropletCreateSSHKey{ID: d.SSHKeyID}
+	
 	log.Infof("Creating Digital Ocean droplet...")
 
 	client := d.getClient()
 
 	createRequest := &godo.DropletCreateRequest{
-		Image:             d.Image,
+		Image:             godo.DropletCreateImage{Slug: "digitalocean-image"},
 		Name:              d.MachineName,
 		Region:            d.Region,
 		Size:              d.Size,
 		IPv6:              d.IPv6,
 		PrivateNetworking: d.PrivateNetworking,
 		Backups:           d.Backups,
-		SSHKeys:           []interface{}{d.SSHKeyID},
+		SSHKeys:           []godo.DropletCreateSSHKey{*sshKey},
 	}
 
 	newDroplet, _, err := client.Droplets.Create(createRequest)
@@ -165,14 +168,15 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	d.DropletID = newDroplet.Droplet.ID
+	d.DropletID = newDroplet.ID
+		
+	droplets, _, err := client.Droplets.List(nil)
+	if err != nil {
+		return err
+	}
 
-	for {
-		newDroplet, _, err = client.Droplets.Get(d.DropletID)
-		if err != nil {
-			return err
-		}
-		for _, network := range newDroplet.Droplet.Networks.V4 {
+	for _, n := range droplets{
+		for _, network := range n.Networks.V4 {
 			if network.Type == "public" {
 				d.IPAddress = network.IPAddress
 			}
@@ -186,7 +190,7 @@ func (d *Driver) Create() error {
 	}
 
 	log.Debugf("Created droplet ID %d, IP address %s",
-		newDroplet.Droplet.ID,
+		newDroplet.ID,
 		d.IPAddress)
 
 	return nil
@@ -235,7 +239,7 @@ func (d *Driver) GetState() (state.State, error) {
 	if err != nil {
 		return state.Error, err
 	}
-	switch droplet.Droplet.Status {
+	switch droplet.Status {
 	case "new":
 		return state.Starting, nil
 	case "active":


### PR DESCRIPTION
machine/drivers/digitalocean/digitalocean.go:153: cannot use d.Image (type string) as type godo.DropletCreateImage in field value

machine/drivers/digitalocean/digitalocean.go:160: cannot use []interface {} literal (type []interface {}) as type []godo.DropletCreateSSHKey in field value

machine/driver/digitalocean/digitalocean.go:168: newDroplet.Droplet undefined (type * godo.Droplet has no field or method Droplet)

machine/driver/digitalocean/digitalocean.go:175: newDroplet.Droplet undefined (type * godo.Droplet has no field or method Droplet)

machine/driver/digitalocean/digitalocean.go:189: newDroplet.Droplet undefined (type * godo.Droplet has no field or method Droplet)

machine/driver/digitalocean/digitalocean.go:238: newDroplet.Droplet undefined (type * godo.Droplet has no field or method Droplet)