### PR TITLE
New option for create: --google-use-internal-ip

### DIFF
--- a/docs/drivers/gce.md
+++ b/docs/drivers/gce.md
@@ -51,6 +51,7 @@ $ docker-machine create --driver google \
  - `--google-address`: Instance's static external IP (name or IP).
  - `--google-preemptible`: Instance preemptibility.
  - `--google-tags`: Instance tags (comma-separated).
+ - `--google-use-internal-ip`: When this option is used during create it will make docker-machine use internal rather than public NATed IPs. The flag is persistent in the sense that a machine created with it retains the IP. It's useful for managing docker machines from another machine on the same network e.g. while deploying swarm.
 
 The GCE driver will use the `ubuntu-1404-trusty-v20150909a` instance image unless otherwise specified. To obtain a
 list of image URLs run:
@@ -60,16 +61,17 @@ gcloud compute images list --uri
 
 Environment variables and default values:
 
-| CLI option                | Environment variable  | Default                              |
-|---------------------------|-----------------------|--------------------------------------|
-| **`--google-project`**    | `GOOGLE_PROJECT`      | -                                    |
-| `--google-zone`           | `GOOGLE_ZONE`         | `us-central1-a`                      |
-| `--google-machine-type`   | `GOOGLE_MACHINE_TYPE` | `n1-standard-1`                      |
-| `--google-machine-image`  | `GOOGLE_MACHINE_IMAGE`| `ubuntu-1404-trusty-v20150909a`      |
-| `--google-username`       | `GOOGLE_USERNAME`     | `docker-user`                        |
-| `--google-scopes`         | `GOOGLE_SCOPES`       | `devstorage.read_only,logging.write` |
-| `--google-disk-size`      | `GOOGLE_DISK_SIZE`    | `10`                                 |
-| `--google-disk-type`      | `GOOGLE_DISK_TYPE`    | `pd-standard`                        |
-| `--google-address`        | `GOOGLE_ADDRESS`      | -                                    |
-| `--google-preemptible`    | `GOOGLE_PREEMPTIBLE`  | -                                    |
-| `--google-tags`           | `GOOGLE_TAGS`         | -                                    |
+| CLI option                 | Environment variable     | Default                              |
+|----------------------------|--------------------------|--------------------------------------|
+| **`--google-project`**     | `GOOGLE_PROJECT`         | -                                    |
+| `--google-zone`            | `GOOGLE_ZONE`            | `us-central1-a`                      |
+| `--google-machine-type`    | `GOOGLE_MACHINE_TYPE`    | `f1-standard-1`                      |
+| `--google-machine-image`   | `GOOGLE_MACHINE_IMAGE`   | `ubuntu-1404-trusty-v20150909a`      |
+| `--google-username`        | `GOOGLE_USERNAME`        | `docker-user`                        |
+| `--google-scopes`          | `GOOGLE_SCOPES`          | `devstorage.read_only,logging.write` |
+| `--google-disk-size`       | `GOOGLE_DISK_SIZE`       | `10`                                 |
+| `--google-disk-type`       | `GOOGLE_DISK_TYPE`       | `pd-standard`                        |
+| `--google-address`         | `GOOGLE_ADDRESS`         | -                                    |
+| `--google-preemptible`     | `GOOGLE_PREEMPTIBLE`     | -                                    |
+| `--google-tags`            | `GOOGLE_TAGS`            | -                                    |
+| `--google-use-internal-ip` | `GOOGLE_USE_INTERNAL_IP` | -                                    |

