### PR TITLE
Issue #1867 improve detectShell for windows

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -659,19 +659,16 @@ func getCertPathInfo(c *cli.Context) libmachine.CertPathInfo {
 }
 
 func detectShell() (string, error) {
-	// check for windows env and not bash (i.e. msysgit, etc)
-	// the SHELL env var is not set for processes in msysgit; we check
-	// for TERM instead
-	if runtime.GOOS == "windows" && os.Getenv("TERM") != "cygwin" {
-		log.Printf("On Windows, please specify either 'cmd' or 'powershell' with the --shell flag.\n\n")
-		return "", ErrUnknownShell
-	}
-
 	// attempt to get the SHELL env var
 	shell := filepath.Base(os.Getenv("SHELL"))
 
 	log.Debugf("shell: %s", shell)
 	if shell == "" {
+		// check for windows env and not bash (i.e. msysgit, etc)
+		if runtime.GOOS == "windows" {
+			log.Printf("On Windows, please specify either 'cmd' or 'powershell' with the --shell flag.\n\n")
+		}
+
 		return "", ErrUnknownShell
 	}
 


### PR DESCRIPTION
newer versions of git bash use mintty which doesn't set TERM=cygwin but
does set SHELL appropriately