### PR TITLE
fix IPV6NetworkMaskPrefixLength value parsing

### DIFF
--- a/drivers/virtualbox/network.go
+++ b/drivers/virtualbox/network.go
@@ -100,7 +100,7 @@ func listHostOnlyNetworks() (map[string]*hostOnlyNetwork, error) {
 		case "IPV6Address":
 			n.IPv6.IP = net.ParseIP(val)
 		case "IPV6NetworkMaskPrefixLength":
-			l, err := strconv.ParseUint(val, 10, 7)
+			l, err := strconv.ParseUint(val, 10, 8)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Adapted from https://github.com/boot2docker/boot2docker-cli/commit/941c70cb0137acccd36c2f8ef9426a12ddc58ef0

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>