### PR TITLE
Adding bash completion and helper scripts

### DIFF
--- a/contrib/completion/.gitignore
+++ b/contrib/completion/.gitignore
@@ -1,0 +1,1 @@
+!docker-machine*

--- a/contrib/completion/bash/docker-machine-prompt.bash
+++ b/contrib/completion/bash/docker-machine-prompt.bash
@@ -1,0 +1,47 @@
+#
+# bash prompt support for docker-machine
+#
+# This script allows you to see the active machine in your bash prompt.
+#
+# To enable:
+#  1a. Copy this file somewhere and source it in your .bashrc
+#      source /some/where/docker-machine-prompt.bash
+#  1b. Alternatively, just copy this file into into /etc/bash_completion.d
+#  2. Change your PS1 to call __docker-machine-ps1 as command-substitution
+#     PS1='[\u@\h \W$(__docker-machine-ps1 " [%s]")]\$ '
+#
+# Configuration:
+#
+# DOCKER_MACHINE_PS1_SHOWSTATUS
+#   When set, the machine status is indicated in the prompt. This can be slow,
+#   so use with care.
+#
+
+__docker-machine-ps1 () {
+    local format=${1:- [%s]}
+    if test ${DOCKER_MACHINE_NAME}; then
+        local status
+        if test ${DOCKER_MACHINE_PS1_SHOWSTATUS:-false} = true; then
+            status=$(docker-machine status ${DOCKER_MACHINE_NAME})
+            case ${status} in
+                Running)
+                    status=' R'
+                    ;;
+                Stopping)
+                    status=' R->S'
+                    ;;
+                Starting)
+                    status=' S->R'
+                    ;;
+                Error|Timeout)
+                    status=' E'
+                    ;;
+                *)
+                    # Just consider everything elase as 'stopped'
+                    status=' S'
+                    ;;
+            esac
+        fi
+        printf -- "${format}" "${DOCKER_MACHINE_NAME}${status}"
+    fi
+}

--- a/contrib/completion/bash/docker-machine-wrapper.bash
+++ b/contrib/completion/bash/docker-machine-wrapper.bash
@@ -1,0 +1,56 @@
+#
+# Function wrapper to docker-machine that adds a use subcommand.
+#
+# The use subcommand runs `eval "$(docker-machine env [args])"`, which is a lot
+# less typing.
+#
+# To enable:
+#  1a. Copy this file somewhere and source it in your .bashrc
+#      source /some/where/docker-machine-wrapper.bash
+#  1b. Alternatively, just copy this file into into /etc/bash_completion.d
+#
+# Configuration:
+#
+# DOCKER_MACHINE_WRAPPED
+#   When set to a value other than true, this will disable the alias wrapper
+#   alias for docker-machine. This is useful if you don't want the wrapper,
+#   but it is installed by default by your installation.
+#
+
+: ${DOCKER_MACHINE_WRAPPED:=true}
+
+__docker-machine-wrapper () {
+    if [[ "$1" == use ]]; then
+        # Special use wrapper
+        shift 1
+        case "$1" in
+            -h|--help|"")
+                cat <<EOF
+Usage: docker-machine use [OPTIONS] [arg...]
+
+Evaluate the commands to set up the environment for the Docker client
+
+Description:
+   Argument is a machine name.
+
+Options:
+
+   --swarm	Display the Swarm config instead of the Docker daemon
+   --unset, -u	Unset variables instead of setting them
+
+EOF
+                ;;
+            *)
+                eval "$(docker-machine env "$@")"
+                echo "Active machine: ${DOCKER_MACHINE_NAME}"
+                ;;
+        esac
+    else
+        # Just call the actual docker-machine app
+        $(which docker-machine) "$@"
+    fi
+}
+
+if [[ ${DOCKER_MACHINE_WRAPPED} = true ]]; then
+    alias docker-machine=__docker-machine-wrapper
+fi

