### PR TITLE
Fix Go Vet errors

### DIFF
--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -176,7 +176,7 @@ func TestGetInfoForScpArg(t *testing.T) {
 
 	host, path, opts, err = getInfoForScpArg("myfunhost:/home/docker/foo", *provider)
 	if err != nil {
-		t.Fatal("Unexpected error in machine-based getInfoForScpArg call: %s", err)
+		t.Fatalf("Unexpected error in machine-based getInfoForScpArg call: %s", err)
 	}
 	expectedOpts := []string{
 		"-i",
@@ -188,7 +188,7 @@ func TestGetInfoForScpArg(t *testing.T) {
 		}
 	}
 	if host.Name != "myfunhost" {
-		t.Fatal("Expected host.Name to be myfunhost, got %s", host.Name)
+		t.Fatalf("Expected host.Name to be myfunhost, got %s", host.Name)
 	}
 	if path != "/home/docker/foo" {
 		t.Fatalf("Expected path to be /home/docker/foo, got %s", path)

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -447,7 +447,6 @@ func (d *Driver) GetState() (state.State, error) {
 	default:
 		return state.Error, nil
 	}
-	return state.None, nil
 }
 
 // GetSSHHostname -

--- a/libmachine/provision/os_release_test.go
+++ b/libmachine/provision/os_release_test.go
@@ -52,7 +52,7 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 
 	osr, err := NewOsRelease(ubuntuTrusty)
 	if err != nil {
-		t.Fatal("Unexpected error parsing os release: %s", err)
+		t.Fatalf("Unexpected error parsing os release: %s", err)
 	}
 
 	expectedOsr := OsRelease{
@@ -74,7 +74,7 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 
 	osr, err = NewOsRelease(gentoo)
 	if err != nil {
-		t.Fatal("Unexpected error parsing os release: %s", err)
+		t.Fatalf("Unexpected error parsing os release: %s", err)
 	}
 
 	expectedOsr = OsRelease{
@@ -96,7 +96,7 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 
 	osr, err = NewOsRelease(noPrettyName)
 	if err != nil {
-		t.Fatal("Unexpected error parsing os release: %s", err)
+		t.Fatalf("Unexpected error parsing os release: %s", err)
 	}
 
 	expectedOsr = OsRelease{
@@ -118,7 +118,7 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 
 	osr, err = NewOsRelease(centos)
 	if err != nil {
-		t.Fatal("Unexpected error parsing os release: %s", err)
+		t.Fatalf("Unexpected error parsing os release: %s", err)
 	}
 
 	expectedOsr = OsRelease{
@@ -172,8 +172,8 @@ func TestParseLine(t *testing.T) {
 	}
 	key, val, err = parseLine(blank)
 	if key != "" || val != "" {
-		t.Fatal("Expected empty response on parseLine, got key: %s val: %s", key, val)
+		t.Fatalf("Expected empty response on parseLine, got key: %s val: %s", key, val)
 	} else if err != nil {
-		t.Fatal("Expected nil err response on parseLine, got %s", err)
+		t.Fatalf("Expected nil err response on parseLine, got %s", err)
 	}
 }

--- a/libmachine/provision/pkgaction/action_test.go
+++ b/libmachine/provision/pkgaction/action_test.go
@@ -4,6 +4,6 @@ import "testing"
 
 func TestActionValue(t *testing.T) {
 	if Install.String() != "install" {
-		t.Fatal("Expected %q but got %q", "install", Install.String())
+		t.Fatalf("Expected %q but got %q", "install", Install.String())
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -46,7 +46,7 @@ func isDebug() bool {
 	if debugEnv != "" {
 		showDebug, err := strconv.ParseBool(debugEnv)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error parsing boolean value from MACHINE_DEBUG: %s", err)
+			fmt.Fprintf(os.Stderr, "Error parsing boolean value from MACHINE_DEBUG: %s\n", err)
 			os.Exit(1)
 		}
 		return showDebug


### PR DESCRIPTION
This commit makes no changes to code execution, but rather resolves some
`go vet` errors, the majority of which relate to `fatal` being used
instead of `fatalf` during testing.

This request partially resolves the errors listed in https://github.com/docker/machine/issues/1849.