### PR TITLE
support github enterprise urls for b2d downloads

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -149,7 +149,7 @@ func (d *Driver) Create() error {
 
 	d.setMachineNameIfNotSet()
 
-	b2dutils := mcnutils.NewB2dUtils("", "", d.StorePath)
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
 	if err := b2dutils.CopyIsoToMachineDir(d.boot2DockerURL, d.MachineName); err != nil {
 		return err
 	}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -223,7 +223,7 @@ func (d *Driver) IsVTXDisabledInTheVM() (bool, error) {
 }
 
 func (d *Driver) Create() error {
-	b2dutils := mcnutils.NewB2dUtils("", "", d.StorePath)
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
 	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
 		return err
 	}

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -203,7 +203,7 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) Create() error {
-	b2dutils := mcnutils.NewB2dUtils("", "", d.StorePath)
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
 	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
 		return err
 	}

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -226,7 +226,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	b2dutils := mcnutils.NewB2dUtils("", "", d.StorePath)
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
 	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
 		return err
 	}

--- a/libmachine/mcnutils/b2d_test.go
+++ b/libmachine/mcnutils/b2d_test.go
@@ -16,15 +16,15 @@ func TestGetLatestBoot2DockerReleaseUrl(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	b := NewB2dUtils(ts.URL, ts.URL, "/tmp/isos")
-	isoUrl, err := b.GetLatestBoot2DockerReleaseURL()
+	b := NewB2dUtils("/tmp/isos")
+	isoUrl, err := b.GetLatestBoot2DockerReleaseURL(ts.URL + "/repos/org/repo/releases")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expectedUrl := fmt.Sprintf("%s/boot2docker/boot2docker/releases/download/0.1/boot2docker.iso", ts.URL)
+	expectedUrl := fmt.Sprintf("%s/org/repo/releases/download/0.1/boot2docker.iso", ts.URL)
 	if isoUrl != expectedUrl {
-		t.Fatalf("expected url %s; received %s", isoUrl, expectedUrl)
+		t.Fatalf("expected url %s; received %s", expectedUrl, isoUrl)
 	}
 }
 
@@ -42,7 +42,7 @@ func TestDownloadIso(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewB2dUtils(ts.URL, ts.URL, "/tmp/artifacts")
+	b := NewB2dUtils("/tmp/artifacts")
 	if err := b.DownloadISO(tmpDir, filename, ts.URL); err != nil {
 		t.Fatal(err)
 	}
@@ -59,8 +59,8 @@ func TestDownloadIso(t *testing.T) {
 
 func TestGetReleasesRequestNoToken(t *testing.T) {
 	GithubApiToken = ""
-	b2d := NewB2dUtils("", "", "/tmp/store")
-	req, err := b2d.getReleasesRequest()
+	b2d := NewB2dUtils("/tmp/store")
+	req, err := b2d.getReleasesRequest("http://some.github.api")
 	if err != nil {
 		t.Fatal("Expected err to be nil, got ", err)
 	}
@@ -73,9 +73,9 @@ func TestGetReleasesRequestNoToken(t *testing.T) {
 func TestGetReleasesRequest(t *testing.T) {
 	expectedToken := "CATBUG"
 	GithubApiToken = expectedToken
-	b2d := NewB2dUtils("", "", "/tmp/store")
+	b2d := NewB2dUtils("/tmp/store")
 
-	req, err := b2d.getReleasesRequest()
+	req, err := b2d.getReleasesRequest("http://some.github.api")
 	if err != nil {
 		t.Fatal("Expected err to be nil, got ", err)
 	}

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -70,11 +70,11 @@ func (provisioner *Boot2DockerProvisioner) upgradeIso() error {
 	// TODO: Ideally, we should not read from mcndirs directory at all.
 	// The driver should be able to communicate how and where to place the
 	// relevant files.
-	b2dutils := mcnutils.NewB2dUtils("", "", mcndirs.GetBaseDir())
+	b2dutils := mcnutils.NewB2dUtils(mcndirs.GetBaseDir())
 
 	// Usually we call this implicitly, but call it here explicitly to get
 	// the latest boot2docker ISO.
-	if err := b2dutils.DownloadLatestBoot2Docker(); err != nil {
+	if err := b2dutils.DownloadLatestBoot2Docker(""); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -180,7 +180,7 @@ func (provisioner *RancherProvisioner) upgradeIso() error {
 	// TODO: Ideally, we should not read from mcndirs directory at all.
 	// The driver should be able to communicate how and where to place the
 	// relevant files.
-	b2dutils := mcnutils.NewB2dUtils("", "", mcndirs.GetBaseDir())
+	b2dutils := mcnutils.NewB2dUtils(mcndirs.GetBaseDir())
 
 	url, err := provisioner.getLatestISOURL()
 	if err != nil {


### PR DESCRIPTION
This commit allows downloading boot2docker releases not only from the official releases url (https://api.github.com/repos/boot2docker/boot2docker/releases) but from arbitrary github repositories that publish releases with a boot2docker.iso artifact. It also supports downloading from github enterprise installations.