### PR TITLE
New option for create: --google-use-internal-ip

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -22,6 +22,7 @@ type ComputeUtil struct {
 	diskTypeURL   string
 	address       string
 	preemptible   bool
+	UseInternalIp bool
 	service       *raw.Service
 	zoneURL       string
 	authTokenPath string
@@ -56,6 +57,7 @@ func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 		diskTypeURL:   driver.DiskType,
 		address:       driver.Address,
 		preemptible:   driver.Preemptible,
+		UseInternalIp: driver.UseInternalIp,
 		service:       service,
 		zoneURL:       apiURL + driver.Project + "/zones/" + driver.Zone,
 		globalURL:     apiURL + driver.Project + "/global",
@@ -344,7 +346,11 @@ func (c *ComputeUtil) ip() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		if c.UseInternalIp {
+			c.ipAddress = instance.NetworkInterfaces[0].NetworkIP
+		} else {
+			c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		}
 	}
 	return c.ipAddress, nil
 }


### PR DESCRIPTION
Introduced a new flag for google driver:
`--google-use-internal-ip`

When invoked while `create` it will make docker-machine use internal rather than public NATed IPs.
It's very useful if you manage machines from within the same network. It's faster, simpler and make deploying e.g. swarm much easier as one do not have to configure firewall even when swarm is managed from within the same network. The flag is persistent in the sense that a machine created with it retains the IP.