--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -18,19 +18,20 @@ import (
 
 // ComputeUtil is used to wrap the raw GCE API code and store common parameters.
 type ComputeUtil struct {
-	zone         string
-	instanceName string
-	userName     string
-	project      string
-	diskTypeURL  string
-	address      string
-	preemptible  bool
-	service      *raw.Service
-	zoneURL      string
-	globalURL    string
-	ipAddress    string
-	SwarmMaster  bool
-	SwarmHost    string
+	zone          string
+	instanceName  string
+	userName      string
+	project       string
+	diskTypeURL   string
+	address       string
+	preemptible   bool
+	useInternalIP bool
+	service       *raw.Service
+	zoneURL       string
+	globalURL     string
+	ipAddress     string
+	SwarmMaster   bool
+	SwarmHost     string
 }
 
 const (
@@ -55,18 +56,19 @@ func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 	}
 
 	c := ComputeUtil{
-		zone:         driver.Zone,
-		instanceName: driver.MachineName,
-		userName:     driver.SSHUser,
-		project:      driver.Project,
-		diskTypeURL:  driver.DiskType,
-		address:      driver.Address,
-		preemptible:  driver.Preemptible,
-		service:      service,
-		zoneURL:      apiURL + driver.Project + "/zones/" + driver.Zone,
-		globalURL:    apiURL + driver.Project + "/global",
-		SwarmMaster:  driver.SwarmMaster,
-		SwarmHost:    driver.SwarmHost,
+		zone:          driver.Zone,
+		instanceName:  driver.MachineName,
+		userName:      driver.SSHUser,
+		project:       driver.Project,
+		diskTypeURL:   driver.DiskType,
+		address:       driver.Address,
+		preemptible:   driver.Preemptible,
+		useInternalIP: driver.UseInternalIP,
+		service:       service,
+		zoneURL:       apiURL + driver.Project + "/zones/" + driver.Zone,
+		globalURL:     apiURL + driver.Project + "/global",
+		SwarmMaster:   driver.SwarmMaster,
+		SwarmHost:     driver.SwarmHost,
 	}
 	return &c, nil
 }
@@ -380,7 +382,11 @@ func (c *ComputeUtil) ip() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		if c.useInternalIP {
+			c.ipAddress = instance.NetworkInterfaces[0].NetworkIP
+		} else {
+			c.ipAddress = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+		}
 	}
 	return c.ipAddress, nil
 }

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -14,16 +14,17 @@ import (
 // Driver is a struct compatible with the docker.hosts.drivers.Driver interface.
 type Driver struct {
 	*drivers.BaseDriver
-	Zone         string
-	MachineType  string
-	MachineImage string
-	DiskType     string
-	Address      string
-	Preemptible  bool
-	Scopes       string
-	DiskSize     int
-	Project      string
-	Tags         string
+	Zone          string
+	MachineType   string
+	MachineImage  string
+	DiskType      string
+	Address       string
+	Preemptible   bool
+	UseInternalIP bool
+	Scopes        string
+	DiskSize      int
+	Project       string
+	Tags          string
 }
 
 const (
@@ -103,6 +104,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "GOOGLE_TAGS",
 			Value:  "",
 		},
+		mcnflag.BoolFlag{
+			Name:   "google-use-internal-ip",
+			Usage:  "Use internal GCE Instance IP rather than public one",
+			EnvVar: "GOOGLE_USE_INTERNAL_IP",
+		},
 	}
 }
 
@@ -155,6 +161,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.DiskType = flags.String("google-disk-type")
 	d.Address = flags.String("google-address")
 	d.Preemptible = flags.Bool("google-preemptible")
+	d.UseInternalIP = flags.Bool("google-use-internal-ip")
 	d.Scopes = flags.String("google-scopes")
 	d.Tags = flags.String("google-tags")
 	d.SwarmMaster = flags.Bool("swarm-master")


### PR DESCRIPTION
Introduced a new flag for google driver:
--google-use-internal-ip

When invoked while create it will make docker-machine use internal rather than public NATed IPs.
It's very useful if you manage machines from within the same network. It's faster, simpler and make deploying e.g. swarm much easier as one do not have to configure firewall even when swarm is managed from within the same network. The flag is persistent in the sense that a machine created with it retains the feature.
