### PR TITLE
Additional info message while waiting for IP address to be assigned to the Droplet.

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -179,6 +179,7 @@ func (d *Driver) Create() error {
 
 	d.DropletID = newDroplet.Droplet.ID
 
+	log.Info("Waiting for IP address to be assigned to the Droplet...")
 	for {
 		newDroplet, _, err = client.Droplets.Get(d.DropletID)
 		if err != nil {


### PR DESCRIPTION
It takes a lot of time to assign the IP to droplet, so informing user
about this hang looks like a good idea.