### PR TITLE
Move VBox detection to Precreate and print version

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -181,17 +181,17 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) PreCreateCheck() error {
+	// Check that VBoxManage exists and works
+	if err := vbm(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (d *Driver) Create() error {
-	var (
-		err error
-	)
-
-	// Check that VBoxManage exists and works
-	if err = vbm(); err != nil {
-		return err
+	if err := vbm("--version"); err != nil {
+		return fmt.Errorf("Checking VirtualBox version failed: %s", err)
 	}
 
 	b2dutils := mcnutils.NewB2dUtils("", "", d.StorePath)


### PR DESCRIPTION
I'm not sure if we printed the VirtualBox version at some point and it just got lost (it's possible we never did), but it's absolutely critical for debugging to know which version of VirtualBox the user is on.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>