### PR TITLE
💄Fix log.* method calls which meant to be log.*f

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -718,7 +718,7 @@ func generateId() string {
 	rb := make([]byte, 10)
 	_, err := rand.Read(rb)
 	if err != nil {
-		log.Warn("Unable to generate id: %s", err)
+		log.Warnf("Unable to generate id: %s", err)
 	}
 
 	h := md5.New()

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -374,7 +374,7 @@ func (d *Driver) Create() error {
 func (d *Driver) hostOnlyIpAvailable() bool {
 	ip, err := d.GetIP()
 	if err != nil {
-		log.Debug("ERROR getting IP: %s", err)
+		log.Debugf("ERROR getting IP: %s", err)
 		return false
 	}
 	if ip != "" {

--- a/libmachine/host/migrate.go
+++ b/libmachine/host/migrate.go
@@ -64,7 +64,7 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 	} else {
 		migrationPerformed = true
 		for h.ConfigVersion = migratedHostMetadata.ConfigVersion; h.ConfigVersion < version.ConfigVersion; h.ConfigVersion++ {
-			log.Debug("Migrating to config v%d", h.ConfigVersion)
+			log.Debugf("Migrating to config v%d", h.ConfigVersion)
 			switch h.ConfigVersion {
 			case 0:
 				hostV0 := &HostV0{

--- a/libmachine/host/migrate_v2_v3.go
+++ b/libmachine/host/migrate_v2_v3.go
@@ -15,7 +15,7 @@ func MigrateHostV2ToHostV3(hostV2 *HostV2, data []byte, storePath string) *Host 
 	// smoothly.
 	rawHost := &RawHost{}
 	if err := json.Unmarshal(data, &rawHost); err != nil {
-		log.Warn("Could not unmarshal raw host for RawDriver information: %s", err)
+		log.Warnf("Could not unmarshal raw host for RawDriver information: %s", err)
 	}
 
 	m := make(map[string]interface{})
@@ -23,7 +23,7 @@ func MigrateHostV2ToHostV3(hostV2 *HostV2, data []byte, storePath string) *Host 
 	// Must migrate to include store path in driver since it was not
 	// previously stored in drivers directly
 	if err := json.Unmarshal(*rawHost.Driver, &m); err != nil {
-		log.Warn("Could not unmarshal raw host into map[string]interface{}: %s", err)
+		log.Warnf("Could not unmarshal raw host into map[string]interface{}: %s", err)
 	}
 
 	m["StorePath"] = storePath
@@ -31,7 +31,7 @@ func MigrateHostV2ToHostV3(hostV2 *HostV2, data []byte, storePath string) *Host 
 	// Now back to []byte
 	rawDriver, err := json.Marshal(m)
 	if err != nil {
-		log.Warn("Could not re-marshal raw driver: %s", err)
+		log.Warnf("Could not re-marshal raw driver: %s", err)
 	}
 
 	h := &Host{

--- a/libmachine/provision/os_release.go
+++ b/libmachine/provision/os_release.go
@@ -69,7 +69,7 @@ func (osr *OsRelease) ParseOsRelease(osReleaseContents []byte) error {
 	for scanner.Scan() {
 		key, val, err := parseLine(scanner.Text())
 		if err != nil {
-			log.Warn("Warning: got an invalid line error parsing /etc/os-release: %s", err)
+			log.Warnf("Warning: got an invalid line error parsing /etc/os-release: %s", err)
 			continue
 		}
 		if err := osr.setIfPossible(key, val); err != nil {

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -186,7 +186,7 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 
 func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
 	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
-		log.Warn("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
 		return false
 	}
 


### PR DESCRIPTION
Stuff like `log.Debug("foo bar: %s", baz)` really wants to be `log.Debugf("foo bar: %s", baz)`...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>