### PR TITLE
Add --openstack-ip-version option

### DIFF
--- a/docs/drivers/openstack.md
+++ b/docs/drivers/openstack.md
@@ -34,6 +34,7 @@ Options:
  - `--openstack-floatingip-pool`: The IP pool that will be used to get a public IP can assign it to the machine. If there is an
    IP address already allocated but not assigned to any machine, this IP will be chosen and assigned to the machine. If
    there is no IP address already allocated a new IP will be allocated and assigned to the machine.
+ - `--openstack-ip-version`: If the instance has both IPv4 and IPv6 address, you can select IP version. If not provided `4` will be used.
  - `--openstack-ssh-user`: The username to use for SSH into the machine. If not provided `root` will be used.
  - `--openstack-ssh-port`: Customize the SSH port if the SSH server on the machine does not listen on the default port.
  - `--openstack-active-timeout`: The timeout in seconds until the OpenStack instance must be active.
@@ -61,6 +62,7 @@ Environment variables and default values:
 | `--openstack-net-id`             | -                      | -       |
 | `--openstack-sec-groups`         | -                      | -       |
 | `--openstack-floatingip-pool`    | -                      | -       |
+| `--openstack-ip-version`         | `OS_IP_VERSION`        | `4`     |
 | `--openstack-ssh-user`           | -                      | `root`  |
 | `--openstack-ssh-port`           | -                      | `22`    |
 | `--openstack-active-timeout`     | -                      | `200`   |

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -89,6 +89,7 @@ type IpAddress struct {
 	Network     string
 	AddressType string
 	Address     string
+	Version     int
 	Mac         string
 }
 
@@ -163,10 +164,16 @@ func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {
 	for network, networkAddresses := range server.Addresses {
 		for _, element := range networkAddresses.([]interface{}) {
 			address := element.(map[string]interface{})
+			version, ok := address["version"].(float64)
+			if !ok {
+				// Assume IPv4 if no version present.
+				version = 4
+			}
 
 			addr := IpAddress{
 				Network: network,
 				Address: address["addr"].(string),
+				Version: int(version),
 			}
 
 			if tp, ok := address["OS-EXT-IPS:type"]; ok {
@@ -179,6 +186,7 @@ func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {
 			addresses = append(addresses, addr)
 		}
 	}
+
 	return addresses, nil
 }
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -39,6 +39,7 @@ type Driver struct {
 	SecurityGroups   []string
 	FloatingIpPool   string
 	FloatingIpPoolId string
+	IpVersion        int
 	client           Client
 }
 
@@ -160,6 +161,12 @@ func GetCreateFlags() []cli.Flag {
 			Usage: "OpenStack floating IP pool to get an IP from to assign to the instance",
 			Value: "",
 		},
+		cli.IntFlag{
+			EnvVar: "OS_IP_VERSION",
+			Name:   "openstack-ip-version",
+			Usage:  "OpenStack version of IP address assigned for the machine",
+			Value:  4,
+		},
 		cli.StringFlag{
 			Name:  "openstack-ssh-user",
 			Usage: "OpenStack SSH user",
@@ -226,6 +233,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.SecurityGroups = strings.Split(flags.String("openstack-sec-groups"), ",")
 	}
 	d.FloatingIpPool = flags.String("openstack-floatingip-pool")
+	d.IpVersion = flags.Int("openstack-ip-version")
 	d.SSHUser = flags.String("openstack-ssh-user")
 	d.SSHPort = flags.Int("openstack-ssh-port")
 	d.SwarmMaster = flags.Bool("swarm-master")
@@ -269,7 +277,7 @@ func (d *Driver) GetIP() (string, error) {
 			return "", err
 		}
 		for _, a := range addresses {
-			if a.AddressType == addressType {
+			if a.AddressType == addressType && a.Version == d.IpVersion {
 				return a.Address, nil
 			}
 		}


### PR DESCRIPTION
When I try to create a instance on Dual-Stack network with OpenStack driver, docker-machine get stuck waiting for ssh connection. The driver attempts to connect the instance using IPv6, but I have only IPv4 address.


The driver detect IP address in "GetInstanceIpAddresses" method and the first one in for loop is used. 
https://github.com/docker/machine/blob/master/drivers/openstack/client.go#L157

In Dual-Stack network, Nova api returns the result including both IPv4 and IPv6 address in "addresses" field, as in the following example

```json
{
  "server": {
    "addresses": {
      "ext-cnode": [
        {
          "OS-EXT-IPS:type": "fixed",
          "addr": "****:****:****:***:***:***:***:***:***",
          "version": 6,
          "OS-EXT-IPS-MAC:mac_addr": "02:01:9d:**:**:**"
        },
        {
          "OS-EXT-IPS:type": "fixed",
          "addr": "***.***.***.***",
          "version": 4,
          "OS-EXT-IPS-MAC:mac_addr": "02:01:9d:**:**:**"
        }
      ]
    },
}
```

This option allows users to specify IP version.