### PR TITLE
Remove redundent assignment to InsecureSkipVerify

### DIFF
--- a/utils/certs.go
+++ b/utils/certs.go
@@ -27,9 +27,6 @@ func getTLSConfig(caCert, cert, key []byte, allowInsecure bool) (*tls.Config, er
 		return &tlsConfig, err
 	}
 	tlsConfig.Certificates = []tls.Certificate{keypair}
-	if allowInsecure {
-		tlsConfig.InsecureSkipVerify = true
-	}
 
 	return &tlsConfig, nil
 }


### PR DESCRIPTION
This second codepath is redundent, since tlsConfig.InsecureSkipVerify is
assigned to earlier in that function body. In addition, there's no need
to wrap the assignment in a check on that boolean value in this case.

Signed-off-by: Paul Tagliamonte <paultag@gmail.com>