### PR TITLE
Change 'ls' to not report 'Saved' hosts as active when $DOCKER_HOST is not set

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -342,10 +342,10 @@ func isActive(h *host.Host) (bool, error) {
 
 	dockerHost := os.Getenv("DOCKER_HOST")
 
-	notStopped := currentState != state.Stopped
+	running := currentState == state.Running
 	correctURL := url == dockerHost
 
-	isActive := notStopped && correctURL
+	isActive := running && correctURL
 
 	return isActive, nil
 }

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -8,6 +8,7 @@ import (
 type FakeDriver struct {
 	*drivers.BaseDriver
 	MockState state.State
+	MockURL   string
 	MockName  string
 }
 
@@ -20,7 +21,7 @@ func (d *FakeDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *FakeDriver) GetURL() (string, error) {
-	return "", nil
+	return d.MockURL, nil
 }
 
 func (d *FakeDriver) GetMachineName() string {


### PR DESCRIPTION
Fixes #1908.

Currently `isActive()` only checks whether the state of a host is not `state.Stopped`, but it should also check the state of a host is not `state.Saved`.
I also added a test for `GetHostListItems()` in the case where `$DOCKER_HOST` is not set.

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>