### PR TITLE
Fix Windows SSH issues

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -1,9 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/state"
 
@@ -33,18 +30,12 @@ func cmdSsh(c *cli.Context) {
 		log.Fatalf("Error: Cannot run SSH command: Host %q is not running", host.Name)
 	}
 
-	if len(c.Args()) == 1 {
-		err := host.CreateSSHShell()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		output, err := host.RunSSHCommand(strings.Join(c.Args().Tail(), " "))
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		fmt.Print(output)
+	client, err := host.CreateSSHClient()
+	if err != nil {
+		log.Fatal(err)
 	}
 
+	if err := client.Shell(c.Args().Tail()...); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -74,15 +74,6 @@ func (h *Host) CreateSSHClient() (ssh.Client, error) {
 	return ssh.NewClient(h.Driver.GetSSHUsername(), addr, port, auth)
 }
 
-func (h *Host) CreateSSHShell() error {
-	client, err := h.CreateSSHClient()
-	if err != nil {
-		return err
-	}
-
-	return client.Shell()
-}
-
 func (h *Host) runActionForState(action func() error, desiredState state.State) error {
 	if drivers.MachineInState(h.Driver, desiredState)() {
 		return fmt.Errorf("Machine %q is already %s.", h.Name, strings.ToLower(desiredState.String()))

--- a/libmachine/ssh/client_test.go
+++ b/libmachine/ssh/client_test.go
@@ -1,0 +1,45 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSSHCmdArgs(t *testing.T) {
+	cases := []struct {
+		binaryPath   string
+		args         []string
+		expectedArgs []string
+	}{
+		{
+			binaryPath: "/usr/local/bin/ssh",
+			args: []string{
+				"docker@localhost",
+				"apt-get install -y htop",
+			},
+			expectedArgs: []string{
+				"/usr/local/bin/ssh",
+				"docker@localhost",
+				"apt-get install -y htop",
+			},
+		},
+		{
+			binaryPath: "C:\\Program Files\\Git\\bin\\ssh.exe",
+			args: []string{
+				"docker@localhost",
+				"sudo /usr/bin/sethostname foobar && echo 'foobar' | sudo tee /var/lib/boot2docker/etc/hostname",
+			},
+			expectedArgs: []string{
+				"C:\\Program Files\\Git\\bin\\ssh.exe",
+				"docker@localhost",
+				"sudo /usr/bin/sethostname foobar && echo 'foobar' | sudo tee /var/lib/boot2docker/etc/hostname",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		cmd := getSSHCmd(c.binaryPath, c.args...)
+		assert.Equal(t, cmd.Args, c.expectedArgs)
+	}
+}

--- a/test/integration/core/ssh-backends.bats
+++ b/test/integration/core/ssh-backends.bats
@@ -26,7 +26,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: test command did what it purported to -- native ssh" {
   run machine --native-ssh ssh $NAME echo foo
-  [[ "$output" == "foo"  ]]
+  [[ "$output" =~ "foo"  ]]
 }
 
 @test "$DRIVER: ensure that ssh extra arguments work" {


### PR DESCRIPTION
Fixes https://github.com/docker/machine/issues/1906

Added bonus:  Makes SSH "streaming" for `docker-machine ssh` work (previously it would buffer the whole output of the command and then display it) and fixes an issue I discovered with SSH port forwarding (e.g. `docker-machine ssh default -L 8080:localhost:8080`).

TODO:

- [x] Unit tests

cc @dmp42 @ehazlett @carolynvs 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>