### PR TITLE
Add argument assertions to inspect/status/url commands

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -23,6 +23,11 @@ var funcMap = template.FuncMap{
 }
 
 func cmdInspect(c *cli.Context) {
+	if len(c.Args()) == 0 {
+		cli.ShowCommandHelp(c, "inspect")
+		log.Fatal("You must specify a machine name")
+	}
+
 	tmplString := c.String("format")
 	if tmplString != "" {
 		var tmpl *template.Template

--- a/commands/status.go
+++ b/commands/status.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
-	"github.com/docker/machine/libmachine/log"
-
 	"github.com/codegangsta/cli"
+	"github.com/docker/machine/libmachine/log"
 )
 
 func cmdStatus(c *cli.Context) {
+	if len(c.Args()) != 1 {
+		log.Fatal(ErrExpectedOneMachine)
+	}
 	host := getFirstArgHost(c)
 	currentState, err := host.Driver.GetState()
 	if err != nil {

--- a/commands/url.go
+++ b/commands/url.go
@@ -3,12 +3,14 @@ package commands
 import (
 	"fmt"
 
-	"github.com/docker/machine/libmachine/log"
-
 	"github.com/codegangsta/cli"
+	"github.com/docker/machine/libmachine/log"
 )
 
 func cmdUrl(c *cli.Context) {
+	if len(c.Args()) != 1 {
+		log.Fatal(ErrExpectedOneMachine)
+	}
 	url, err := getFirstArgHost(c).GetURL()
 	if err != nil {
 		log.Fatal(err)

--- a/test/integration/cli/inspect.bats
+++ b/test/integration/cli/inspect.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+@test "inspect: show error in case of no args" {
+  run machine inspect
+  [ "$status" -eq 1 ]
+  [[ ${output} == *"must specify a machine name"* ]]
+}

--- a/test/integration/cli/status.bats
+++ b/test/integration/cli/status.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+@test "status: show error in case of no args" {
+  run machine inspect
+  [ "$status" -eq 1 ]
+  [[ ${output} == *"must specify a machine name"* ]]
+}

--- a/test/integration/cli/url.bats
+++ b/test/integration/cli/url.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+@test "url: show error in case of no args" {
+  run machine inspect
+  [ "$status" -eq 1 ]
+  [[ ${output} == *"must specify a machine name"* ]]
+}


### PR DESCRIPTION
Add assertions for no-argument case on `inspect`, `status` and `url` commands to fix unkind messages.

Current message is:
```
$ docker-machine status
unable to load host: open /Users/user/.docker/machine/machines/config.json: no such file or directory
```

To be fixed like:
```
$ docker-machine status
Error: Expected one machine name as an argument.
```

-----
os: OSX Yosemite 10.10.5
docker-machine version: 0.4.1 (e2c88d6)