### PR TITLE
Simple networking and authentication

### DIFF
--- a/drivers/vmwarevsphere/vc_conn.go
+++ b/drivers/vmwarevsphere/vc_conn.go
@@ -215,6 +215,7 @@ func (conn VcConn) VMDiskCreate() error {
 }
 
 func (conn VcConn) VMAttachNetwork() error {
+	/*
 	args := []string{"vm.network.add"}
 	args = conn.AppendConnectionString(args)
 	args = append(args, fmt.Sprintf("--dc=%s", conn.driver.Datacenter))
@@ -226,6 +227,8 @@ func (conn VcConn) VMAttachNetwork() error {
 		return nil
 	}
 	return errors.NewVMError("add network", conn.driver.MachineName, stderr)
+	*/
+	return nil
 }
 
 func (conn VcConn) VMFetchIP() (string, error) {

--- a/drivers/vmwarevsphere/vc_conn.go
+++ b/drivers/vmwarevsphere/vc_conn.go
@@ -215,7 +215,6 @@ func (conn VcConn) VMDiskCreate() error {
 }
 
 func (conn VcConn) VMAttachNetwork() error {
-	/*
 	args := []string{"vm.network.add"}
 	args = conn.AppendConnectionString(args)
 	args = append(args, fmt.Sprintf("--dc=%s", conn.driver.Datacenter))
@@ -227,8 +226,6 @@ func (conn VcConn) VMAttachNetwork() error {
 		return nil
 	}
 	return errors.NewVMError("add network", conn.driver.MachineName, stderr)
-	*/
-	return nil
 }
 
 func (conn VcConn) VMFetchIP() (string, error) {

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -400,12 +400,14 @@ func (d *Driver) checkVsphereConfig() error {
 	if d.IP == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere IP")
 	}
+	/*
 	if d.Username == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere username")
 	}
 	if d.Password == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere password")
 	}
+	*/
 	if d.Network == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere network")
 	}

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -260,9 +260,11 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+/*
 	if err := vcConn.VMAttachNetwork(); err != nil {
 		return err
 	}
+*/
 
 	if err := d.Start(); err != nil {
 		return err


### PR DESCRIPTION
There is no need for two ethernet cards, both connected to the very same network on ESXi/vsphere.
Also it's possible to pass the govc credentials via GOVC_ environment variables hence vsphere username and passwords are not mandatory.