### PR TITLE
Add --openstack-user-data option to OpenStack driver

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -66,6 +67,13 @@ func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 				UUID: d.NetworkId,
 			},
 		}
+	}
+	if d.UserData != "" {
+		userdata, err := ioutil.ReadFile(d.UserData)
+		if err != nil {
+			return "", err
+		}
+		serverOpts.UserData = userdata
 	}
 
 	log.Info("Creating machine...")

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -40,6 +40,7 @@ type Driver struct {
 	FloatingIpPool   string
 	FloatingIpPoolId string
 	IpVersion        int
+	UserData         string
 	client           Client
 }
 
@@ -194,6 +195,12 @@ func GetCreateFlags() []cli.Flag {
 			Usage:  "OpenStack active timeout",
 			Value:  defaultActiveTimeout,
 		},
+		cli.StringFlag{
+			EnvVar: "OS_USER_DATA",
+			Name:   "openstack-user-data",
+			Usage:  "Path to OpenStack user data",
+			Value:  "",
+		},
 	}
 }
 
@@ -248,6 +255,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.IpVersion = flags.Int("openstack-ip-version")
 	d.SSHUser = flags.String("openstack-ssh-user")
 	d.SSHPort = flags.Int("openstack-ssh-port")
+	d.UserData = flags.String("openstack-user-data")
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")
 	d.SwarmDiscovery = flags.String("swarm-discovery")


### PR DESCRIPTION
This patch adds `--openstack-user-data` option to the `docker-machine create` command.
It allows users to specify a user data for the created OpenStack compute instance,
which is processed by Cloud-Init in the early initialization stage of the instance.

The driver takes the file name in the command line option or from the environment,
reads the file, and then pass its content to gophercloud.

Signed-off-by: Kasumi Fukuda <fukuda.k@pepabo.com>