### PR TITLE
Fixing JSON marshaling of large numbers during migration

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -113,7 +113,7 @@ func listHosts(store persist.Store) ([]*host.Host, error) {
 	for _, h := range hosts {
 		d, err := newPluginDriver(h.DriverName, h.RawDriver)
 		if err != nil {
-			return nil, fmt.Errorf("Error attempting to invoke binary for plugin: %s", err)
+			return nil, fmt.Errorf("Error attempting to invoke binary for plugin '%s': %s", h.DriverName, err)
 		}
 
 		h.Driver = d

--- a/libmachine/host/migrate_v2_v3.go
+++ b/libmachine/host/migrate_v2_v3.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/docker/machine/libmachine/log"
@@ -22,7 +23,9 @@ func MigrateHostV2ToHostV3(hostV2 *HostV2, data []byte, storePath string) *Host 
 
 	// Must migrate to include store path in driver since it was not
 	// previously stored in drivers directly
-	if err := json.Unmarshal(*rawHost.Driver, &m); err != nil {
+	d := json.NewDecoder(bytes.NewReader(*rawHost.Driver))
+	d.UseNumber()
+	if err := d.Decode(&m); err != nil {
 		log.Warnf("Could not unmarshal raw host into map[string]interface{}: %s", err)
 	}
 


### PR DESCRIPTION
Fixes #1998

- Added some context to an error message - it's useful to know _which_
  plugin failed when invoking the binary failed
- Replaced `json.Umarshal` with a `json.Decoder`, so that the
  `UseNumber` function can be called, which prevents large integers from
  being interpreted as `float64`s.
- Fixed a couple `log.Warn` calls that should've been `log.Warnf`

Signed-off-by: Dave Henderson <dhenderson@gmail.com>