### PR TITLE
DOCKER_OPTS in generic provisioner is not generated correctly for config file.

### DIFF
--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -82,18 +82,18 @@ func (provisioner *GenericProvisioner) GenerateDockerOptions(dockerPort int) (*D
 
 	engineConfigTmpl := `
 DOCKER_OPTS='
--H tcp://0.0.0.0:{{.DockerPort}}
--H unix:///var/run/docker.sock
---storage-driver {{.EngineOptions.StorageDriver}}
---tlsverify
---tlscacert {{.AuthOptions.CaCertRemotePath}}
---tlscert {{.AuthOptions.ServerCertRemotePath}}
---tlskey {{.AuthOptions.ServerKeyRemotePath}}
-{{ range .EngineOptions.Labels }}--label {{.}}
-{{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}}
-{{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}}
-{{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}}
-{{ end }}
+-H tcp://0.0.0.0:{{.DockerPort}} \
+-H unix:///var/run/docker.sock \
+--storage-driver {{.EngineOptions.StorageDriver}} \
+--tlsverify \
+--tlscacert {{.AuthOptions.CaCertRemotePath}} \
+--tlscert {{.AuthOptions.ServerCertRemotePath}} \
+--tlskey {{.AuthOptions.ServerKeyRemotePath}} \
+{{ range .EngineOptions.Labels }}--label {{.}} \
+{{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} \
+{{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} \
+{{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} \
+{{ end }} 
 '
 {{range .EngineOptions.Env}}export \"{{ printf "%q" . }}\"
 {{end}}


### PR DESCRIPTION
About #1891
My VM is running under Ubuntu 15.04 server OS too.

I checked my servers /etc/default/docker,so I recognized DOCKER_OPS is different from running docker option('/usr/bin/docker -d -H fd://').
It seems that,the reason for this is lack of backslash of each line.
So add backslash to DOCKER_OPS to prevent startup option unrecognized.