### PR TITLE
cleanup log.*ln and correct typos error 

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -92,10 +92,6 @@ func newProvider(store libmachine.Store) (*libmachine.Provider, error) {
 	return libmachine.New(store)
 }
 
-func getMachineDir(rootPath string) string {
-	return filepath.Join(rootPath, "machines")
-}
-
 func getDefaultStore(rootPath, caCertPath, privateKeyPath string) (libmachine.Store, error) {
 	return libmachine.NewFilestore(
 		rootPath,
@@ -462,7 +458,7 @@ func runActionForeachMachine(actionName string, machines []*libmachine.Host) {
 		serialChan := make(chan error)
 		go machineCommand(actionName, machine, serialChan)
 		if err := <-serialChan; err != nil {
-			log.Errorln(err)
+			log.Error(err)
 		}
 		close(serialChan)
 	}
@@ -472,7 +468,7 @@ func runActionForeachMachine(actionName string, machines []*libmachine.Host) {
 	// rate limit us.
 	for i := 0; i < numConcurrentActions; i++ {
 		if err := <-errorChan; err != nil {
-			log.Errorln(err)
+			log.Error(err)
 		}
 	}
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -9,9 +9,6 @@ import (
 	"github.com/docker/machine/drivers/fakedriver"
 	_ "github.com/docker/machine/drivers/none"
 	"github.com/docker/machine/libmachine"
-	"github.com/docker/machine/libmachine/auth"
-	"github.com/docker/machine/libmachine/engine"
-	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/state"
 )
 
@@ -72,36 +69,6 @@ func getTestDriverFlags() *DriverOptionsMock {
 		},
 	}
 	return flags
-}
-
-func getDefaultTestHost() (*libmachine.Host, error) {
-	engineOptions := &engine.EngineOptions{}
-	swarmOptions := &swarm.SwarmOptions{
-		Master:    false,
-		Host:      "",
-		Discovery: "",
-		Address:   "",
-	}
-	authOptions := &auth.AuthOptions{
-		CaCertPath:     hostTestCaCert,
-		PrivateKeyPath: hostTestPrivateKey,
-	}
-	hostOptions := &libmachine.HostOptions{
-		EngineOptions: engineOptions,
-		SwarmOptions:  swarmOptions,
-		AuthOptions:   authOptions,
-	}
-	host, err := libmachine.NewHost(hostTestName, hostTestDriverName, hostOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	flags := getTestDriverFlags()
-	if err := host.Driver.SetConfigFromFlags(flags); err != nil {
-		return nil, err
-	}
-
-	return host, nil
 }
 
 type DriverOptionsMock struct {

--- a/commands/config.go
+++ b/commands/config.go
@@ -43,7 +43,7 @@ func cmdConfig(c *cli.Context) {
 		mParts := strings.Split(mUrl.Host, ":")
 		machineIp := mParts[0]
 
-		dockerHost = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
+		dockerHost = fmt.Sprintf("tcp://%s:%s\n", machineIp, swarmPort)
 	}
 
 	log.Debug(dockerHost)
@@ -74,6 +74,6 @@ func cmdConfig(c *cli.Context) {
 		}
 	}
 
-	fmt.Printf("--tlsverify --tlscacert=%q --tlscert=%q --tlskey=%q -H=%s",
+	fmt.Printf("--tlsverify --tlscacert=%q --tlscert=%q --tlskey=%q -H=%s\n",
 		cfg.caCertPath, cfg.clientCertPath, cfg.clientKeyPath, dockerHost)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Why the interface?  We may only want to print to STDOUT and STDERR for now,
-// but it won't neccessarily be that way forever.  This interface is intended
+// but it won't necessarily be that way forever.  This interface is intended
 // to provide a "framework" for a variety of different logging types in the
 // future (log to file, log to logstash, etc.) There could be a driver model
 // similar to what is done with OS or machine providers.
@@ -17,11 +17,9 @@ type Logger interface {
 
 	Error(...interface{})
 	Errorf(string, ...interface{})
-	Errorln(...interface{})
 
 	Info(...interface{})
 	Infof(string, ...interface{})
-	Infoln(...interface{})
 
 	Fatal(...interface{})
 	Fatalf(string, ...interface{})
@@ -72,20 +70,12 @@ func Errorf(fmtString string, args ...interface{}) {
 	l.Errorf(fmtString, args...)
 }
 
-func Errorln(args ...interface{}) {
-	l.Errorln(args...)
-}
-
 func Info(args ...interface{}) {
 	l.Info(args...)
 }
 
 func Infof(fmtString string, args ...interface{}) {
 	l.Infof(fmtString, args...)
-}
-
-func Infoln(args ...interface{}) {
-	l.Infoln(args...)
 }
 
 func Fatal(args ...interface{}) {

--- a/log/terminal.go
+++ b/log/terminal.go
@@ -55,20 +55,12 @@ func (t TerminalLogger) Errorf(fmtString string, args ...interface{}) {
 	t.errf(fmtString, args...)
 }
 
-func (t TerminalLogger) Errorln(args ...interface{}) {
-	t.err(args...)
-}
-
 func (t TerminalLogger) Info(args ...interface{}) {
 	t.log(args...)
 }
 
 func (t TerminalLogger) Infof(fmtString string, args ...interface{}) {
 	t.logf(fmtString, args...)
-}
-
-func (t TerminalLogger) Infoln(args ...interface{}) {
-	t.log(args...)
 }
 
 func (t TerminalLogger) Fatal(args ...interface{}) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -160,7 +160,7 @@ func GenerateRandomID() string {
 		}
 		value := hex.EncodeToString(id)
 		// if we try to parse the truncated for as an int and we don't have
-		// an error then the value is all numberic and causes issues when
+		// an error then the value is all numeric and causes issues when
 		// used as a hostname. ref #3869
 		if _, err := strconv.ParseInt(TruncateID(value), 10, 64); err == nil {
 			continue


### PR DESCRIPTION
1. cleanup log.*ln for #1081
2. add "\n" to config command
3. typos error

Signed-off-by: Xiaohui Liu <xiaohui.liu@ucloud.cn>