### PR TITLE
Set default VirtualBox disk size to 200GB

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -39,7 +39,7 @@ const (
 	defaultHostOnlyNictype     = "82540EM"
 	defaultHostOnlyPromiscMode = "deny"
 	defaultNoShare             = false
-	defaultDiskSize            = 20000
+	defaultDiskSize            = 204800
 )
 
 var (


### PR DESCRIPTION
As commented in this pull request to Docker Toolbox: https://github.com/docker/toolbox/pull/203 the default disk size for a Docker Machine in VirtualBox is set to 20GB, it could be useful to set that default to 200GB.

I edited the code based on this comment: https://github.com/docker/toolbox/pull/203#issuecomment-144593368 by @SydOps, who nailed down where that default was set.

I submit this pull request as asked by @mchiang0610 and @nathanleclaire in other comments in that PR (https://github.com/docker/toolbox/pull/203#issuecomment-150402370).

If that other PR seems to work for Docker Toolbox users and don't rise any additional issues and if you see fit, you may consider merging this PR to update the default Docker-Machine VirtualBox disk size to 200GB.