### PR TITLE
Re-add godep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN go get  github.com/mitchellh/gox \
             github.com/golang/lint/golint \
             github.com/mattn/goveralls \
             golang.org/x/tools/cover \
+            github.com/tools/godep \
             github.com/aktau/github-release
 
 WORKDIR /go/src/github.com/docker/machine


### PR DESCRIPTION
This change is needed to fix a Continuous Build pipeline run by
@ehazlett which spits out master build binaries for Docker Machine.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>