### PR TITLE
READY FOR REVIEW - Work-around erroneous SSL: CERTIFICATE_VERIFY_FAILED error with some buggy versions of OpenSSL

### DIFF
--- a/libmachine/cert/bootstrap.go
+++ b/libmachine/cert/bootstrap.go
@@ -20,7 +20,8 @@ func BootstrapCertificates(authOptions *auth.AuthOptions) error {
 	// TODO: I'm not super happy about this use of "org", the user should
 	// have to specify it explicitly instead of implicitly basing it on
 	// $USER.
-	org := mcnutils.GetUsername()
+	caOrg := mcnutils.GetUsername()
+	org := caOrg + ".<bootstrap>"
 
 	bits := 2048
 
@@ -42,7 +43,7 @@ func BootstrapCertificates(authOptions *auth.AuthOptions) error {
 			return errors.New("The CA key already exists.  Please remove it or specify a different key/cert.")
 		}
 
-		if err := GenerateCACertificate(caCertPath, caPrivateKeyPath, org, bits); err != nil {
+		if err := GenerateCACertificate(caCertPath, caPrivateKeyPath, caOrg, bits); err != nil {
 			return fmt.Errorf("Generating CA certificate failed: %s", err)
 		}
 	}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -63,7 +63,7 @@ func ConfigureAuth(p Provisioner) error {
 	driver := p.GetDriver()
 	machineName := driver.GetMachineName()
 	authOptions := p.GetAuthOptions()
-	org := machineName
+	org := mcnutils.GetUsername() + "." + machineName
 	bits := 2048
 
 	ip, err := driver.GetIP()


### PR DESCRIPTION
This was inspired by my investigation into #1880 (and sister issues such as docker/compose#890). This patch ensures that the `ca.pem` subject is different from the `cert.pem` subject for [*bootstrapped* certificates](/docker/machine/blob/master/libmachine/cert/bootstrap.go). This is a work-around for a bug in some versions of OpenSSL that would erroneously error out with `SSL: CERTIFICATE_VERIFY_FAILED` if the subjects are the same.

Note: for *provisioned* certificates (i.e., those generated with [`libmachine/provision/utils.go`](/docker/machine/blob/master/libmachine/provision/utils.go)), the subject of `ca.pem` is the username and the subject of `cert.pem` is the machine name. This generally does not implicate the OpenSSL bug unless the user tries to provision a machine with the same name as his username (e.g., `docker-machine create ... "$( id -u -n )"`). That situation is also addressed by this patch, which prefixes the machine name with the user name.