### PR TITLE
Remove beta warning message

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,6 @@ parent="smn_workw_machine"
 
 # Docker Machine
 
-> **Note**: Machine is currently in beta, so things are likely to change. We
-> don't recommend you use it in production yet.
-
 Machine lets you create Docker hosts on your computer, on cloud providers, and
 inside your own data center. It automatically creates hosts, installs Docker on
 them, then configures the `docker` client to talk to them. A "machine" is the


### PR DESCRIPTION
The amount of confusion over this message has been very surprising to me.  It was intended to warn against using Machine in production, but users have taken it to indicate that Machine is unreliable in lower environments as well.  Since I'm not sure how to phrase the message to explain this to someone who doesn't grok the difference between "development" and "production", perhaps it's best just to take out.

cc @moxiegirl @ehazlett 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>