### PR TITLE
Credentials and server can be passed in GOVC_ environment variables.

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -395,15 +395,6 @@ func (d *Driver) publicSSHKeyPath() string {
 }
 
 func (d *Driver) checkVsphereConfig() error {
-	if d.IP == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere IP")
-	}
-	if d.Username == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere username")
-	}
-	if d.Password == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere password")
-	}
 	if d.Network == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere network")
 	}


### PR DESCRIPTION
vsphere/ESXi server IP and credentials are not mandatory on command line as long as they are set in GOVC_ env variables.