### PR TITLE
change debug env var to MACHINE_DEBUG

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -661,7 +661,7 @@ func createDiskImage(dest string, size int, r io.Reader) error {
 	cmd := exec.Command(vboxManageCmd, "convertfromraw", "stdin", dest,
 		fmt.Sprintf("%d", sizeBytes), "--format", "VMDK")
 
-	if os.Getenv("DEBUG") != "" {
+	if os.Getenv("MACHINE_DEBUG") != "" {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}

--- a/drivers/vmwarefusion/vmrun_darwin.go
+++ b/drivers/vmwarefusion/vmrun_darwin.go
@@ -28,7 +28,7 @@ var (
 
 func vmrun(args ...string) (string, string, error) {
 	cmd := exec.Command(vmrunbin, args...)
-	if os.Getenv("DEBUG") != "" {
+	if os.Getenv("MACHINE_DEBUG") != "" {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}
@@ -51,7 +51,7 @@ func vmrun(args ...string) (string, string, error) {
 // Make a vmdk disk image with the given size (in MB).
 func vdiskmanager(dest string, size int) error {
 	cmd := exec.Command(vdiskmanbin, "-c", "-t", "0", "-s", fmt.Sprintf("%dMB", size), "-a", "lsilogic", dest)
-	if os.Getenv("DEBUG") != "" {
+	if os.Getenv("MACHINE_DEBUG") != "" {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -42,11 +42,11 @@ var (
 // TODO: I think this is superflous and can be replaced by one check for if
 // debug is on that sets a variable in this module.
 func isDebug() bool {
-	debugEnv := os.Getenv("DEBUG")
+	debugEnv := os.Getenv("MACHINE_DEBUG")
 	if debugEnv != "" {
 		showDebug, err := strconv.ParseBool(debugEnv)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error parsing boolean value from DEBUG: %s", err)
+			fmt.Fprintln(os.Stderr, "Error parsing boolean value from MACHINE_DEBUG: %s", err)
 			os.Exit(1)
 		}
 		return showDebug

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ Options:
 func main() {
 	for _, f := range os.Args {
 		if f == "-D" || f == "--debug" || f == "-debug" {
-			os.Setenv("DEBUG", "1")
+			os.Setenv("MACHINE_DEBUG", "1")
 		}
 	}
 


### PR DESCRIPTION
This changes the debug environment variable detection to use `MACHINE_DEBUG` instead of `DEBUG`.  `DEBUG` is a bit vague and can be used in other things.