### PR TITLE
Ensure log writes only to os.Stderr for env and config command

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/docker/machine/cli"
@@ -14,6 +15,10 @@ import (
 )
 
 func cmdConfig(c *cli.Context) {
+	// Ensure that log messages always go to stderr when this command is
+	// being run (it is intended to be run in a subshell)
+	log.SetOutWriter(os.Stderr)
+
 	if len(c.Args()) != 1 {
 		fatal(ErrExpectedOneMachine)
 	}

--- a/commands/env.go
+++ b/commands/env.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/docker/machine/cli"
+	"github.com/docker/machine/libmachine/log"
 )
 
 const (
@@ -32,6 +33,10 @@ type ShellConfig struct {
 }
 
 func cmdEnv(c *cli.Context) {
+	// Ensure that log messages always go to stderr when this command is
+	// being run (it is intended to be run in a subshell)
+	log.SetOutWriter(os.Stderr)
+
 	if len(c.Args()) != 1 && !c.Bool("unset") {
 		fatal(improperEnvArgsError)
 	}


### PR DESCRIPTION
This fixes some issue where if you run `eval $(docker-machine env default)` and it needs to regenerate the certs it was dumping output to STDOUT and messing up the subshell

cc @jeffdm FYI

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>