### PR TITLE
New create flag --google-use-internal-ip

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codegangsta/cli"
 	"github.com/docker/machine/log"
 	"github.com/docker/machine/ssh"
 	raw "google.golang.org/api/compute/v1"

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/codegangsta/cli"
 	"github.com/docker/machine/log"
 	"github.com/docker/machine/ssh"
 	raw "google.golang.org/api/compute/v1"
@@ -22,6 +23,7 @@ type ComputeUtil struct {
 	diskTypeURL   string
 	address       string
 	preemptible   bool
+	UseInternalIp bool
 	service       *raw.Service
 	zoneURL       string
 	authTokenPath string
@@ -56,6 +58,7 @@ func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 		diskTypeURL:   driver.DiskType,
 		address:       driver.Address,
 		preemptible:   driver.Preemptible,
+		UseInternalIp: driver.UseInternalIp,
 		service:       service,
 		zoneURL:       apiURL + driver.Project + "/zones/" + driver.Zone,
 		globalURL:     apiURL + driver.Project + "/global",
@@ -344,7 +347,11 @@ func (c *ComputeUtil) ip() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		if c.UseInternalIp {
+			c.ipAddress = instance.NetworkInterfaces[0].NetworkIP
+		} else {
+			c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		}
 	}
 	return c.ipAddress, nil
 }

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -202,11 +202,15 @@ func (d *Driver) GetURL() (string, error) {
 
 // GetIP returns the IP address of the GCE instance.
 func (d *Driver) GetIP() (string, error) {
-	c, err := newComputeUtil(d)
-	if err != nil {
-		return "", err
+	if d.IPAddress == "" {
+		c, err := newComputeUtil(d)
+		if err != nil {
+			return "", err
+		}
+		return c.ip()
+	} else {
+		return d.IPAddress, nil
 	}
-	return c.ip()
 }
 
 // GetState returns a docker.hosts.state.State value representing the current state of the host.

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -172,7 +172,22 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	return c.createInstance(d)
+	// create instance
+	if err := c.createInstance(d); err != nil {
+		return err
+	}
+
+	if !c.UseInternalIp {
+		return nil
+	}
+
+	ip, err := c.ip()
+
+	// remember the internal IP
+	if err != nil {
+		d.IPAddress = ip
+	}
+	return err
 }
 
 // GetURL returns the URL of the remote docker daemon.

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -18,6 +18,7 @@ type Driver struct {
 	DiskType      string
 	Address       string
 	Preemptible   bool
+	UseInternalIp bool
 	Scopes        string
 	DiskSize      int
 	AuthTokenPath string
@@ -91,6 +92,11 @@ func GetCreateFlags() []cli.Flag {
 			Usage:  "GCE Instance Preemptibility",
 			EnvVar: "GOOGLE_PREEMPTIBLE",
 		},
+		cli.BoolFlag{
+			Name:   "google-use-internal-ip",
+			Usage:  "Use internal GCE Instance IP rather than public one",
+			EnvVar: "GOOGLE_USE_INTERNAL_IP",
+		},
 	}
 }
 
@@ -125,6 +131,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.DiskType = flags.String("google-disk-type")
 	d.Address = flags.String("google-address")
 	d.Preemptible = flags.Bool("google-preemptible")
+	d.UseInternalIp = flags.Bool("google-use-internal-ip")
 	d.AuthTokenPath = flags.String("google-auth-token")
 	d.Project = flags.String("google-project")
 	d.Scopes = flags.String("google-scopes")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -395,15 +395,6 @@ func (d *Driver) publicSSHKeyPath() string {
 }
 
 func (d *Driver) checkVsphereConfig() error {
-	if d.IP == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere IP")
-	}
-	if d.Username == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere username")
-	}
-	if d.Password == "" {
-		return errors.NewIncompleteVsphereConfigError("vSphere password")
-	}
 	if d.Network == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere network")
 	}

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -395,6 +395,15 @@ func (d *Driver) publicSSHKeyPath() string {
 }
 
 func (d *Driver) checkVsphereConfig() error {
+	if d.IP == "" {
+		return errors.NewIncompleteVsphereConfigError("vSphere IP")
+	}
+	if d.Username == "" {
+		return errors.NewIncompleteVsphereConfigError("vSphere username")
+	}
+	if d.Password == "" {
+		return errors.NewIncompleteVsphereConfigError("vSphere password")
+	}
 	if d.Network == "" {
 		return errors.NewIncompleteVsphereConfigError("vSphere network")
 	}


### PR DESCRIPTION
Introduces the new flag for google driver:
`--google-use-internal-ip`

When invoked while `create` it will make `docker-machine` use static (internal) rather than ephemeral (public, NATed) IPs.
It's very useful if you manage machines from within the same network. It's faster, simpler and makes deploying e.g. swarm much simpler as one do not have to configure firewall even when swarm is managed from within the same network. The flag is persistent in the sense that a machine created with it retains the IP with its configuration.