### PR TITLE
Spit out at least some message when flag parsing etc. fails

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -160,8 +160,9 @@ func main() {
 	}()
 
 	// TODO: Close plugin servers in case of client panic.
-
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		log.Error(err)
+	}
 
 	close(commands.RpcClientDriversCh)
 	<-commands.RpcDriversClosedCh


### PR DESCRIPTION
Prints error messages such as: `flag provided but not defined: -engine-laber` which were missing before (only got message "Incorrect Usage")

Inspired by conversation with @moxiegirl and others about our previous less useful flag error messages

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>