### PR TITLE
Adding support for darwin to IsVTXDisabled

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -187,24 +187,6 @@ func (d *Driver) PreCreateCheck() error {
 	return d.vbm()
 }
 
-// IsVTXDisabled checks if VT-X is disabled in the BIOS. If it is, the vm will fail to start.
-// If we can't be sure it is disabled, we carry on and will check the vm logs after it's started.
-func (d *Driver) IsVTXDisabled() bool {
-	if runtime.GOOS == "windows" {
-		output, err := cmdOutput("wmic", "cpu", "get", "VirtualizationFirmwareEnabled")
-		if err != nil {
-			log.Debugf("Couldn't check that VT-X/AMD-v is enabled. Will check that the vm is properly created: %v", err)
-			return false
-		}
-
-		disabled := strings.Contains(output, "FALSE")
-		return disabled
-	}
-
-	// TODO: linux and OSX
-	return false
-}
-
 // cmdOutput runs a shell command and returns its output.
 func cmdOutput(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)

--- a/drivers/virtualbox/virtualbox_darwin.go
+++ b/drivers/virtualbox/virtualbox_darwin.go
@@ -1,0 +1,22 @@
+package virtualbox
+
+import (
+	"strings"
+	"syscall"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+// IsVTXDisabled checks if VT-X is disabled in the BIOS. If it is, the vm will fail to start.
+// If we can't be sure it is disabled, we carry on and will check the vm logs after it's started.
+func (d *Driver) IsVTXDisabled() bool {
+	errmsg := "Couldn't check that VT-X/AMD-v is enabled. Will check that the vm is properly created: %v"
+	features, err := syscall.Sysctl("machdep.cpu.features")
+	if err != nil {
+		log.Debugf(errmsg, err)
+		return false
+	}
+
+	disabled := !strings.Contains(features, "VMX")
+	return disabled
+}

--- a/drivers/virtualbox/virtualbox_linux.go
+++ b/drivers/virtualbox/virtualbox_linux.go
@@ -1,0 +1,7 @@
+package virtualbox
+
+// IsVTXDisabled checks if VT-X is disabled in the BIOS. If it is, the vm will fail to start.
+// If we can't be sure it is disabled, we carry on and will check the vm logs after it's started.
+func (d *Driver) IsVTXDisabled() bool {
+	return false
+}

--- a/drivers/virtualbox/virtualbox_windows.go
+++ b/drivers/virtualbox/virtualbox_windows.go
@@ -1,0 +1,21 @@
+package virtualbox
+
+import (
+	"strings"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+// IsVTXDisabled checks if VT-X is disabled in the BIOS. If it is, the vm will fail to start.
+// If we can't be sure it is disabled, we carry on and will check the vm logs after it's started.
+func (d *Driver) IsVTXDisabled() bool {
+	errmsg := "Couldn't check that VT-X/AMD-v is enabled. Will check that the vm is properly created: %v"
+	output, err := cmdOutput("wmic", "cpu", "get", "VirtualizationFirmwareEnabled")
+	if err != nil {
+		log.Debugf(errmsg, err)
+		return false
+	}
+
+	disabled := strings.Contains(output, "FALSE")
+	return disabled
+}


### PR DESCRIPTION
Here's an OS X/darwin implementation for `IsVTXDisabled` - related to #1983, and a follow-on to #1990.

/cc @dmp42 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>