### PR TITLE
Disabled load PowerShell profile when start the powershell.exe

### DIFF
--- a/drivers/hyperv/powershell_windows.go
+++ b/drivers/hyperv/powershell_windows.go
@@ -24,6 +24,7 @@ func init() {
 }
 
 func execute(args []string) (string, error) {
+	args = append([]string{"-NoProfile"}, args...)
 	cmd := exec.Command(powershell, args...)
 	log.Debugf("[executing ==>] : %v %v", powershell, strings.Join(args, " "))
 	var stdout bytes.Buffer


### PR DESCRIPTION
To manage Hyper-V hyperv driver uses Powershell cmdlets. After the call the cmdlet hyperv driver expects in stdout to receive from it the answer (for example see function hypervAvailable() from drivers/hyperv/powershell_windows.go). 
Powershell first executes all the scripts from the user profile and then the cmdlet. Scripts from the user profile can have any output to stdout and break the parser driver hyperv. I added the flag "-NoProfile" for powershell.exe that disables scripts from the user profile (details http://www.powertheshell.com/bp_noprofile/).