### PR TITLE
Add heartbeat / automatic server cleanup code

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -305,6 +305,10 @@ func cmdCreateOuter(c *cli.Context) {
 		}
 	}
 
+	if err := driver.Close(); err != nil {
+		fatal(err)
+	}
+
 	if err := c.App.Run(os.Args); err != nil {
 		fatal(err)
 	}

--- a/libmachine/drivers/plugin/localbinary/plugin_test.go
+++ b/libmachine/drivers/plugin/localbinary/plugin_test.go
@@ -106,7 +106,7 @@ func TestExecServer(t *testing.T) {
 		stopCh:      make(chan bool, 1),
 	}
 
-	finalErr := make(chan error, 1)
+	finalErr := make(chan error)
 
 	// Start the docker-machine-foo plugin server
 	go func() {

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -67,6 +67,15 @@ func (r RpcFlags) Bool(key string) bool {
 type RpcServerDriver struct {
 	ActualDriver drivers.Driver
 	CloseCh      chan bool
+	HeartbeatCh  chan bool
+}
+
+func NewRpcServerDriver(d drivers.Driver) *RpcServerDriver {
+	return &RpcServerDriver{
+		ActualDriver: d,
+		CloseCh:      make(chan bool),
+		HeartbeatCh:  make(chan bool),
+	}
 }
 
 func (r *RpcServerDriver) Close(_, _ *struct{}) error {
@@ -180,4 +189,9 @@ func (r *RpcServerDriver) Start(_ *struct{}, _ *struct{}) error {
 
 func (r *RpcServerDriver) Stop(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Stop()
+}
+
+func (r *RpcServerDriver) Heartbeat(_ *struct{}, _ *struct{}) error {
+	r.HeartbeatCh <- true
+	return nil
 }


### PR DESCRIPTION
This replaces the previous method of attempting to clean up servers when
an unexpected exit occurs in the client (e.g. SIGINT or panic) by a
heartbeat protocol.  If the server does not hear from the connecting
client within a certain interval of time (500ms in this commit), it will
de-activate itself.  This prevents dangling Docker Machine server
processes from accumulating.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>