### PR TITLE
Fix config drive support in VMware Fusion driver

### DIFF
--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -146,6 +146,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Boot2DockerURL = flags.String("vmwarefusion-boot2docker-url")
 	d.ConfigDriveURL = flags.String("vmwarefusion-configdrive-url")
 	d.ISO = d.ResolveStorePath(isoFilename)
+	d.ConfigDriveISO = d.ResolveStorePath(isoConfigDrive)
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")


### PR DESCRIPTION
This PR fixes support for cloud-init configuration drives in the VMware Fusion driver (added in PR #1479). This was broken by PR #1729.