### PR TITLE
force tty allocation for ssh with multiple '-tt'.

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -73,10 +73,12 @@ func (provisioner *RedHatProvisioner) SSHCommand(args string) (string, error) {
 	}
 
 	// redhat needs "-t" for tty allocation on ssh therefore we check for the
-	// external client and add as needed
+	// external client and add as needed.
+	// Note: CentOS 7.0 needs multiple "-tt" to force tty allocation when ssh has
+	// no local tty.
 	switch c := client.(type) {
 	case ssh.ExternalClient:
-		c.BaseArgs = append(c.BaseArgs, "-t")
+		c.BaseArgs = append(c.BaseArgs, "-tt")
 		client = c
 	case ssh.NativeClient:
 		return c.OutputWithPty(args)


### PR DESCRIPTION
fix #2037:
when provision on CentOS 7.0, it needs to force tty allocation with multiple '-t' option.
Otherwise, the ssh command will failed with "sudo: sorry, you must have a tty to run sudo"
in SetHostname.

Signed-off-by: Xiaohui Liu <xiaohui.liu@ucloud.cn>