### PR TITLE
Additional validation on virtualbox-hostonly-cidr

### DIFF
--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -152,6 +152,31 @@ func TestGetIPErrors(t *testing.T) {
 	}
 }
 
+func TestParseValidCIDR(t *testing.T) {
+	ip, network, err := parseAndValidateCIDR("192.168.100.1/24")
+
+	assert.Equal(t, "192.168.100.1", ip.String())
+	assert.Equal(t, "192.168.100.0", network.IP.String())
+	assert.Equal(t, "ffffff00", network.Mask.String())
+	assert.NoError(t, err)
+}
+
+func TestInvalidCIDR(t *testing.T) {
+	ip, network, err := parseAndValidateCIDR("192.168.100.1")
+
+	assert.EqualError(t, err, "invalid CIDR address: 192.168.100.1")
+	assert.Nil(t, ip)
+	assert.Nil(t, network)
+}
+
+func TestInvalidNetworkIpCIDR(t *testing.T) {
+	ip, network, err := parseAndValidateCIDR("192.168.100.0/24")
+
+	assert.Equal(t, ErrNetworkAddrCidr, err)
+	assert.Nil(t, ip)
+	assert.Nil(t, network)
+}
+
 func newTestDriver(name string) *Driver {
 	return NewDriver(name, "")
 }


### PR DESCRIPTION
Check that the CIDR provided for a virtualbox host only CIDR is specified as a host IP and netmask, e.g., 192.168.100.1/24, and not a network IP and netmask, e.g., 192.168.100.0/24. This will help prevent confusion like #1383

Signed-off-by: Chris Abernethy <cabernet@chrisabernethy.com>

Signed-off-by: David Gageot <david@gageot.net>