### PR TITLE
Updating CI builds to use Go 1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5
+- 1.5.1
 install:
 - go get github.com/mattn/goveralls
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5
+FROM golang:1.5.1
 
 RUN go get  github.com/golang/lint/golint \
             github.com/mattn/goveralls \

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
     # - sudo apt-get install -y virtualbox
 
   post:
-    - gvm install go1.5 -B --name=stable
+    - gvm install go1.5.1 -B --name=stable
 
   environment:
   # Convenient shortcuts to "common" locations


### PR DESCRIPTION
Note: I recognize that the `FROM` in the Dockerfile is a no-op since `golang:1.5` == `golang:1.5.1`. I decided to change it anyway though, to make the next update simpler (i.e. we can just `grep -R 1.5.1 *`).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>