--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -1,0 +1,244 @@
+#
+# bash completion file for docker-machine commands
+#
+# This script provides completion of:
+#  - commands and their options
+#  - machine names
+#  - filepaths
+#
+# To enable the completions either:
+#  - place this file in /etc/bash_completion.d
+#  or
+#  - copy this file to e.g. ~/.docker-machine-completion.sh and add the line
+#    below to your .bashrc after bash completion features are loaded
+#    . ~/.docker-machine-completion.sh
+#
+
+_docker-machine-active() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--swarm --help" -- "${cur}"))
+    else
+        COMPREPLY=()
+    fi
+}
+
+_docker-machine-config() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--swarm --help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-create() {
+    # cheating, b/c there are approximately one zillion options to create
+    COMPREPLY=($(compgen -W "$(docker-machine create --help | grep '^   -' | sed 's/^   //; s/[^a-z0-9-].*$//')" -- "${cur}"))
+}
+
+_docker-machine-env() {
+    case "${prev}" in
+        --shell)
+            # What are the options for --shell?
+            COMPREPLY=()
+            ;;
+        *)
+            if [[ "${cur}" == -* ]]; then
+                COMPREPLY=($(compgen -W "--swarm --shell --unset --help" -- "${cur}"))
+            else
+                COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+            fi
+    esac
+}
+
+# See docker-machine-wrapper.bash for the use command
+_docker-machine-use() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--swarm --unset --help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-inspect() {
+    case "${prev}" in
+        -f|--format)
+            COMPREPLY=()
+            ;;
+        *)
+            if [[ "${cur}" == -* ]]; then
+                COMPREPLY=($(compgen -W "--format --help" -- "${cur}"))
+            else
+                COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+            fi
+            ;;
+    esac
+}
+
+_docker-machine-ip() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-kill() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-ls() {
+    case "${prev}" in
+        --filter)
+            COMPREPLY=()
+            ;;
+        *)
+            COMPREPLY=($(compgen -W "--quiet --filter --help" -- "${cur}"))
+            ;;
+    esac
+}
+
+_docker-machine-regenerate-certs() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help --force" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-restart() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-rm() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help --force" -- "${cur}"))
+    else
+        # For rm, it's best to be explicit
+        COMPREPLY=()
+    fi
+}
+
+_docker-machine-ssh() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-scp() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help --recursive" -- "${cur}"))
+    else
+        _filedir
+        # It would be really nice to ssh to the machine and ls to complete
+        # remote files.
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q | sed 's/$/:/')" -- "${cur}") "${COMPREPLY[@]}")
+    fi
+}
+
+_docker-machine-start() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-status() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-stop() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-upgrade() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-url() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+    fi
+}
+
+_docker-machine-help() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "${commands[*]}" -- "${cur}"))
+    fi
+}
+
+_docker-machine-docker-machine() {
+    if [[ " ${wants_file[*]} " =~ " ${prev} " ]]; then
+        _filedir
+    elif [[ " ${wants_dir[*]} " =~ " ${prev} " ]]; then
+        _filedir -d
+    elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "${flags[*]} ${wants_dir[*]} ${wants_file[*]}" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "${commands[*]}" -- "${cur}"))
+    fi
+}
+
+_docker-machine() {
+    COMPREPLY=()
+    local commands=(active config create env inspect ip kill ls regenerate-certs restart rm ssh scp start status stop upgrade url help)
+
+    local flags=(--debug --native-ssh --help --version)
+    local wants_dir=(--storage-path)
+    local wants_file=(--tls-ca-cert --tls-ca-key --tls-client-cert --tls-client-key)
+
+    # Add the use subcommand, if we have an alias loaded
+    if [[ ${DOCKER_MACHINE_WRAPPED} = true ]]; then
+        commands=("${commands[@]}" use)
+    fi
+
+    local cur prev words cword
+    _get_comp_words_by_ref -n : cur prev words cword
+    local i
+    local command=docker-machine
+
+    for (( i=1; i < ${cword}; ++i)); do
+        local word=${words[i]}
+        if [[ " ${wants_file[*]} ${wants_dir[*]} " =~ " ${word} " ]]; then
+            # skip the next option
+            (( ++i ))
+        elif [[ " ${commands[*]} " =~ " ${word} " ]]; then
+            command=${word}
+        fi
+    done
+
+    local completion_func=_docker-machine-"${command}"
+    if declare -F "${completion_func}" > /dev/null; then
+        ${completion_func}
+    fi
+
+    return 0
+}
+
+complete -F _docker-machine docker-machine

--- a/docs/install-machine.md
+++ b/docs/install-machine.md
@@ -57,6 +57,25 @@ to your PATH.
         $ docker-machine -v
         machine version 0.5.0 (3e06852)
 
+## Installing bash completion scripts
+
+The Machine repository supplies several `bash` scripts that add features such
+as:
+
+* command completion
+* a function that displays the active machine in your shell prompt
+* a function wrapper that adds a `docker-machine use` subcommand to switch the
+  active machine
+
+To install the scripts, copy or link them into your `/etc/bash_completion.d` or
+`/usr/local/etc/bash_completion.d` file. To enable the `docker-machine` shell
+prompt, add `$(__docker-machine-ps1)` to your `PS1` setting in `~/.bashrc`.
+
+    PS1='[\u@\h \W$(__docker-machine-ps1)]\$ '
+
+You can find additional documentation in the comments at the
+[top of each script](https://github.com/docker/machine/tree/master/contrib/completion/bash).
+
 ## Where to go next
 
 * [Docker Machine overview](/)


### PR DESCRIPTION
This patch adds some bash helper scripts.

 * docker-machine.bash - command completion for docker-machine
 * docker-machine-prompt.bash - function for putting the active machine
   name in PS1
 * docker-machine-wrapper.bash - function wrapper adding an `eval`
   command that runs `eval $(docker-machine env whatever)` in the
   current shell.