### PR TITLE
Linting 3, final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ go:
 - 1.5.1
 install:
 - go get github.com/mattn/goveralls
+- go get github.com/golang/lint/golint
 script:
 - make dco
 - make fmt
-# - make lint
+- make lint
 - make vet
 - make test-short
 - make test-long

--- a/cli/flag.go
+++ b/cli/flag.go
@@ -171,9 +171,8 @@ func (f *IntSlice) Set(value string) error {
 	tmp, err := strconv.Atoi(value)
 	if err != nil {
 		return err
-	} else {
-		*f = append(*f, tmp)
 	}
+	*f = append(*f, tmp)
 	return nil
 }
 

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -80,7 +80,7 @@ func main() {
 		if c.GlobalBool("native-ssh") {
 			ssh.SetDefaultClient(ssh.Native)
 		}
-		mcnutils.GithubApiToken = c.GlobalString("github-api-token")
+		mcnutils.GithubAPIToken = c.GlobalString("github-api-token")
 		mcndirs.BaseDir = c.GlobalString("storage-path")
 		return nil
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -23,8 +23,8 @@ var (
 	ErrExpectedOneMachine = errors.New("Error: Expected one machine name as an argument.")
 )
 
-func newPluginDriver(driverName string, rawContent []byte) (*rpcdriver.RpcClientDriver, error) {
-	d, err := rpcdriver.NewRpcClientDriver(rawContent, driverName)
+func newPluginDriver(driverName string, rawContent []byte) (*rpcdriver.RPCClientDriver, error) {
+	d, err := rpcdriver.NewRPCClientDriver(rawContent, driverName)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func runActionWithContext(actionName string, c *cli.Context) error {
 // codegangsta/cli will not set the cert paths if the storage-path is set to
 // something different so we cannot use the paths in the global options. le
 // sigh.
-func getCertPathInfoFromContext(c *cli.Context) cert.CertPathInfo {
+func getCertPathInfoFromContext(c *cli.Context) cert.PathInfo {
 	caCertPath := c.GlobalString("tls-ca-cert")
 	caKeyPath := c.GlobalString("tls-ca-key")
 	clientCertPath := c.GlobalString("tls-client-cert")
@@ -463,7 +463,7 @@ func getCertPathInfoFromContext(c *cli.Context) cert.CertPathInfo {
 		clientKeyPath = filepath.Join(mcndirs.GetMachineCertDir(), "key.pem")
 	}
 
-	return cert.CertPathInfo{
+	return cert.PathInfo{
 		CaCertPath:       caCertPath,
 		CaPrivateKeyPath: caKeyPath,
 		ClientCertPath:   clientCertPath,

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -217,7 +217,7 @@ var Commands = []cli.Command{
 		Name:        "ip",
 		Usage:       "Get the IP address of a machine",
 		Description: "Argument(s) are one or more machine names.",
-		Action:      cmdIp,
+		Action:      cmdIP,
 	},
 	{
 		Name:        "kill",
@@ -275,7 +275,7 @@ var Commands = []cli.Command{
 		Name:            "ssh",
 		Usage:           "Log into or run a command on a machine with SSH.",
 		Description:     "Arguments are [machine-name] [command]",
-		Action:          cmdSsh,
+		Action:          cmdSSH,
 		SkipFlagParsing: true,
 	},
 	{
@@ -318,7 +318,7 @@ var Commands = []cli.Command{
 		Name:        "url",
 		Usage:       "Get the URL of a machine",
 		Description: "Argument is a machine name.",
-		Action:      cmdUrl,
+		Action:      cmdURL,
 	},
 }
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -44,7 +44,7 @@ func runConnectionBoilerplate(h *host.Host, c *cli.Context) (string, *auth.AuthO
 		return "", &auth.AuthOptions{}, fmt.Errorf("Error trying to get host state: %s", err)
 	}
 	if hostState != state.Running {
-		return "", &auth.AuthOptions{}, fmt.Errorf("%s is not running. Please start it in order to use the connection settings.", h.Name)
+		return "", &auth.AuthOptions{}, fmt.Errorf("%s is not running. Please start it in order to use the connection settings", h.Name)
 	}
 
 	dockerHost, err := h.Driver.GetURL()
@@ -74,9 +74,9 @@ func runConnectionBoilerplate(h *host.Host, c *cli.Context) (string, *auth.AuthO
 	return dockerHost, authOptions, nil
 }
 
-func checkCert(hostUrl string, authOptions *auth.AuthOptions, c *cli.Context) error {
+func checkCert(hostURL string, authOptions *auth.AuthOptions, c *cli.Context) error {
 	valid, err := cert.ValidateCertificate(
-		hostUrl,
+		hostURL,
 		authOptions.CaCertPath,
 		authOptions.ServerCertPath,
 		authOptions.ServerKeyPath,
@@ -86,7 +86,7 @@ func checkCert(hostUrl string, authOptions *auth.AuthOptions, c *cli.Context) er
 	}
 
 	if !valid {
-		log.Errorf("Invalid certs detected; regenerating for %s", hostUrl)
+		log.Errorf("Invalid certs detected; regenerating for %s", hostURL)
 
 		if err := runActionWithContext("configureAuth", c); err != nil {
 			return fmt.Errorf("Error attempting to regenerate the certs: %s", err)
@@ -97,7 +97,7 @@ func checkCert(hostUrl string, authOptions *auth.AuthOptions, c *cli.Context) er
 }
 
 // TODO: This could use a unit test.
-func parseSwarm(hostUrl string, h *host.Host) (string, error) {
+func parseSwarm(hostURL string, h *host.Host) (string, error) {
 	swarmOptions := h.HostOptions.SwarmOptions
 
 	if !swarmOptions.Master {
@@ -112,15 +112,15 @@ func parseSwarm(hostUrl string, h *host.Host) (string, error) {
 	swarmPort := parts[1]
 
 	// get IP of machine to replace in case swarm host is 0.0.0.0
-	mUrl, err := url.Parse(hostUrl)
+	mURL, err := url.Parse(hostURL)
 	if err != nil {
 		return "", fmt.Errorf("There was an error parsing the url: %s", err)
 	}
 
-	mParts := strings.Split(mUrl.Host, ":")
-	machineIp := mParts[0]
+	mParts := strings.Split(mURL.Host, ":")
+	machineIP := mParts[0]
 
-	hostUrl = fmt.Sprintf("tcp://%s:%s", machineIp, swarmPort)
+	hostURL = fmt.Sprintf("tcp://%s:%s", machineIP, swarmPort)
 
-	return hostUrl, nil
+	return hostURL, nil
 }

--- a/commands/config.go
+++ b/commands/config.go
@@ -36,45 +36,45 @@ func cmdConfig(c *cli.Context) {
 		authOptions.CaCertPath, authOptions.ClientCertPath, authOptions.ClientKeyPath, dockerHost)
 }
 
-func runConnectionBoilerplate(h *host.Host, c *cli.Context) (string, *auth.AuthOptions, error) {
+func runConnectionBoilerplate(h *host.Host, c *cli.Context) (string, *auth.Options, error) {
 	hostState, err := h.Driver.GetState()
 	if err != nil {
 		// TODO: This is a common operation and should have a commonly
 		// defined error.
-		return "", &auth.AuthOptions{}, fmt.Errorf("Error trying to get host state: %s", err)
+		return "", &auth.Options{}, fmt.Errorf("Error trying to get host state: %s", err)
 	}
 	if hostState != state.Running {
-		return "", &auth.AuthOptions{}, fmt.Errorf("%s is not running. Please start it in order to use the connection settings", h.Name)
+		return "", &auth.Options{}, fmt.Errorf("%s is not running. Please start it in order to use the connection settings", h.Name)
 	}
 
 	dockerHost, err := h.Driver.GetURL()
 	if err != nil {
-		return "", &auth.AuthOptions{}, fmt.Errorf("Error getting driver URL: %s", err)
+		return "", &auth.Options{}, fmt.Errorf("Error getting driver URL: %s", err)
 	}
 
 	if c.Bool("swarm") {
 		var err error
 		dockerHost, err = parseSwarm(dockerHost, h)
 		if err != nil {
-			return "", &auth.AuthOptions{}, fmt.Errorf("Error parsing swarm: %s", err)
+			return "", &auth.Options{}, fmt.Errorf("Error parsing swarm: %s", err)
 		}
 	}
 
 	u, err := url.Parse(dockerHost)
 	if err != nil {
-		return "", &auth.AuthOptions{}, fmt.Errorf("Error parsing URL: %s", err)
+		return "", &auth.Options{}, fmt.Errorf("Error parsing URL: %s", err)
 	}
 
 	authOptions := h.HostOptions.AuthOptions
 
 	if err := checkCert(u.Host, authOptions, c); err != nil {
-		return "", &auth.AuthOptions{}, fmt.Errorf("Error checking and/or regenerating the certs: %s", err)
+		return "", &auth.Options{}, fmt.Errorf("Error checking and/or regenerating the certs: %s", err)
 	}
 
 	return dockerHost, authOptions, nil
 }
 
-func checkCert(hostURL string, authOptions *auth.AuthOptions, c *cli.Context) error {
+func checkCert(hostURL string, authOptions *auth.Options, c *cli.Context) error {
 	valid, err := cert.ValidateCertificate(
 		hostURL,
 		authOptions.CaCertPath,

--- a/commands/create.go
+++ b/commands/create.go
@@ -161,8 +161,8 @@ func cmdCreateInner(c *cli.Context) {
 		fatalf("Error getting new host: %s", err)
 	}
 
-	h.HostOptions = &host.HostOptions{
-		AuthOptions: &auth.AuthOptions{
+	h.HostOptions = &host.Options{
+		AuthOptions: &auth.Options{
 			CertDir:          mcndirs.GetMachineCertDir(),
 			CaCertPath:       certInfo.CaCertPath,
 			CaPrivateKeyPath: certInfo.CaPrivateKeyPath,
@@ -172,17 +172,17 @@ func cmdCreateInner(c *cli.Context) {
 			ServerKeyPath:    filepath.Join(mcndirs.GetMachineDir(), name, "server-key.pem"),
 			StorePath:        filepath.Join(mcndirs.GetMachineDir(), name),
 		},
-		EngineOptions: &engine.EngineOptions{
+		EngineOptions: &engine.Options{
 			ArbitraryFlags:   c.StringSlice("engine-opt"),
 			Env:              c.StringSlice("engine-env"),
 			InsecureRegistry: c.StringSlice("engine-insecure-registry"),
 			Labels:           c.StringSlice("engine-label"),
 			RegistryMirror:   c.StringSlice("engine-registry-mirror"),
 			StorageDriver:    c.String("engine-storage-driver"),
-			TlsVerify:        true,
+			TLSVerify:        true,
 			InstallURL:       c.String("engine-install-url"),
 		},
-		SwarmOptions: &swarm.SwarmOptions{
+		SwarmOptions: &swarm.Options{
 			IsSwarm:        c.Bool("swarm"),
 			Image:          c.String("swarm-image"),
 			Master:         c.Bool("swarm-master"),
@@ -321,7 +321,7 @@ func getDriverOpts(c *cli.Context, mcnflags []mcnflag.Flag) drivers.DriverOption
 	// But, we need it so that we can actually send the flags for creating
 	// a machine over the wire (cli.Context is a no go since there is so
 	// much stuff in it).
-	driverOpts := rpcdriver.RpcFlags{
+	driverOpts := rpcdriver.RPCFlags{
 		Values: make(map[string]interface{}),
 	}
 

--- a/commands/env.go
+++ b/commands/env.go
@@ -16,7 +16,7 @@ const (
 )
 
 var (
-	improperEnvArgsError = errors.New("Error: Expected either one machine name, or -u flag to unset the variables in the arguments.")
+	errImproperEnvArgs = errors.New("Error: Expected either one machine name, or -u flag to unset the variables in the arguments")
 )
 
 type ShellConfig struct {
@@ -42,7 +42,7 @@ func cmdEnv(c *cli.Context) {
 	log.SetOutWriter(os.Stderr)
 
 	if len(c.Args()) != 1 && !c.Bool("unset") {
-		fatal(improperEnvArgsError)
+		fatal(errImproperEnvArgs)
 	}
 
 	h := getFirstArgHost(c)

--- a/commands/ip.go
+++ b/commands/ip.go
@@ -2,7 +2,7 @@ package commands
 
 import "github.com/docker/machine/cli"
 
-func cmdIp(c *cli.Context) {
+func cmdIP(c *cli.Context) {
 	if err := runActionWithContext("ip", c); err != nil {
 		fatal(err)
 	}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -38,7 +38,7 @@ type HostListItem struct {
 	DriverName   string
 	State        state.State
 	URL          string
-	SwarmOptions *swarm.SwarmOptions
+	SwarmOptions *swarm.Options
 }
 
 func cmdLs(c *cli.Context) {

--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -73,7 +73,7 @@ func TestFilterHostsReturnsSameGivenNoFilters(t *testing.T) {
 		{
 			Name:        "testhost",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		},
 	}
 	actual := filterHosts(hosts, opts)
@@ -96,7 +96,7 @@ func TestFilterHostsReturnsEmptyGivenNonMatchingFilters(t *testing.T) {
 		{
 			Name:        "testhost",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		},
 	}
 	assert.Empty(t, filterHosts(hosts, opts))
@@ -109,22 +109,22 @@ func TestFilterHostsBySwarmName(t *testing.T) {
 	master :=
 		&host.Host{
 			Name: "master",
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{Master: true, Discovery: "foo"},
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{Master: true, Discovery: "foo"},
 			},
 		}
 	node1 :=
 		&host.Host{
 			Name: "node1",
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{Master: false, Discovery: "foo"},
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{Master: false, Discovery: "foo"},
 			},
 		}
 	othermaster :=
 		&host.Host{
 			Name: "othermaster",
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{Master: true, Discovery: "bar"},
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{Master: true, Discovery: "bar"},
 			},
 		}
 	hosts := []*host.Host{master, node1, othermaster}
@@ -141,19 +141,19 @@ func TestFilterHostsByDriverName(t *testing.T) {
 		&host.Host{
 			Name:        "node1",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	node2 :=
 		&host.Host{
 			Name:        "node2",
 			DriverName:  "virtualbox",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	node3 :=
 		&host.Host{
 			Name:        "node3",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	hosts := []*host.Host{node1, node2, node3}
 	expected := []*host.Host{node1, node3}
@@ -169,21 +169,21 @@ func TestFilterHostsByState(t *testing.T) {
 		&host.Host{
 			Name:        "node1",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused},
 		}
 	node2 :=
 		&host.Host{
 			Name:        "node2",
 			DriverName:  "virtualbox",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Stopped},
 		}
 	node3 :=
 		&host.Host{
 			Name:        "node3",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Running},
 		}
 	hosts := []*host.Host{node1, node2, node3}
@@ -200,28 +200,28 @@ func TestFilterHostsByName(t *testing.T) {
 		&host.Host{
 			Name:        "fire",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "fire"},
 		}
 	node2 :=
 		&host.Host{
 			Name:        "ice",
 			DriverName:  "adriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "ice"},
 		}
 	node3 :=
 		&host.Host{
 			Name:        "air",
 			DriverName:  "nodriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "air"},
 		}
 	node4 :=
 		&host.Host{
 			Name:        "water",
 			DriverName:  "falsedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "water"},
 		}
 	hosts := []*host.Host{node1, node2, node3, node4}
@@ -239,19 +239,19 @@ func TestFilterHostsMultiFlags(t *testing.T) {
 		&host.Host{
 			Name:        "node1",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	node2 :=
 		&host.Host{
 			Name:        "node2",
 			DriverName:  "virtualbox",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	node3 :=
 		&host.Host{
 			Name:        "node3",
 			DriverName:  "softlayer",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 		}
 	hosts := []*host.Host{node1, node2, node3}
 	expected := []*host.Host{node1, node2}
@@ -268,21 +268,21 @@ func TestFilterHostsDifferentFlagsProduceAND(t *testing.T) {
 		&host.Host{
 			Name:        "node1",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Paused},
 		}
 	node2 :=
 		&host.Host{
 			Name:        "node2",
 			DriverName:  "virtualbox",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Stopped},
 		}
 	node3 :=
 		&host.Host{
 			Name:        "node3",
 			DriverName:  "fakedriver",
-			HostOptions: &host.HostOptions{},
+			HostOptions: &host.Options{},
 			Driver:      &fakedriver.Driver{MockState: state.Running},
 		}
 	hosts := []*host.Host{node1, node2, node3}
@@ -317,8 +317,8 @@ func TestGetHostListItems(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Running,
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",
@@ -331,8 +331,8 @@ func TestGetHostListItems(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Stopped,
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",
@@ -345,8 +345,8 @@ func TestGetHostListItems(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Running,
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",
@@ -400,8 +400,8 @@ func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
 				MockState: state.Running,
 				MockURL:   "tcp://120.0.0.1:2376",
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",
@@ -414,8 +414,8 @@ func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Stopped,
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",
@@ -428,8 +428,8 @@ func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Saved,
 			},
-			HostOptions: &host.HostOptions{
-				SwarmOptions: &swarm.SwarmOptions{
+			HostOptions: &host.Options{
+				SwarmOptions: &swarm.Options{
 					Master:    false,
 					Address:   "",
 					Discovery: "",

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -5,7 +5,7 @@ import (
 	"github.com/docker/machine/libmachine/state"
 )
 
-func cmdSsh(c *cli.Context) {
+func cmdSSH(c *cli.Context) {
 	args := c.Args()
 	name := args.First()
 

--- a/commands/url.go
+++ b/commands/url.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/machine/cli"
 )
 
-func cmdUrl(c *cli.Context) {
+func cmdURL(c *cli.Context) {
 	if len(c.Args()) != 1 {
 		fatal(ErrExpectedOneMachine)
 	}

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Machine defines interfaces to manage a variety of docker instances
+// Package machine defines interfaces to manage a variety of docker instances
 // deployed on different backends (VMs, baremetal).
 // The goal is to allow users get from zero to docker as fast as possible.
 package machine

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
-	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 )
@@ -40,8 +39,8 @@ const (
 	defaultSSHUsername     = "ubuntu"
 )
 
-// GetCreateFlags registers the flags this d adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.IntFlag{
@@ -103,6 +102,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	d := &Driver{
 		DockerPort:            defaultDockerPort,
@@ -372,11 +372,6 @@ func (d *Driver) Kill() error {
 
 	d.IPAddress = ""
 	return nil
-}
-
-func generateVMName() string {
-	randomID := mcnutils.TruncateID(mcnutils.GenerateRandomID())
-	return fmt.Sprintf("docker-host-%s", randomID)
 }
 
 func (d *Driver) setUserSubscription() error {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -397,13 +397,13 @@ func (d *Driver) addDockerEndpoints(vmConfig *vmClient.Role) error {
 			LocalPort: d.DockerPort,
 		}
 		if d.SwarmMaster {
-			swarm_ep := vmClient.InputEndpoint{
+			swarmEp := vmClient.InputEndpoint{
 				Name:      "docker swarm",
 				Protocol:  "tcp",
 				Port:      d.DockerSwarmMasterPort,
 				LocalPort: d.DockerSwarmMasterPort,
 			}
-			configSets[i].InputEndpoints.InputEndpoint = append(configSets[i].InputEndpoints.InputEndpoint, swarm_ep)
+			configSets[i].InputEndpoints.InputEndpoint = append(configSets[i].InputEndpoints.InputEndpoint, swarmEp)
 			log.Debugf("added Docker swarm master endpoint (port %d) to configuration", d.DockerSwarmMasterPort)
 		}
 		configSets[i].InputEndpoints.InputEndpoint = append(configSets[i].InputEndpoints.InputEndpoint, ep)

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -34,8 +34,8 @@ const (
 	defaultSize   = "512mb"
 )
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -85,7 +85,8 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
-func NewDriver(hostName, storePath string) *Driver {
+// NewDriver creates and returns a new instance of the driver
+func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		Image:  defaultImage,
 		Size:   defaultSize,

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -19,8 +19,8 @@ import (
 type Driver struct {
 	*drivers.BaseDriver
 	URL              string
-	ApiKey           string
-	ApiSecretKey     string
+	APIKey           string
+	APISecretKey     string
 	InstanceProfile  string
 	DiskSize         int
 	Image            string
@@ -28,7 +28,7 @@ type Driver struct {
 	AvailabilityZone string
 	KeyPair          string
 	PublicKey        string
-	Id               string
+	ID               string
 }
 
 const (
@@ -38,8 +38,8 @@ const (
 	defaultAvailabilityZone = "ch-gva-2"
 )
 
-// RegisterCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -90,6 +90,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		InstanceProfile:  defaultInstanceProfile,
@@ -113,8 +114,8 @@ func (d *Driver) DriverName() string {
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.URL = flags.String("exoscale-endpoint")
-	d.ApiKey = flags.String("exoscale-api-key")
-	d.ApiSecretKey = flags.String("exoscale-api-secret-key")
+	d.APIKey = flags.String("exoscale-api-key")
+	d.APISecretKey = flags.String("exoscale-api-secret-key")
 	d.InstanceProfile = flags.String("exoscale-instance-profile")
 	d.DiskSize = flags.Int("exoscale-disk-size")
 	d.Image = flags.String("exoscale-image")
@@ -131,7 +132,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	if d.URL == "" {
 		d.URL = "https://api.exoscale.ch/compute"
 	}
-	if d.ApiKey == "" || d.ApiSecretKey == "" {
+	if d.APIKey == "" || d.APISecretKey == "" {
 		return fmt.Errorf("Please specify an API key (--exoscale-api-key) and an API secret key (--exoscale-api-secret-key).")
 	}
 
@@ -147,8 +148,8 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
-	vm, err := client.GetVirtualMachine(d.Id)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
+	vm, err := client.GetVirtualMachine(d.ID)
 	if err != nil {
 		return state.Error, err
 	}
@@ -218,7 +219,7 @@ func (d *Driver) createDefaultSecurityGroup(client *egoscale.Client, group strin
 
 func (d *Driver) Create() error {
 	log.Infof("Querying exoscale for the requested parameters...")
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
 	topology, err := client.GetTopology()
 	if err != nil {
 		return err
@@ -310,7 +311,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 	d.IPAddress = vm.Nic[0].Ipaddress
-	d.Id = vm.Id
+	d.ID = vm.Id
 
 	return nil
 }
@@ -325,8 +326,8 @@ func (d *Driver) Start() error {
 		return nil
 	}
 
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
-	svmresp, err := client.StartVirtualMachine(d.Id)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
+	svmresp, err := client.StartVirtualMachine(d.ID)
 	if err != nil {
 		return err
 	}
@@ -346,8 +347,8 @@ func (d *Driver) Stop() error {
 		return nil
 	}
 
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
-	svmresp, err := client.StopVirtualMachine(d.Id)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
+	svmresp, err := client.StopVirtualMachine(d.ID)
 	if err != nil {
 		return err
 	}
@@ -358,7 +359,7 @@ func (d *Driver) Stop() error {
 }
 
 func (d *Driver) Remove() error {
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
 
 	// Destroy the SSH key
 	if _, err := client.DeleteKeypair(d.KeyPair); err != nil {
@@ -366,7 +367,7 @@ func (d *Driver) Remove() error {
 	}
 
 	// Destroy the virtual machine
-	dvmresp, err := client.DestroyVirtualMachine(d.Id)
+	dvmresp, err := client.DestroyVirtualMachine(d.ID)
 	if err != nil {
 		return err
 	}
@@ -385,8 +386,8 @@ func (d *Driver) Restart() error {
 		return fmt.Errorf("Host is stopped, use start command to start it")
 	}
 
-	client := egoscale.NewClient(d.URL, d.ApiKey, d.ApiSecretKey)
-	svmresp, err := client.RebootVirtualMachine(d.Id)
+	client := egoscale.NewClient(d.URL, d.APIKey, d.APISecretKey)
+	svmresp, err := client.RebootVirtualMachine(d.ID)
 	if err != nil {
 		return err
 	}

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -62,6 +62,8 @@ func (d *Driver) DriverName() string {
 	return driverName
 }
 
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{

--- a/drivers/google/auth_util.go
+++ b/drivers/google/auth_util.go
@@ -19,7 +19,7 @@ import (
 const (
 	AuthURL      = "https://accounts.google.com/o/oauth2/auth"
 	TokenURL     = "https://accounts.google.com/o/oauth2/token"
-	ClientId     = "22738965389-8arp8bah3uln9eoenproamovfjj1ac33.apps.googleusercontent.com"
+	ClientID     = "22738965389-8arp8bah3uln9eoenproamovfjj1ac33.apps.googleusercontent.com"
 	ClientSecret = "qApc3amTyr5wI74vVrRWAfC_"
 	RedirectURI  = "urn:ietf:wg:oauth:2.0:oob"
 )
@@ -32,7 +32,7 @@ func newGCEService(storePath, authTokenPath string) (*raw.Service, error) {
 
 func newOauthClient(storePath, authTokenPath string) *http.Client {
 	config := &oauth.Config{
-		ClientId:     ClientId,
+		ClientId:     ClientID,
 		ClientSecret: ClientSecret,
 		Scope:        raw.ComputeScope,
 		AuthURL:      AuthURL,

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -35,8 +35,8 @@ const (
 	defaultDiskSize    = 10
 )
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -42,8 +42,8 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 	}
 }
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{

--- a/drivers/none/driver.go
+++ b/drivers/none/driver.go
@@ -19,7 +19,8 @@ type Driver struct {
 	URL string
 }
 
-func NewDriver(hostName, storePath string) *Driver {
+// NewDriver creates and returns a new instance of the driver
+func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		BaseDriver: &drivers.BaseDriver{
 			MachineName: hostName,
@@ -28,6 +29,8 @@ func NewDriver(hostName, storePath string) *Driver {
 	}
 }
 
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -446,7 +446,7 @@ func (c *GenericClient) Authenticate(d *Driver) error {
 		return err
 	}
 
-	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%d", version.ApiVersion))
+	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%d", version.APIVersion))
 
 	if d.Insecure {
 		// Configure custom TLS settings.

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -34,16 +34,16 @@ type Client interface {
 	RestartInstance(d *Driver) error
 	DeleteInstance(d *Driver) error
 	WaitForInstanceStatus(d *Driver, status string) error
-	GetInstanceIpAddresses(d *Driver) ([]IpAddress, error)
+	GetInstanceIPAddresses(d *Driver) ([]IPAddress, error)
 	CreateKeyPair(d *Driver, name string, publicKey string) error
 	DeleteKeyPair(d *Driver, name string) error
-	GetNetworkId(d *Driver) (string, error)
-	GetFlavorId(d *Driver) (string, error)
-	GetImageId(d *Driver) (string, error)
-	AssignFloatingIP(d *Driver, floatingIp *FloatingIp, portId string) error
-	GetFloatingIPs(d *Driver) ([]FloatingIp, error)
-	GetFloatingIpPoolId(d *Driver) (string, error)
-	GetInstancePortId(d *Driver) (string, error)
+	GetNetworkID(d *Driver) (string, error)
+	GetFlavorID(d *Driver) (string, error)
+	GetImageID(d *Driver) (string, error)
+	AssignFloatingIP(d *Driver, floatingIP *FloatingIP, portID string) error
+	GetFloatingIPs(d *Driver) ([]FloatingIP, error)
+	GetFloatingIPPoolID(d *Driver) (string, error)
+	GetInstancePortID(d *Driver) (string, error)
 }
 
 type GenericClient struct {
@@ -55,15 +55,15 @@ type GenericClient struct {
 func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 	serverOpts := servers.CreateOpts{
 		Name:             d.MachineName,
-		FlavorRef:        d.FlavorId,
-		ImageRef:         d.ImageId,
+		FlavorRef:        d.FlavorID,
+		ImageRef:         d.ImageID,
 		SecurityGroups:   d.SecurityGroups,
 		AvailabilityZone: d.AvailabilityZone,
 	}
-	if d.NetworkId != "" {
+	if d.NetworkID != "" {
 		serverOpts.Networks = []servers.Network{
 			{
-				UUID: d.NetworkId,
+				UUID: d.NetworkID,
 			},
 		}
 	}
@@ -85,7 +85,7 @@ const (
 	Fixed    string = "fixed"
 )
 
-type IpAddress struct {
+type IPAddress struct {
 	Network     string
 	AddressType string
 	Address     string
@@ -93,11 +93,11 @@ type IpAddress struct {
 	Mac         string
 }
 
-type FloatingIp struct {
-	Id        string
-	Ip        string
-	NetworkId string
-	PortId    string
+type FloatingIP struct {
+	ID        string
+	IP        string
+	NetworkID string
+	PortID    string
 }
 
 func (c *GenericClient) GetInstanceState(d *Driver) (string, error) {
@@ -109,28 +109,28 @@ func (c *GenericClient) GetInstanceState(d *Driver) (string, error) {
 }
 
 func (c *GenericClient) StartInstance(d *Driver) error {
-	if result := startstop.Start(c.Compute, d.MachineId); result.Err != nil {
+	if result := startstop.Start(c.Compute, d.MachineID); result.Err != nil {
 		return result.Err
 	}
 	return nil
 }
 
 func (c *GenericClient) StopInstance(d *Driver) error {
-	if result := startstop.Stop(c.Compute, d.MachineId); result.Err != nil {
+	if result := startstop.Stop(c.Compute, d.MachineID); result.Err != nil {
 		return result.Err
 	}
 	return nil
 }
 
 func (c *GenericClient) RestartInstance(d *Driver) error {
-	if result := servers.Reboot(c.Compute, d.MachineId, servers.SoftReboot); result.Err != nil {
+	if result := servers.Reboot(c.Compute, d.MachineID, servers.SoftReboot); result.Err != nil {
 		return result.Err
 	}
 	return nil
 }
 
 func (c *GenericClient) DeleteInstance(d *Driver) error {
-	if result := servers.Delete(c.Compute, d.MachineId); result.Err != nil {
+	if result := servers.Delete(c.Compute, d.MachineID); result.Err != nil {
 		return result.Err
 	}
 	return nil
@@ -138,7 +138,7 @@ func (c *GenericClient) DeleteInstance(d *Driver) error {
 
 func (c *GenericClient) WaitForInstanceStatus(d *Driver, status string) error {
 	return mcnutils.WaitForSpecificOrError(func() (bool, error) {
-		current, err := servers.Get(c.Compute, d.MachineId).Extract()
+		current, err := servers.Get(c.Compute, d.MachineID).Extract()
 		if err != nil {
 			return true, err
 		}
@@ -155,12 +155,12 @@ func (c *GenericClient) WaitForInstanceStatus(d *Driver, status string) error {
 	}, (d.ActiveTimeout / 4), 4*time.Second)
 }
 
-func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {
+func (c *GenericClient) GetInstanceIPAddresses(d *Driver) ([]IPAddress, error) {
 	server, err := c.GetServerDetail(d)
 	if err != nil {
 		return nil, err
 	}
-	addresses := []IpAddress{}
+	addresses := []IPAddress{}
 	for network, networkAddresses := range server.Addresses {
 		for _, element := range networkAddresses.([]interface{}) {
 			address := element.(map[string]interface{})
@@ -170,7 +170,7 @@ func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {
 				version = 4
 			}
 
-			addr := IpAddress{
+			addr := IPAddress{
 				Network:     network,
 				AddressType: Fixed,
 				Address:     address["addr"].(string),
@@ -191,18 +191,18 @@ func (c *GenericClient) GetInstanceIpAddresses(d *Driver) ([]IpAddress, error) {
 	return addresses, nil
 }
 
-func (c *GenericClient) GetNetworkId(d *Driver) (string, error) {
-	return c.getNetworkId(d, d.NetworkName)
+func (c *GenericClient) GetNetworkID(d *Driver) (string, error) {
+	return c.getNetworkID(d, d.NetworkName)
 }
 
-func (c *GenericClient) GetFloatingIpPoolId(d *Driver) (string, error) {
-	return c.getNetworkId(d, d.FloatingIpPool)
+func (c *GenericClient) GetFloatingIPPoolID(d *Driver) (string, error) {
+	return c.getNetworkID(d, d.FloatingIPPool)
 }
 
-func (c *GenericClient) getNetworkId(d *Driver, networkName string) (string, error) {
+func (c *GenericClient) getNetworkID(d *Driver, networkName string) (string, error) {
 	opts := networks.ListOpts{Name: networkName}
 	pager := networks.List(c.Network, opts)
-	networkId := ""
+	networkID := ""
 
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		networkList, err := networks.ExtractNetworks(page)
@@ -212,7 +212,7 @@ func (c *GenericClient) getNetworkId(d *Driver, networkName string) (string, err
 
 		for _, n := range networkList {
 			if n.Name == networkName {
-				networkId = n.ID
+				networkID = n.ID
 				return false, nil
 			}
 		}
@@ -220,12 +220,12 @@ func (c *GenericClient) getNetworkId(d *Driver, networkName string) (string, err
 		return true, nil
 	})
 
-	return networkId, err
+	return networkID, err
 }
 
-func (c *GenericClient) GetFlavorId(d *Driver) (string, error) {
+func (c *GenericClient) GetFlavorID(d *Driver) (string, error) {
 	pager := flavors.ListDetail(c.Compute, nil)
-	flavorId := ""
+	flavorID := ""
 
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		flavorList, err := flavors.ExtractFlavors(page)
@@ -235,7 +235,7 @@ func (c *GenericClient) GetFlavorId(d *Driver) (string, error) {
 
 		for _, f := range flavorList {
 			if f.Name == d.FlavorName {
-				flavorId = f.ID
+				flavorID = f.ID
 				return false, nil
 			}
 		}
@@ -243,13 +243,13 @@ func (c *GenericClient) GetFlavorId(d *Driver) (string, error) {
 		return true, nil
 	})
 
-	return flavorId, err
+	return flavorID, err
 }
 
-func (c *GenericClient) GetImageId(d *Driver) (string, error) {
+func (c *GenericClient) GetImageID(d *Driver) (string, error) {
 	opts := images.ListOpts{Name: d.ImageName}
 	pager := images.ListDetail(c.Compute, opts)
-	imageId := ""
+	imageID := ""
 
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		imageList, err := images.ExtractImages(page)
@@ -259,7 +259,7 @@ func (c *GenericClient) GetImageId(d *Driver) (string, error) {
 
 		for _, i := range imageList {
 			if i.Name == d.ImageName {
-				imageId = i.ID
+				imageID = i.ID
 				return false, nil
 			}
 		}
@@ -267,7 +267,7 @@ func (c *GenericClient) GetImageId(d *Driver) (string, error) {
 		return true, nil
 	})
 
-	return imageId, err
+	return imageID, err
 }
 
 func (c *GenericClient) CreateKeyPair(d *Driver, name string, publicKey string) error {
@@ -289,30 +289,30 @@ func (c *GenericClient) DeleteKeyPair(d *Driver, name string) error {
 }
 
 func (c *GenericClient) GetServerDetail(d *Driver) (*servers.Server, error) {
-	server, err := servers.Get(c.Compute, d.MachineId).Extract()
+	server, err := servers.Get(c.Compute, d.MachineID).Extract()
 	if err != nil {
 		return nil, err
 	}
 	return server, nil
 }
 
-func (c *GenericClient) AssignFloatingIP(d *Driver, floatingIp *FloatingIp, portId string) error {
-	if floatingIp.Id == "" {
+func (c *GenericClient) AssignFloatingIP(d *Driver, floatingIP *FloatingIP, portID string) error {
+	if floatingIP.ID == "" {
 		f, err := floatingips.Create(c.Network, floatingips.CreateOpts{
-			FloatingNetworkID: d.FloatingIpPoolId,
-			PortID:            portId,
+			FloatingNetworkID: d.FloatingIPPoolID,
+			PortID:            portID,
 		}).Extract()
 		if err != nil {
 			return err
 		}
-		floatingIp.Id = f.ID
-		floatingIp.Ip = f.FloatingIP
-		floatingIp.NetworkId = f.FloatingNetworkID
-		floatingIp.PortId = f.PortID
+		floatingIP.ID = f.ID
+		floatingIP.IP = f.FloatingIP
+		floatingIP.NetworkID = f.FloatingNetworkID
+		floatingIP.PortID = f.PortID
 		return nil
 	}
-	_, err := floatingips.Update(c.Network, floatingIp.Id, floatingips.UpdateOpts{
-		PortID: portId,
+	_, err := floatingips.Update(c.Network, floatingIP.ID, floatingips.UpdateOpts{
+		PortID: portID,
 	}).Extract()
 	if err != nil {
 		return err
@@ -320,23 +320,23 @@ func (c *GenericClient) AssignFloatingIP(d *Driver, floatingIp *FloatingIp, port
 	return nil
 }
 
-func (c *GenericClient) GetFloatingIPs(d *Driver) ([]FloatingIp, error) {
+func (c *GenericClient) GetFloatingIPs(d *Driver) ([]FloatingIP, error) {
 	pager := floatingips.List(c.Network, floatingips.ListOpts{
-		FloatingNetworkID: d.FloatingIpPoolId,
+		FloatingNetworkID: d.FloatingIPPoolID,
 	})
 
-	ips := []FloatingIp{}
+	ips := []FloatingIP{}
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		floatingipList, err := floatingips.ExtractFloatingIPs(page)
 		if err != nil {
 			return false, err
 		}
 		for _, f := range floatingipList {
-			ips = append(ips, FloatingIp{
-				Id:        f.ID,
-				Ip:        f.FloatingIP,
-				NetworkId: f.FloatingNetworkID,
-				PortId:    f.PortID,
+			ips = append(ips, FloatingIP{
+				ID:        f.ID,
+				IP:        f.FloatingIP,
+				NetworkID: f.FloatingNetworkID,
+				PortID:    f.PortID,
 			})
 		}
 		return true, nil
@@ -348,20 +348,20 @@ func (c *GenericClient) GetFloatingIPs(d *Driver) ([]FloatingIp, error) {
 	return ips, nil
 }
 
-func (c *GenericClient) GetInstancePortId(d *Driver) (string, error) {
+func (c *GenericClient) GetInstancePortID(d *Driver) (string, error) {
 	pager := ports.List(c.Network, ports.ListOpts{
-		DeviceID:  d.MachineId,
-		NetworkID: d.NetworkId,
+		DeviceID:  d.MachineID,
+		NetworkID: d.NetworkID,
 	})
 
-	var portId string
+	var portID string
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		portList, err := ports.ExtractPorts(page)
 		if err != nil {
 			return false, err
 		}
 		for _, port := range portList {
-			portId = port.ID
+			portID = port.ID
 			return false, nil
 		}
 		return true, nil
@@ -370,7 +370,7 @@ func (c *GenericClient) GetInstancePortId(d *Driver) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return portId, nil
+	return portID, nil
 }
 
 func (c *GenericClient) InitComputeClient(d *Driver) error {
@@ -421,23 +421,23 @@ func (c *GenericClient) Authenticate(d *Driver) error {
 	}
 
 	log.WithFields(log.Fields{
-		"AuthUrl":    d.AuthUrl,
+		"AuthUrl":    d.AuthURL,
 		"Insecure":   d.Insecure,
 		"DomainID":   d.DomainID,
 		"DomainName": d.DomainName,
 		"Username":   d.Username,
 		"TenantName": d.TenantName,
-		"TenantID":   d.TenantId,
+		"TenantID":   d.TenantID,
 	}).Debug("Authenticating...")
 
 	opts := gophercloud.AuthOptions{
-		IdentityEndpoint: d.AuthUrl,
+		IdentityEndpoint: d.AuthURL,
 		DomainID:         d.DomainID,
 		DomainName:       d.DomainName,
 		Username:         d.Username,
 		Password:         d.Password,
 		TenantName:       d.TenantName,
-		TenantID:         d.TenantId,
+		TenantID:         d.TenantID,
 		AllowReauth:      true,
 	}
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -49,6 +49,8 @@ const (
 	defaultActiveTimeout = 200
 )
 
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -201,6 +203,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return NewDerivedDriver(hostName, storePath)
 }

--- a/drivers/rackspace/client.go
+++ b/drivers/rackspace/client.go
@@ -41,7 +41,7 @@ func (c *Client) Authenticate(d *openstack.Driver) error {
 		return err
 	}
 
-	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%d", version.ApiVersion))
+	provider.UserAgent.Prepend(fmt.Sprintf("docker-machine/v%d", version.APIVersion))
 
 	err = rackspace.Authenticate(provider, opts)
 	if err != nil {

--- a/drivers/rackspace/client.go
+++ b/drivers/rackspace/client.go
@@ -64,12 +64,12 @@ func (c *Client) StopInstance(d *openstack.Driver) error {
 }
 
 // GetInstanceIpAddresses can be short-circuited with the server's AccessIPv4Addr on Rackspace.
-func (c *Client) GetInstanceIpAddresses(d *openstack.Driver) ([]openstack.IpAddress, error) {
+func (c *Client) GetInstanceIPAddresses(d *openstack.Driver) ([]openstack.IPAddress, error) {
 	server, err := c.GetServerDetail(d)
 	if err != nil {
 		return nil, err
 	}
-	return []openstack.IpAddress{
+	return []openstack.IPAddress{
 		{
 			Network:     "public",
 			Address:     server.AccessIPv4,

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -24,8 +24,8 @@ const (
 	defaultDockerInstall = "true"
 )
 
-// GetCreateFlags registers the "machine create" flags recognized by this driver, including
-// their help text and defaults.
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -80,7 +80,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
-// NewDriver instantiates a Rackspace driver.
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(machineName, storePath string) drivers.Driver {
 	log.WithFields(log.Fields{
 		"machineName": machineName,
@@ -93,7 +93,7 @@ func NewDriver(machineName, storePath string) drivers.Driver {
 	}
 }
 
-// DriverName is the user-visible name of this driver.
+// DriverName returns the name of the driver as it is registered
 func (d *Driver) DriverName() string {
 	return "rackspace"
 }
@@ -107,7 +107,8 @@ func missingEnvOrOption(setting, envVar, opt string) error {
 	)
 }
 
-// SetConfigFromFlags assigns and verifies the command-line arguments presented to the driver.
+// SetConfigFromFlags configures the driver with the object that was returned
+// by RegisterCreateFlags
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Username = flags.String("rackspace-username")
 	d.APIKey = flags.String("rackspace-api-key")

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -18,7 +18,7 @@ type Driver struct {
 
 const (
 	defaultEndpointType  = "publicURL"
-	defaultFlavorId      = "general1-1"
+	defaultFlavorID      = "general1-1"
 	defaultSSHUser       = "root"
 	defaultSSHPort       = 22
 	defaultDockerInstall = "true"
@@ -59,7 +59,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			Name:   "rackspace-flavor-id",
 			Usage:  "Rackspace flavor ID. Default: General Purpose 1GB",
-			Value:  defaultFlavorId,
+			Value:  defaultFlavorID,
 			EnvVar: "OS_FLAVOR_ID",
 		},
 		mcnflag.StringFlag{
@@ -114,8 +114,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.APIKey = flags.String("rackspace-api-key")
 	d.Region = flags.String("rackspace-region")
 	d.EndpointType = flags.String("rackspace-endpoint-type")
-	d.ImageId = flags.String("rackspace-image-id")
-	d.FlavorId = flags.String("rackspace-flavor-id")
+	d.ImageID = flags.String("rackspace-image-id")
+	d.FlavorID = flags.String("rackspace-flavor-id")
 	d.SSHUser = flags.String("rackspace-ssh-user")
 	d.SSHPort = flags.Int("rackspace-ssh-port")
 	d.SwarmMaster = flags.Bool("swarm-master")
@@ -132,11 +132,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		return missingEnvOrOption("API key", "OS_API_KEY", "--rackspace-api-key")
 	}
 
-	if d.ImageId == "" {
+	if d.ImageID == "" {
 		// Default to the Ubuntu 14.04 image.
 		// This is done here, rather than in the option registration, to keep the default value
 		// from making "machine create --help" ugly.
-		d.ImageId = "598a4282-f14b-4e50-af4c-b3e52749d9f9"
+		d.ImageID = "598a4282-f14b-4e50-af4c-b3e52749d9f9"
 	}
 
 	if d.EndpointType != "publicURL" && d.EndpointType != "adminURL" && d.EndpointType != "internalURL" {

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -51,6 +51,7 @@ const (
 	defaultPrivateVLANIP = 0
 )
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		Client: &Client{
@@ -73,6 +74,8 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 	}
 }
 
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	// Set hourly billing to true by default since codegangsta cli doesn't take default bool values
 	if os.Getenv("SOFTLAYER_HOURLY_BILLING") == "" {

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -62,8 +62,8 @@ type Driver struct {
 	NoShare             bool
 }
 
-// NewDriver creates a new VirtualBox driver with default settings.
-func NewDriver(hostName, storePath string) *Driver {
+// NewDriver creates and returns a new instance of the driver
+func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		VBoxManager: &VBoxCmdManager{},
 		BaseDriver: &drivers.BaseDriver{
@@ -79,8 +79,8 @@ func NewDriver(hostName, storePath string) *Driver {
 	}
 }
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.IntFlag{

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -408,7 +408,7 @@ func (d *Driver) Create() error {
 	return d.Start()
 }
 
-func (d *Driver) hostOnlyIpAvailable() bool {
+func (d *Driver) hostOnlyIPAvailable() bool {
 	ip, err := d.GetIP()
 	if err != nil {
 		log.Debugf("ERROR getting IP: %s", err)
@@ -471,7 +471,7 @@ func (d *Driver) Start() error {
 	}
 
 	// Bail if we don't get an IP from DHCP after a given number of seconds.
-	if err := mcnutils.WaitForSpecific(d.hostOnlyIpAvailable, 5, 4*time.Second); err != nil {
+	if err := mcnutils.WaitForSpecific(d.hostOnlyIPAvailable, 5, 4*time.Second); err != nil {
 		return err
 	}
 

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -178,5 +178,5 @@ func TestInvalidNetworkIpCIDR(t *testing.T) {
 }
 
 func newTestDriver(name string) *Driver {
-	return NewDriver(name, "")
+	return NewDriver(name, "").(*Driver)
 }

--- a/drivers/virtualbox/vm.go
+++ b/drivers/virtualbox/vm.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 )
 
-type VirtualBoxVM struct {
+type vm struct {
 	CPUs   int
 	Memory int
 }
 
-func (d *Driver) getVMInfo() (*VirtualBoxVM, error) {
+func (d *Driver) getVMInfo() (*vm, error) {
 	out, err := d.vbmOut("showvminfo", d.MachineName, "--machinereadable")
 	if err != nil {
 		return nil, err
@@ -22,9 +22,9 @@ func (d *Driver) getVMInfo() (*VirtualBoxVM, error) {
 	return parseVMInfo(r)
 }
 
-func parseVMInfo(r io.Reader) (*VirtualBoxVM, error) {
+func parseVMInfo(r io.Reader) (*vm, error) {
 	s := bufio.NewScanner(r)
-	vm := &VirtualBoxVM{}
+	vm := &vm{}
 	for s.Scan() {
 		line := s.Text()
 		if line == "" {

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -33,7 +33,6 @@ const (
 	isoConfigDrive = "configdrive.iso"
 )
 
-// Driver for VMware Fusion
 type Driver struct {
 	*drivers.BaseDriver
 	Memory         int
@@ -56,8 +55,8 @@ const (
 	defaultMemory   = 1024
 )
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -105,6 +104,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		CPUS:        defaultCpus,

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -45,8 +45,8 @@ const (
 	defaultDockerPort  = 2376
 )
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.StringFlag{
@@ -123,6 +123,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		Catalog:     defaultCatalog,
@@ -138,7 +139,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 	}
 }
 
-// Driver interface implementation
+// DriverName returns the name of the driver as it is registered
 func (d *Driver) DriverName() string {
 	return "vmwarevcloudair"
 }

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -53,8 +53,8 @@ const (
 	defaultDiskSize = 20000
 )
 
-// GetCreateFlags registers the flags this driver adds to
-// "docker hosts create"
+// GetCreateFlags returns the mcnflag.Flag slice representing the flags
+// that can be set, their descriptions and defaults.
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	return []mcnflag.Flag{
 		mcnflag.IntFlag{
@@ -123,6 +123,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
+// NewDriver creates and returns a new instance of the driver
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
 		CPU:      defaultCpus,

--- a/libmachine/auth/auth.go
+++ b/libmachine/auth/auth.go
@@ -1,6 +1,6 @@
 package auth
 
-type AuthOptions struct {
+type Options struct {
 	CertDir              string
 	CaCertPath           string
 	CaPrivateKeyPath     string

--- a/libmachine/cert/bootstrap.go
+++ b/libmachine/cert/bootstrap.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/machine/libmachine/mcnutils"
 )
 
-func BootstrapCertificates(authOptions *auth.AuthOptions) error {
+func BootstrapCertificates(authOptions *auth.Options) error {
 	certDir := authOptions.CertDir
 	caCertPath := authOptions.CaCertPath
 	caPrivateKeyPath := authOptions.CaPrivateKeyPath

--- a/libmachine/cert/cert_path_info.go
+++ b/libmachine/cert/cert_path_info.go
@@ -1,6 +1,6 @@
 package cert
 
-type CertPathInfo struct {
+type PathInfo struct {
 	CaCertPath       string
 	CaPrivateKeyPath string
 	ClientCertPath   string

--- a/libmachine/drivers/base_test.go
+++ b/libmachine/drivers/base_test.go
@@ -10,7 +10,7 @@ import (
 func TestIP(t *testing.T) {
 	cases := []struct {
 		baseDriver  *BaseDriver
-		expectedIp  string
+		expectedIP  string
 		expectedErr error
 	}{
 		{&BaseDriver{}, "", errors.New("IP address is not set")},
@@ -22,7 +22,7 @@ func TestIP(t *testing.T) {
 
 	for _, c := range cases {
 		ip, err := c.baseDriver.GetIP()
-		assert.Equal(t, c.expectedIp, ip)
+		assert.Equal(t, c.expectedIP, ip)
 		assert.Equal(t, c.expectedErr, err)
 	}
 }

--- a/libmachine/drivers/plugin/localbinary/plugin_test.go
+++ b/libmachine/drivers/plugin/localbinary/plugin_test.go
@@ -26,7 +26,7 @@ func (fe *FakeExecutor) Close() error {
 }
 
 func TestLocalBinaryPluginAddress(t *testing.T) {
-	lbp := &LocalBinaryPlugin{}
+	lbp := &Plugin{}
 	expectedAddr := "127.0.0.1:12345"
 
 	lbp.addrCh = make(chan string, 1)
@@ -55,7 +55,7 @@ func TestLocalBinaryPluginAddressTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping timeout test")
 	}
-	lbp := &LocalBinaryPlugin{}
+	lbp := &Plugin{}
 	lbp.addrCh = make(chan string, 1)
 	go func() {
 		_, err := lbp.Address()
@@ -67,7 +67,7 @@ func TestLocalBinaryPluginAddressTimeout(t *testing.T) {
 }
 
 func TestLocalBinaryPluginClose(t *testing.T) {
-	lbp := &LocalBinaryPlugin{}
+	lbp := &Plugin{}
 	lbp.stopCh = make(chan bool, 1)
 	go lbp.Close()
 	stopped := <-lbp.stopCh
@@ -99,7 +99,7 @@ func TestExecServer(t *testing.T) {
 		stderr: stderrReader,
 	}
 
-	lbp := &LocalBinaryPlugin{
+	lbp := &Plugin{
 		MachineName: machineName,
 		Executor:    fe,
 		addrCh:      make(chan string, 1),

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -28,7 +28,7 @@ Please use this plugin through the main 'docker-machine' binary.`)
 
 	libmachine.SetDebug(true)
 
-	rpcd := rpcdriver.NewRpcServerDriver(d)
+	rpcd := rpcdriver.NewRPCServerDriver(d)
 	rpc.Register(rpcd)
 	rpc.HandleHTTP()
 

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -16,13 +16,13 @@ var (
 	heartbeatInterval = 200 * time.Millisecond
 )
 
-type RpcClientDriver struct {
+type RPCClientDriver struct {
 	plugin          localbinary.DriverPlugin
 	heartbeatDoneCh chan bool
 	Client          *InternalClient
 }
 
-type RpcCall struct {
+type RPCCall struct {
 	ServiceMethod string
 	Args          interface{}
 	Reply         interface{}
@@ -30,22 +30,22 @@ type RpcCall struct {
 
 type InternalClient struct {
 	MachineName string
-	RpcClient   *rpc.Client
+	RPCClient   *rpc.Client
 }
 
 func (ic *InternalClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
-	if serviceMethod != "RpcServerDriver.Heartbeat" {
+	if serviceMethod != "RPCServerDriver.Heartbeat" {
 		log.Debugf("(%s) Calling %+v", ic.MachineName, serviceMethod)
 	}
-	return ic.RpcClient.Call(serviceMethod, args, reply)
+	return ic.RPCClient.Call(serviceMethod, args, reply)
 }
 
 func NewInternalClient(rpcclient *rpc.Client) *InternalClient {
 	return &InternalClient{
-		RpcClient: rpcclient,
+		RPCClient: rpcclient,
 	}
 }
-func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriver, error) {
+func NewRPCClientDriver(rawDriverData []byte, driverName string) (*RPCClientDriver, error) {
 	mcnName := ""
 
 	p := localbinary.NewLocalBinaryPlugin(driverName)
@@ -68,7 +68,7 @@ func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriv
 		return nil, err
 	}
 
-	c := &RpcClientDriver{
+	c := &RPCClientDriver{
 		Client:          NewInternalClient(rpcclient),
 		heartbeatDoneCh: make(chan bool),
 	}
@@ -79,7 +79,7 @@ func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriv
 			case <-heartbeatDoneCh:
 				return
 			default:
-				if err := c.Client.Call("RpcServerDriver.Heartbeat", struct{}{}, nil); err != nil {
+				if err := c.Client.Call("RPCServerDriver.Heartbeat", struct{}{}, nil); err != nil {
 					log.Warnf("Error attempting heartbeat call to plugin server: %s", err)
 				}
 				time.Sleep(heartbeatInterval)
@@ -88,7 +88,7 @@ func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriv
 	}(c.heartbeatDoneCh)
 
 	var version int
-	if err := c.Client.Call("RpcServerDriver.GetVersion", struct{}{}, &version); err != nil {
+	if err := c.Client.Call("RPCServerDriver.GetVersion", struct{}{}, &version); err != nil {
 		return nil, err
 	}
 	log.Debug("Using API Version ", version)
@@ -105,15 +105,15 @@ func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriv
 	return c, nil
 }
 
-func (c *RpcClientDriver) MarshalJSON() ([]byte, error) {
+func (c *RPCClientDriver) MarshalJSON() ([]byte, error) {
 	return c.GetConfigRaw()
 }
 
-func (c *RpcClientDriver) UnmarshalJSON(data []byte) error {
+func (c *RPCClientDriver) UnmarshalJSON(data []byte) error {
 	return c.SetConfigRaw(data)
 }
 
-func (c *RpcClientDriver) Close() error {
+func (c *RPCClientDriver) Close() error {
 	c.heartbeatDoneCh <- true
 	close(c.heartbeatDoneCh)
 
@@ -125,7 +125,7 @@ func (c *RpcClientDriver) Close() error {
 
 	log.Debug("Making call to close driver server")
 
-	if err := c.Client.Call("RpcServerDriver.Close", struct{}{}, nil); err != nil {
+	if err := c.Client.Call("RPCServerDriver.Close", struct{}{}, nil); err != nil {
 		return err
 	}
 
@@ -136,7 +136,7 @@ func (c *RpcClientDriver) Close() error {
 
 // Helper method to make requests which take no arguments and return simply a
 // string, e.g. "GetIP".
-func (c *RpcClientDriver) rpcStringCall(method string) (string, error) {
+func (c *RPCClientDriver) rpcStringCall(method string) (string, error) {
 	var info string
 
 	if err := c.Client.Call(method, struct{}{}, &info); err != nil {
@@ -146,32 +146,32 @@ func (c *RpcClientDriver) rpcStringCall(method string) (string, error) {
 	return info, nil
 }
 
-func (c *RpcClientDriver) GetCreateFlags() []mcnflag.Flag {
+func (c *RPCClientDriver) GetCreateFlags() []mcnflag.Flag {
 	var flags []mcnflag.Flag
 
-	if err := c.Client.Call("RpcServerDriver.GetCreateFlags", struct{}{}, &flags); err != nil {
+	if err := c.Client.Call("RPCServerDriver.GetCreateFlags", struct{}{}, &flags); err != nil {
 		log.Warnf("Error attempting call to get create flags: %s", err)
 	}
 
 	return flags
 }
 
-func (c *RpcClientDriver) SetConfigRaw(data []byte) error {
-	return c.Client.Call("RpcServerDriver.SetConfigRaw", data, nil)
+func (c *RPCClientDriver) SetConfigRaw(data []byte) error {
+	return c.Client.Call("RPCServerDriver.SetConfigRaw", data, nil)
 }
 
-func (c *RpcClientDriver) GetConfigRaw() ([]byte, error) {
+func (c *RPCClientDriver) GetConfigRaw() ([]byte, error) {
 	var data []byte
 
-	if err := c.Client.Call("RpcServerDriver.GetConfigRaw", struct{}{}, &data); err != nil {
+	if err := c.Client.Call("RPCServerDriver.GetConfigRaw", struct{}{}, &data); err != nil {
 		return nil, err
 	}
 
 	return data, nil
 }
 
-func (c *RpcClientDriver) DriverName() string {
-	driverName, err := c.rpcStringCall("RpcServerDriver.DriverName")
+func (c *RPCClientDriver) DriverName() string {
+	driverName, err := c.rpcStringCall("RPCServerDriver.DriverName")
 	if err != nil {
 		log.Warnf("Error attempting call to get driver name: %s", err)
 	}
@@ -179,16 +179,16 @@ func (c *RpcClientDriver) DriverName() string {
 	return driverName
 }
 
-func (c *RpcClientDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	return c.Client.Call("RpcServerDriver.SetConfigFromFlags", &flags, nil)
+func (c *RPCClientDriver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	return c.Client.Call("RPCServerDriver.SetConfigFromFlags", &flags, nil)
 }
 
-func (c *RpcClientDriver) GetURL() (string, error) {
-	return c.rpcStringCall("RpcServerDriver.GetURL")
+func (c *RPCClientDriver) GetURL() (string, error) {
+	return c.rpcStringCall("RPCServerDriver.GetURL")
 }
 
-func (c *RpcClientDriver) GetMachineName() string {
-	name, err := c.rpcStringCall("RpcServerDriver.GetMachineName")
+func (c *RPCClientDriver) GetMachineName() string {
+	name, err := c.rpcStringCall("RPCServerDriver.GetMachineName")
 	if err != nil {
 		log.Warnf("Error attempting call to get machine name: %s", err)
 	}
@@ -196,17 +196,17 @@ func (c *RpcClientDriver) GetMachineName() string {
 	return name
 }
 
-func (c *RpcClientDriver) GetIP() (string, error) {
-	return c.rpcStringCall("RpcServerDriver.GetIP")
+func (c *RPCClientDriver) GetIP() (string, error) {
+	return c.rpcStringCall("RPCServerDriver.GetIP")
 }
 
-func (c *RpcClientDriver) GetSSHHostname() (string, error) {
-	return c.rpcStringCall("RpcServerDriver.GetSSHHostname")
+func (c *RPCClientDriver) GetSSHHostname() (string, error) {
+	return c.rpcStringCall("RPCServerDriver.GetSSHHostname")
 }
 
 // TODO:  This method doesn't even make sense to have with RPC.
-func (c *RpcClientDriver) GetSSHKeyPath() string {
-	path, err := c.rpcStringCall("RpcServerDriver.GetSSHKeyPath")
+func (c *RPCClientDriver) GetSSHKeyPath() string {
+	path, err := c.rpcStringCall("RPCServerDriver.GetSSHKeyPath")
 	if err != nil {
 		log.Warnf("Error attempting call to get SSH key path: %s", err)
 	}
@@ -214,18 +214,18 @@ func (c *RpcClientDriver) GetSSHKeyPath() string {
 	return path
 }
 
-func (c *RpcClientDriver) GetSSHPort() (int, error) {
+func (c *RPCClientDriver) GetSSHPort() (int, error) {
 	var port int
 
-	if err := c.Client.Call("RpcServerDriver.GetSSHPort", struct{}{}, &port); err != nil {
+	if err := c.Client.Call("RPCServerDriver.GetSSHPort", struct{}{}, &port); err != nil {
 		return 0, err
 	}
 
 	return port, nil
 }
 
-func (c *RpcClientDriver) GetSSHUsername() string {
-	username, err := c.rpcStringCall("RpcServerDriver.GetSSHUsername")
+func (c *RPCClientDriver) GetSSHUsername() string {
+	username, err := c.rpcStringCall("RPCServerDriver.GetSSHUsername")
 	if err != nil {
 		log.Warnf("Error attempting call to get SSH username: %s", err)
 	}
@@ -233,56 +233,56 @@ func (c *RpcClientDriver) GetSSHUsername() string {
 	return username
 }
 
-func (c *RpcClientDriver) GetState() (state.State, error) {
+func (c *RPCClientDriver) GetState() (state.State, error) {
 	var s state.State
 
-	if err := c.Client.Call("RpcServerDriver.GetState", struct{}{}, &s); err != nil {
+	if err := c.Client.Call("RPCServerDriver.GetState", struct{}{}, &s); err != nil {
 		return state.Error, err
 	}
 
 	return s, nil
 }
 
-func (c *RpcClientDriver) PreCreateCheck() error {
-	return c.Client.Call("RpcServerDriver.PreCreateCheck", struct{}{}, nil)
+func (c *RPCClientDriver) PreCreateCheck() error {
+	return c.Client.Call("RPCServerDriver.PreCreateCheck", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Create() error {
-	return c.Client.Call("RpcServerDriver.Create", struct{}{}, nil)
+func (c *RPCClientDriver) Create() error {
+	return c.Client.Call("RPCServerDriver.Create", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Remove() error {
-	return c.Client.Call("RpcServerDriver.Remove", struct{}{}, nil)
+func (c *RPCClientDriver) Remove() error {
+	return c.Client.Call("RPCServerDriver.Remove", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Start() error {
-	return c.Client.Call("RpcServerDriver.Start", struct{}{}, nil)
+func (c *RPCClientDriver) Start() error {
+	return c.Client.Call("RPCServerDriver.Start", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Stop() error {
-	return c.Client.Call("RpcServerDriver.Stop", struct{}{}, nil)
+func (c *RPCClientDriver) Stop() error {
+	return c.Client.Call("RPCServerDriver.Stop", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Restart() error {
-	return c.Client.Call("RpcServerDriver.Restart", struct{}{}, nil)
+func (c *RPCClientDriver) Restart() error {
+	return c.Client.Call("RPCServerDriver.Restart", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) Kill() error {
-	return c.Client.Call("RpcServerDriver.Kill", struct{}{}, nil)
+func (c *RPCClientDriver) Kill() error {
+	return c.Client.Call("RPCServerDriver.Kill", struct{}{}, nil)
 }
 
-func (c *RpcClientDriver) LocalArtifactPath(file string) string {
+func (c *RPCClientDriver) LocalArtifactPath(file string) string {
 	var path string
 
-	if err := c.Client.Call("RpcServerDriver.LocalArtifactPath", file, &path); err != nil {
+	if err := c.Client.Call("RPCServerDriver.LocalArtifactPath", file, &path); err != nil {
 		log.Warnf("Error attempting call to get LocalArtifactPath: %s", err)
 	}
 
 	return path
 }
 
-func (c *RpcClientDriver) GlobalArtifactPath() string {
-	globalArtifactPath, err := c.rpcStringCall("RpcServerDriver.GlobalArtifactPath")
+func (c *RPCClientDriver) GlobalArtifactPath() string {
+	globalArtifactPath, err := c.rpcStringCall("RPCServerDriver.GlobalArtifactPath")
 	if err != nil {
 		log.Warnf("Error attempting call to get GlobalArtifactPath: %s", err)
 	}
@@ -290,6 +290,6 @@ func (c *RpcClientDriver) GlobalArtifactPath() string {
 	return globalArtifactPath
 }
 
-func (c *RpcClientDriver) Upgrade() error {
-	return c.Client.Call("RpcServerDriver.Upgrade", struct{}{}, nil)
+func (c *RPCClientDriver) Upgrade() error {
+	return c.Client.Call("RPCServerDriver.Upgrade", struct{}{}, nil)
 }

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -12,18 +12,18 @@ import (
 )
 
 func init() {
-	gob.Register(new(RpcFlags))
+	gob.Register(new(RPCFlags))
 	gob.Register(new(mcnflag.IntFlag))
 	gob.Register(new(mcnflag.StringFlag))
 	gob.Register(new(mcnflag.StringSliceFlag))
 	gob.Register(new(mcnflag.BoolFlag))
 }
 
-type RpcFlags struct {
+type RPCFlags struct {
 	Values map[string]interface{}
 }
 
-func (r RpcFlags) Get(key string) interface{} {
+func (r RPCFlags) Get(key string) interface{} {
 	val, ok := r.Values[key]
 	if !ok {
 		log.Warnf("Trying to access option %s which does not exist", key)
@@ -32,7 +32,7 @@ func (r RpcFlags) Get(key string) interface{} {
 	return val
 }
 
-func (r RpcFlags) String(key string) string {
+func (r RPCFlags) String(key string) string {
 	val, ok := r.Get(key).(string)
 	if !ok {
 		log.Warnf("Type assertion did not go smoothly to string for key %s", key)
@@ -40,7 +40,7 @@ func (r RpcFlags) String(key string) string {
 	return val
 }
 
-func (r RpcFlags) StringSlice(key string) []string {
+func (r RPCFlags) StringSlice(key string) []string {
 	val, ok := r.Get(key).([]string)
 	if !ok {
 		log.Warnf("Type assertion did not go smoothly to string slice for key %s", key)
@@ -48,7 +48,7 @@ func (r RpcFlags) StringSlice(key string) []string {
 	return val
 }
 
-func (r RpcFlags) Int(key string) int {
+func (r RPCFlags) Int(key string) int {
 	val, ok := r.Get(key).(int)
 	if !ok {
 		log.Warnf("Type assertion did not go smoothly to int for key %s", key)
@@ -56,7 +56,7 @@ func (r RpcFlags) Int(key string) int {
 	return val
 }
 
-func (r RpcFlags) Bool(key string) bool {
+func (r RPCFlags) Bool(key string) bool {
 	val, ok := r.Get(key).(bool)
 	if !ok {
 		log.Warnf("Type assertion did not go smoothly to bool for key %s", key)
@@ -64,31 +64,31 @@ func (r RpcFlags) Bool(key string) bool {
 	return val
 }
 
-type RpcServerDriver struct {
+type RPCServerDriver struct {
 	ActualDriver drivers.Driver
 	CloseCh      chan bool
 	HeartbeatCh  chan bool
 }
 
-func NewRpcServerDriver(d drivers.Driver) *RpcServerDriver {
-	return &RpcServerDriver{
+func NewRPCServerDriver(d drivers.Driver) *RPCServerDriver {
+	return &RPCServerDriver{
 		ActualDriver: d,
 		CloseCh:      make(chan bool),
 		HeartbeatCh:  make(chan bool),
 	}
 }
 
-func (r *RpcServerDriver) Close(_, _ *struct{}) error {
+func (r *RPCServerDriver) Close(_, _ *struct{}) error {
 	r.CloseCh <- true
 	return nil
 }
 
-func (r *RpcServerDriver) GetVersion(_ *struct{}, reply *int) error {
-	*reply = version.ApiVersion
+func (r *RPCServerDriver) GetVersion(_ *struct{}, reply *int) error {
+	*reply = version.APIVersion
 	return nil
 }
 
-func (r *RpcServerDriver) GetConfigRaw(_ *struct{}, reply *[]byte) error {
+func (r *RPCServerDriver) GetConfigRaw(_ *struct{}, reply *[]byte) error {
 	driverData, err := json.Marshal(r.ActualDriver)
 	if err != nil {
 		return err
@@ -99,99 +99,99 @@ func (r *RpcServerDriver) GetConfigRaw(_ *struct{}, reply *[]byte) error {
 	return nil
 }
 
-func (r *RpcServerDriver) GetCreateFlags(_ *struct{}, reply *[]mcnflag.Flag) error {
+func (r *RPCServerDriver) GetCreateFlags(_ *struct{}, reply *[]mcnflag.Flag) error {
 	*reply = r.ActualDriver.GetCreateFlags()
 	return nil
 }
 
-func (r *RpcServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
+func (r *RPCServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
 	return json.Unmarshal(data, &r.ActualDriver)
 }
 
-func (r *RpcServerDriver) Create(_, _ *struct{}) error {
+func (r *RPCServerDriver) Create(_, _ *struct{}) error {
 	return r.ActualDriver.Create()
 }
 
-func (r *RpcServerDriver) DriverName(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) DriverName(_ *struct{}, reply *string) error {
 	*reply = r.ActualDriver.DriverName()
 	return nil
 }
 
-func (r *RpcServerDriver) GetIP(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetIP(_ *struct{}, reply *string) error {
 	ip, err := r.ActualDriver.GetIP()
 	*reply = ip
 	return err
 }
 
-func (r *RpcServerDriver) GetMachineName(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetMachineName(_ *struct{}, reply *string) error {
 	*reply = r.ActualDriver.GetMachineName()
 	return nil
 }
 
-func (r *RpcServerDriver) GetSSHHostname(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetSSHHostname(_ *struct{}, reply *string) error {
 	hostname, err := r.ActualDriver.GetSSHHostname()
 	*reply = hostname
 	return err
 }
 
-func (r *RpcServerDriver) GetSSHKeyPath(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetSSHKeyPath(_ *struct{}, reply *string) error {
 	*reply = r.ActualDriver.GetSSHKeyPath()
 	return nil
 }
 
 // GetSSHPort returns port for use with ssh
-func (r *RpcServerDriver) GetSSHPort(_ *struct{}, reply *int) error {
+func (r *RPCServerDriver) GetSSHPort(_ *struct{}, reply *int) error {
 	port, err := r.ActualDriver.GetSSHPort()
 	*reply = port
 	return err
 }
 
-func (r *RpcServerDriver) GetSSHUsername(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetSSHUsername(_ *struct{}, reply *string) error {
 	*reply = r.ActualDriver.GetSSHUsername()
 	return nil
 }
 
-func (r *RpcServerDriver) GetURL(_ *struct{}, reply *string) error {
+func (r *RPCServerDriver) GetURL(_ *struct{}, reply *string) error {
 	info, err := r.ActualDriver.GetURL()
 	*reply = info
 	return err
 }
 
-func (r *RpcServerDriver) GetState(_ *struct{}, reply *state.State) error {
+func (r *RPCServerDriver) GetState(_ *struct{}, reply *state.State) error {
 	s, err := r.ActualDriver.GetState()
 	*reply = s
 	return err
 }
 
-func (r *RpcServerDriver) Kill(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Kill(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Kill()
 }
 
-func (r *RpcServerDriver) PreCreateCheck(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) PreCreateCheck(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.PreCreateCheck()
 }
 
-func (r *RpcServerDriver) Remove(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Remove(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Remove()
 }
 
-func (r *RpcServerDriver) Restart(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Restart(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Restart()
 }
 
-func (r *RpcServerDriver) SetConfigFromFlags(flags *drivers.DriverOptions, _ *struct{}) error {
+func (r *RPCServerDriver) SetConfigFromFlags(flags *drivers.DriverOptions, _ *struct{}) error {
 	return r.ActualDriver.SetConfigFromFlags(*flags)
 }
 
-func (r *RpcServerDriver) Start(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Start(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Start()
 }
 
-func (r *RpcServerDriver) Stop(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Stop(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Stop()
 }
 
-func (r *RpcServerDriver) Heartbeat(_ *struct{}, _ *struct{}) error {
+func (r *RPCServerDriver) Heartbeat(_ *struct{}, _ *struct{}) error {
 	r.HeartbeatCh <- true
 	return nil
 }

--- a/libmachine/engine/engine.go
+++ b/libmachine/engine/engine.go
@@ -1,8 +1,8 @@
 package engine
 
-type EngineOptions struct {
+type Options struct {
 	ArbitraryFlags   []string
-	Dns              []string
+	DNS              []string
 	GraphDir         string
 	Env              []string
 	Ipv6             bool
@@ -11,7 +11,7 @@ type EngineOptions struct {
 	LogLevel         string
 	StorageDriver    string
 	SelinuxEnabled   bool
-	TlsVerify        bool
+	TLSVerify        bool
 	RegistryMirror   []string
 	InstallURL       string
 }

--- a/libmachine/examples/vbox_create.go
+++ b/libmachine/examples/vbox_create.go
@@ -25,7 +25,7 @@ func main() {
 	hostName := "myfunhost"
 
 	// Set some options on the provider...
-	driver := virtualbox.NewDriver(hostName, "/tmp/automatic")
+	driver := virtualbox.NewDriver(hostName, "/tmp/automatic").(*virtualbox.Driver)
 	driver.CPU = 2
 	driver.Memory = 2048
 

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -28,24 +28,24 @@ type Host struct {
 	ConfigVersion int
 	Driver        drivers.Driver
 	DriverName    string
-	HostOptions   *HostOptions
+	HostOptions   *Options
 	Name          string
 	RawDriver     []byte
 }
 
-type HostOptions struct {
+type Options struct {
 	Driver        string
 	Memory        int
 	Disk          int
-	EngineOptions *engine.EngineOptions
-	SwarmOptions  *swarm.SwarmOptions
-	AuthOptions   *auth.AuthOptions
+	EngineOptions *engine.Options
+	SwarmOptions  *swarm.Options
+	AuthOptions   *auth.Options
 }
 
-type HostMetadata struct {
+type Metadata struct {
 	ConfigVersion int
 	DriverName    string
-	HostOptions   HostOptions
+	HostOptions   Options
 }
 
 func ValidateHostName(name string) bool {
@@ -160,7 +160,7 @@ func (h *Host) ConfigureAuth() error {
 	// and modularity of the provisioners should be).
 	//
 	// Call provision to re-provision the certs properly.
-	if err := provisioner.Provision(swarm.SwarmOptions{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
+	if err := provisioner.Provision(swarm.Options{}, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
 		return err
 	}
 

--- a/libmachine/host/host_v0.go
+++ b/libmachine/host/host_v0.go
@@ -2,12 +2,12 @@ package host
 
 import "github.com/docker/machine/libmachine/drivers"
 
-type HostV0 struct {
+type V0 struct {
 	Name          string `json:"-"`
 	Driver        drivers.Driver
 	DriverName    string
 	ConfigVersion int
-	HostOptions   *HostOptions
+	HostOptions   *Options
 
 	StorePath      string
 	CaCertPath     string
@@ -21,8 +21,8 @@ type HostV0 struct {
 	ClientKeyPath  string
 }
 
-type HostMetadataV0 struct {
-	HostOptions HostOptions
+type MetadataV0 struct {
+	HostOptions Options
 	DriverName  string
 
 	ConfigVersion  int

--- a/libmachine/host/host_v2.go
+++ b/libmachine/host/host_v2.go
@@ -2,10 +2,10 @@ package host
 
 import "github.com/docker/machine/libmachine/drivers"
 
-type HostV2 struct {
+type V2 struct {
 	ConfigVersion int
 	Driver        drivers.Driver
 	DriverName    string
-	HostOptions   *HostOptions
+	HostOptions   *Options
 	Name          string
 }

--- a/libmachine/host/migrate.go
+++ b/libmachine/host/migrate.go
@@ -22,14 +22,14 @@ func (r *RawDataDriver) MarshalJSON() ([]byte, error) {
 	return r.data, nil
 }
 
-func getMigratedHostMetadata(data []byte) (*HostMetadata, error) {
+func getMigratedHostMetadata(data []byte) (*Metadata, error) {
 	// HostMetadata is for a "first pass" so we can then load the driver
 	var (
-		hostMetadata *HostMetadataV0
+		hostMetadata *MetadataV0
 	)
 
 	if err := json.Unmarshal(data, &hostMetadata); err != nil {
-		return &HostMetadata{}, err
+		return &Metadata{}, err
 	}
 
 	migratedHostMetadata := MigrateHostMetadataV0ToHostMetadataV1(hostMetadata)
@@ -41,8 +41,8 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 	var (
 		migrationNeeded    = false
 		migrationPerformed = false
-		hostV1             *HostV1
-		hostV2             *HostV2
+		hostV1             *V1
+		hostV2             *V2
 	)
 
 	migratedHostMetadata, err := getMigratedHostMetadata(data)
@@ -91,7 +91,7 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 			log.Debugf("Migrating to config v%d", h.ConfigVersion)
 			switch h.ConfigVersion {
 			case 0:
-				hostV0 := &HostV0{
+				hostV0 := &V0{
 					Driver: driver,
 				}
 				if err := json.Unmarshal(data, &hostV0); err != nil {
@@ -100,7 +100,7 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 				hostV1 = MigrateHostV0ToHostV1(hostV0)
 			case 1:
 				if hostV1 == nil {
-					hostV1 = &HostV1{
+					hostV1 = &V1{
 						Driver: driver,
 					}
 					if err := json.Unmarshal(data, &hostV1); err != nil {
@@ -110,7 +110,7 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 				hostV2 = MigrateHostV1ToHostV2(hostV1)
 			case 2:
 				if hostV2 == nil {
-					hostV2 = &HostV2{
+					hostV2 = &V2{
 						Driver: driver,
 					}
 					if err := json.Unmarshal(data, &hostV2); err != nil {

--- a/libmachine/host/migrate.go
+++ b/libmachine/host/migrate.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 
 	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/version"
 )
 
 type RawDataDriver struct {
-	*none.Driver
+	drivers.Driver
 	data []byte // passed directly back when invoking json.Marshal on this type
 }
 

--- a/libmachine/host/migrate_v0_v1.go
+++ b/libmachine/host/migrate_v0_v1.go
@@ -15,14 +15,14 @@ import (
 
 // validates host config and modifies if needed
 // this is used for configuration updates
-func MigrateHostV0ToHostV1(hostV0 *HostV0) *HostV1 {
-	hostV1 := &HostV1{
+func MigrateHostV0ToHostV1(hostV0 *V0) *V1 {
+	hostV1 := &V1{
 		Driver: hostV0.Driver,
 	}
 
-	hostV1.HostOptions = &HostOptionsV1{}
-	hostV1.HostOptions.EngineOptions = &engine.EngineOptions{}
-	hostV1.HostOptions.SwarmOptions = &swarm.SwarmOptions{
+	hostV1.HostOptions = &OptionsV1{}
+	hostV1.HostOptions.EngineOptions = &engine.Options{}
+	hostV1.HostOptions.SwarmOptions = &swarm.Options{
 		Address:   "",
 		Discovery: hostV0.SwarmDiscovery,
 		Host:      hostV0.SwarmHost,
@@ -46,11 +46,11 @@ func MigrateHostV0ToHostV1(hostV0 *HostV0) *HostV1 {
 
 // fills nested host metadata and modifies if needed
 // this is used for configuration updates
-func MigrateHostMetadataV0ToHostMetadataV1(m *HostMetadataV0) *HostMetadata {
-	hostMetadata := &HostMetadata{}
+func MigrateHostMetadataV0ToHostMetadataV1(m *MetadataV0) *Metadata {
+	hostMetadata := &Metadata{}
 	hostMetadata.DriverName = m.DriverName
-	hostMetadata.HostOptions.EngineOptions = &engine.EngineOptions{}
-	hostMetadata.HostOptions.AuthOptions = &auth.AuthOptions{
+	hostMetadata.HostOptions.EngineOptions = &engine.Options{}
+	hostMetadata.HostOptions.AuthOptions = &auth.Options{
 		StorePath:            m.StorePath,
 		CaCertPath:           m.CaCertPath,
 		CaCertRemotePath:     "",

--- a/libmachine/host/migrate_v0_v1_test.go
+++ b/libmachine/host/migrate_v0_v1_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMigrateHostV0ToV1(t *testing.T) {
 	mcndirs.BaseDir = "/tmp/migration"
-	originalHost := &HostV0{
+	originalHost := &V0{
 		HostOptions:    nil,
 		SwarmDiscovery: "token://foobar",
 		SwarmHost:      "1.2.3.4:2376",
@@ -24,8 +24,8 @@ func TestMigrateHostV0ToV1(t *testing.T) {
 		ServerCertPath: "/tmp/migration/certs/server.pem",
 		ServerKeyPath:  "/tmp/migration/certs/server-key.pem",
 	}
-	hostOptions := &HostOptionsV1{
-		SwarmOptions: &swarm.SwarmOptions{
+	hostOptions := &OptionsV1{
+		SwarmOptions: &swarm.Options{
 			Master:    true,
 			Discovery: "token://foobar",
 			Host:      "1.2.3.4:2376",
@@ -38,10 +38,10 @@ func TestMigrateHostV0ToV1(t *testing.T) {
 			ServerCertPath: "/tmp/migration/certs/server.pem",
 			ServerKeyPath:  "/tmp/migration/certs/server-key.pem",
 		},
-		EngineOptions: &engine.EngineOptions{},
+		EngineOptions: &engine.Options{},
 	}
 
-	expectedHost := &HostV1{
+	expectedHost := &V1{
 		HostOptions: hostOptions,
 	}
 
@@ -55,8 +55,8 @@ func TestMigrateHostV0ToV1(t *testing.T) {
 }
 
 func TestMigrateHostMetadataV0ToV1(t *testing.T) {
-	metadata := &HostMetadataV0{
-		HostOptions: HostOptions{
+	metadata := &MetadataV0{
+		HostOptions: Options{
 			EngineOptions: nil,
 			AuthOptions:   nil,
 		},
@@ -64,15 +64,15 @@ func TestMigrateHostMetadataV0ToV1(t *testing.T) {
 		CaCertPath:     "/tmp/store/certs/ca.pem",
 		ServerCertPath: "/tmp/store/certs/server.pem",
 	}
-	expectedAuthOptions := &auth.AuthOptions{
+	expectedAuthOptions := &auth.Options{
 		StorePath:      "/tmp/store",
 		CaCertPath:     "/tmp/store/certs/ca.pem",
 		ServerCertPath: "/tmp/store/certs/server.pem",
 	}
 
-	expectedMetadata := &HostMetadata{
-		HostOptions: HostOptions{
-			EngineOptions: &engine.EngineOptions{},
+	expectedMetadata := &Metadata{
+		HostOptions: Options{
+			EngineOptions: &engine.Options{},
 			AuthOptions:   expectedAuthOptions,
 		},
 	}

--- a/libmachine/host/migrate_v1_v2.go
+++ b/libmachine/host/migrate_v1_v2.go
@@ -22,43 +22,43 @@ type AuthOptionsV1 struct {
 	ClientCertPath       string
 }
 
-type HostOptionsV1 struct {
+type OptionsV1 struct {
 	Driver        string
 	Memory        int
 	Disk          int
-	EngineOptions *engine.EngineOptions
-	SwarmOptions  *swarm.SwarmOptions
+	EngineOptions *engine.Options
+	SwarmOptions  *swarm.Options
 	AuthOptions   *AuthOptionsV1
 }
 
-type HostV1 struct {
+type V1 struct {
 	ConfigVersion int
 	Driver        drivers.Driver
 	DriverName    string
-	HostOptions   *HostOptionsV1
+	HostOptions   *OptionsV1
 	Name          string `json:"-"`
 	StorePath     string
 }
 
-func MigrateHostV1ToHostV2(hostV1 *HostV1) *HostV2 {
+func MigrateHostV1ToHostV2(hostV1 *V1) *V2 {
 	// Changed:  Put StorePath directly in AuthOptions (for provisioning),
 	// and AuthOptions.PrivateKeyPath => AuthOptions.CaPrivateKeyPath
 	// Also, CertDir has been added.
 
 	globalStorePath := filepath.Dir(filepath.Dir(hostV1.StorePath))
 
-	h := &HostV2{
+	h := &V2{
 		ConfigVersion: hostV1.ConfigVersion,
 		Driver:        hostV1.Driver,
 		Name:          hostV1.Driver.GetMachineName(),
 		DriverName:    hostV1.DriverName,
-		HostOptions: &HostOptions{
+		HostOptions: &Options{
 			Driver:        hostV1.HostOptions.Driver,
 			Memory:        hostV1.HostOptions.Memory,
 			Disk:          hostV1.HostOptions.Disk,
 			EngineOptions: hostV1.HostOptions.EngineOptions,
 			SwarmOptions:  hostV1.HostOptions.SwarmOptions,
-			AuthOptions: &auth.AuthOptions{
+			AuthOptions: &auth.Options{
 				CertDir:              filepath.Join(globalStorePath, "certs"),
 				CaCertPath:           hostV1.HostOptions.AuthOptions.CaCertPath,
 				CaPrivateKeyPath:     hostV1.HostOptions.AuthOptions.PrivateKeyPath,

--- a/libmachine/host/migrate_v2_v3.go
+++ b/libmachine/host/migrate_v2_v3.go
@@ -11,7 +11,7 @@ type RawHost struct {
 	Driver *json.RawMessage
 }
 
-func MigrateHostV2ToHostV3(hostV2 *HostV2, data []byte, storePath string) *Host {
+func MigrateHostV2ToHostV3(hostV2 *V2, data []byte, storePath string) *Host {
 	// Migrate to include RawDriver so that driver plugin will work
 	// smoothly.
 	rawHost := &RawHost{}

--- a/libmachine/hosttest/default_test_host.go
+++ b/libmachine/hosttest/default_test_host.go
@@ -51,10 +51,10 @@ func GetTestDriverFlags() *DriverOptionsMock {
 }
 
 func GetDefaultTestHost() (*host.Host, error) {
-	hostOptions := &host.HostOptions{
-		EngineOptions: &engine.EngineOptions{},
-		SwarmOptions:  &swarm.SwarmOptions{},
-		AuthOptions: &auth.AuthOptions{
+	hostOptions := &host.Options{
+		EngineOptions: &engine.Options{},
+		SwarmOptions:  &swarm.Options{},
+		AuthOptions: &auth.Options{
 			CaCertPath:       HostTestCaCert,
 			CaPrivateKeyPath: HostTestPrivateKey,
 		},

--- a/libmachine/log/log.go
+++ b/libmachine/log/log.go
@@ -37,7 +37,7 @@ var (
 	l = StandardLogger{
 		mu: &sync.Mutex{},
 	}
-	IsDebug bool = false
+	IsDebug = false
 )
 
 type Fields map[string]interface{}

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	GithubApiToken string
+	GithubAPIToken string
 )
 
 const (
@@ -47,8 +47,8 @@ type B2dUtils struct {
 	isoFilename      string
 	commonIsoPath    string
 	imgCachePath     string
-	githubApiBaseUrl string
-	githubBaseUrl    string
+	githubAPIBaseURL string
+	githubBaseURL    string
 }
 
 func NewB2dUtils(storePath string) *B2dUtils {
@@ -63,14 +63,14 @@ func NewB2dUtils(storePath string) *B2dUtils {
 	}
 }
 
-func (b *B2dUtils) getReleasesRequest(apiUrl string) (*http.Request, error) {
-	req, err := http.NewRequest("GET", apiUrl, nil)
+func (b *B2dUtils) getReleasesRequest(apiURL string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if GithubApiToken != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("token %s", GithubApiToken))
+	if GithubAPIToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("token %s", GithubAPIToken))
 	}
 
 	return req, nil
@@ -78,16 +78,16 @@ func (b *B2dUtils) getReleasesRequest(apiUrl string) (*http.Request, error) {
 
 // Get the latest boot2docker release tag name (e.g. "v0.6.0").
 // FIXME: find or create some other way to get the "latest release" of boot2docker since the GitHub API has a pretty low rate limit on API requests
-func (b *B2dUtils) GetLatestBoot2DockerReleaseURL(apiUrl string) (string, error) {
-	if apiUrl == "" {
-		apiUrl = "https://api.github.com/repos/boot2docker/boot2docker/releases"
+func (b *B2dUtils) GetLatestBoot2DockerReleaseURL(apiURL string) (string, error) {
+	if apiURL == "" {
+		apiURL = "https://api.github.com/repos/boot2docker/boot2docker/releases"
 	}
-	isoUrl := ""
+	isoURL := ""
 	// match github (enterprise) release urls:
 	// https://api.github.com/repos/../../releases or
 	// https://some.github.enterprise/api/v3/repos/../../releases
 	re := regexp.MustCompile("(https?)://([^/]+)(/api/v3)?/repos/([^/]+)/([^/]+)/releases")
-	if matches := re.FindStringSubmatch(apiUrl); len(matches) == 6 {
+	if matches := re.FindStringSubmatch(apiURL); len(matches) == 6 {
 		scheme := matches[1]
 		host := matches[2]
 		org := matches[4]
@@ -96,7 +96,7 @@ func (b *B2dUtils) GetLatestBoot2DockerReleaseURL(apiUrl string) (string, error)
 			host = "github.com"
 		}
 		client := getClient()
-		req, err := b.getReleasesRequest(apiUrl)
+		req, err := b.getReleasesRequest(apiURL)
 		if err != nil {
 			return "", err
 		}
@@ -118,13 +118,13 @@ func (b *B2dUtils) GetLatestBoot2DockerReleaseURL(apiUrl string) (string, error)
 
 		tag := t[0].TagName
 		log.Infof("Latest release for %s/%s/%s is %s\n", host, org, repo, tag)
-		isoUrl = fmt.Sprintf("%s://%s/%s/%s/releases/download/%s/boot2docker.iso", scheme, host, org, repo, tag)
+		isoURL = fmt.Sprintf("%s://%s/%s/%s/releases/download/%s/boot2docker.iso", scheme, host, org, repo, tag)
 	} else {
 		//does not match a github releases api url
-		isoUrl = apiUrl
+		isoURL = apiURL
 	}
 
-	return isoUrl, nil
+	return isoURL, nil
 }
 
 func removeFileIfExists(name string) error {
@@ -137,8 +137,8 @@ func removeFileIfExists(name string) error {
 }
 
 // Download boot2docker ISO image for the given tag and save it at dest.
-func (b *B2dUtils) DownloadISO(dir, file, isoUrl string) error {
-	u, err := url.Parse(isoUrl)
+func (b *B2dUtils) DownloadISO(dir, file, isoURL string) error {
+	u, err := url.Parse(isoURL)
 	var src io.ReadCloser
 	if u.Scheme == "file" || u.Scheme == "" {
 		s, err := os.Open(u.Path)
@@ -148,7 +148,7 @@ func (b *B2dUtils) DownloadISO(dir, file, isoUrl string) error {
 		src = s
 	} else {
 		client := getClient()
-		s, err := client.Get(isoUrl)
+		s, err := client.Get(isoURL)
 		if err != nil {
 			return err
 		}
@@ -194,18 +194,18 @@ func (b *B2dUtils) DownloadISO(dir, file, isoUrl string) error {
 	return nil
 }
 
-func (b *B2dUtils) DownloadLatestBoot2Docker(apiUrl string) error {
-	latestReleaseUrl, err := b.GetLatestBoot2DockerReleaseURL(apiUrl)
+func (b *B2dUtils) DownloadLatestBoot2Docker(apiURL string) error {
+	latestReleaseURL, err := b.GetLatestBoot2DockerReleaseURL(apiURL)
 	if err != nil {
 		return err
 	}
 
-	return b.DownloadISOFromURL(latestReleaseUrl)
+	return b.DownloadISOFromURL(latestReleaseURL)
 }
 
-func (b *B2dUtils) DownloadISOFromURL(latestReleaseUrl string) error {
-	log.Infof("Downloading %s to %s...", latestReleaseUrl, b.commonIsoPath)
-	if err := b.DownloadISO(b.imgCachePath, b.isoFilename, latestReleaseUrl); err != nil {
+func (b *B2dUtils) DownloadISOFromURL(latestReleaseURL string) error {
+	log.Infof("Downloading %s to %s...", latestReleaseURL, b.commonIsoPath)
+	if err := b.DownloadISO(b.imgCachePath, b.isoFilename, latestReleaseURL); err != nil {
 		return err
 	}
 
@@ -235,9 +235,9 @@ func (b *B2dUtils) CopyIsoToMachineDir(isoURL, machineName string) error {
 	} else {
 		//if ISO is specified, check if it matches a github releases url or fallback
 		//to a direct download
-		if downloadUrl, err := b.GetLatestBoot2DockerReleaseURL(isoURL); err == nil {
-			log.Infof("Downloading %s from %s...", b.isoFilename, downloadUrl)
-			if err := b.DownloadISO(machineDir, b.isoFilename, downloadUrl); err != nil {
+		if downloadURL, err := b.GetLatestBoot2DockerReleaseURL(isoURL); err == nil {
+			log.Infof("Downloading %s from %s...", b.isoFilename, downloadURL)
+			if err := b.DownloadISO(machineDir, b.isoFilename, downloadURL); err != nil {
 				return err
 			}
 		} else {

--- a/libmachine/mcnutils/b2d_test.go
+++ b/libmachine/mcnutils/b2d_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestGetLatestBoot2DockerReleaseUrl(t *testing.T) {
+func TestGetLatestBoot2DockerReleaseURL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respText := `[{"tag_name": "0.1"}]`
 		w.Write([]byte(respText))
@@ -17,14 +17,14 @@ func TestGetLatestBoot2DockerReleaseUrl(t *testing.T) {
 	defer ts.Close()
 
 	b := NewB2dUtils("/tmp/isos")
-	isoUrl, err := b.GetLatestBoot2DockerReleaseURL(ts.URL + "/repos/org/repo/releases")
+	isoURL, err := b.GetLatestBoot2DockerReleaseURL(ts.URL + "/repos/org/repo/releases")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expectedUrl := fmt.Sprintf("%s/org/repo/releases/download/0.1/boot2docker.iso", ts.URL)
-	if isoUrl != expectedUrl {
-		t.Fatalf("expected url %s; received %s", expectedUrl, isoUrl)
+	expectedURL := fmt.Sprintf("%s/org/repo/releases/download/0.1/boot2docker.iso", ts.URL)
+	if isoURL != expectedURL {
+		t.Fatalf("expected url %s; received %s", expectedURL, isoURL)
 	}
 }
 
@@ -58,7 +58,7 @@ func TestDownloadIso(t *testing.T) {
 }
 
 func TestGetReleasesRequestNoToken(t *testing.T) {
-	GithubApiToken = ""
+	GithubAPIToken = ""
 	b2d := NewB2dUtils("/tmp/store")
 	req, err := b2d.getReleasesRequest("http://some.github.api")
 	if err != nil {
@@ -72,7 +72,7 @@ func TestGetReleasesRequestNoToken(t *testing.T) {
 
 func TestGetReleasesRequest(t *testing.T) {
 	expectedToken := "CATBUG"
-	GithubApiToken = expectedToken
+	GithubAPIToken = expectedToken
 	b2d := NewB2dUtils("/tmp/store")
 
 	req, err := b2d.getReleasesRequest("http://some.github.api")

--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -35,7 +35,7 @@ func (s Filestore) saveToFile(data []byte, file string) error {
 
 func (s Filestore) Save(host *host.Host) error {
 	// TODO: Does this belong here?
-	if rpcClientDriver, ok := host.Driver.(*rpcdriver.RpcClientDriver); ok {
+	if rpcClientDriver, ok := host.Driver.(*rpcdriver.RPCClientDriver); ok {
 		data, err := rpcClientDriver.GetConfigRaw()
 		if err != nil {
 			return fmt.Errorf("Error getting raw config for driver: %s", err)
@@ -154,8 +154,8 @@ func (s Filestore) Load(name string) (*host.Host, error) {
 func (s Filestore) NewHost(driver drivers.Driver) (*host.Host, error) {
 	certDir := filepath.Join(s.Path, "certs")
 
-	hostOptions := &host.HostOptions{
-		AuthOptions: &auth.AuthOptions{
+	hostOptions := &host.Options{
+		AuthOptions: &auth.Options{
 			CertDir:          certDir,
 			CaCertPath:       filepath.Join(certDir, "ca.pem"),
 			CaPrivateKeyPath: filepath.Join(certDir, "ca-key.pem"),
@@ -164,12 +164,12 @@ func (s Filestore) NewHost(driver drivers.Driver) (*host.Host, error) {
 			ServerCertPath:   filepath.Join(s.getMachinesDir(), "server.pem"),
 			ServerKeyPath:    filepath.Join(s.getMachinesDir(), "server-key.pem"),
 		},
-		EngineOptions: &engine.EngineOptions{
+		EngineOptions: &engine.Options{
 			InstallURL:    "https://get.docker.com",
 			StorageDriver: "aufs",
-			TlsVerify:     true,
+			TLSVerify:     true,
 		},
-		SwarmOptions: &swarm.SwarmOptions{
+		SwarmOptions: &swarm.Options{
 			Host:     "tcp://0.0.0.0:3376",
 			Image:    "swarm:latest",
 			Strategy: "spread",

--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -26,7 +26,7 @@ func NewArchProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseId:       "arch",
+			OsReleaseID:       "arch",
 			Packages:          []string{},
 			Driver:            d,
 		},
@@ -38,7 +38,7 @@ type ArchProvisioner struct {
 }
 
 func (provisioner *ArchProvisioner) CompatibleWithHost() bool {
-	return provisioner.OsReleaseInfo.Id == provisioner.OsReleaseId || provisioner.OsReleaseInfo.IdLike == provisioner.OsReleaseId
+	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID || provisioner.OsReleaseInfo.IDLike == provisioner.OsReleaseID
 }
 
 func (provisioner *ArchProvisioner) Service(name string, action serviceaction.ServiceAction) error {
@@ -104,7 +104,7 @@ func (provisioner *ArchProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -36,9 +36,9 @@ func NewBoot2DockerProvisioner(d drivers.Driver) Provisioner {
 type Boot2DockerProvisioner struct {
 	OsReleaseInfo *OsRelease
 	Driver        drivers.Driver
-	AuthOptions   auth.AuthOptions
-	EngineOptions engine.EngineOptions
-	SwarmOptions  swarm.SwarmOptions
+	AuthOptions   auth.Options
+	EngineOptions engine.Options
+	SwarmOptions  swarm.Options
 }
 
 func (provisioner *Boot2DockerProvisioner) Service(name string, action serviceaction.ServiceAction) error {
@@ -134,7 +134,7 @@ func (provisioner *Boot2DockerProvisioner) GetDockerOptionsDir() string {
 	return "/var/lib/boot2docker"
 }
 
-func (provisioner *Boot2DockerProvisioner) GetAuthOptions() auth.AuthOptions {
+func (provisioner *Boot2DockerProvisioner) GetAuthOptions() auth.Options {
 	return provisioner.AuthOptions
 }
 
@@ -185,7 +185,7 @@ SERVERCERT={{.AuthOptions.ServerCertRemotePath}}
 }
 
 func (provisioner *Boot2DockerProvisioner) CompatibleWithHost() bool {
-	return provisioner.OsReleaseInfo.Id == "boot2docker"
+	return provisioner.OsReleaseInfo.ID == "boot2docker"
 }
 
 func (provisioner *Boot2DockerProvisioner) SetOsReleaseInfo(info *OsRelease) {
@@ -221,7 +221,7 @@ You also might want to clear any VirtualBox host only interfaces you are not usi
 	}
 }
 
-func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	const (
 		dockerPort = 2376
 	)

--- a/libmachine/provision/centos.go
+++ b/libmachine/provision/centos.go
@@ -14,7 +14,7 @@ func NewCentosProvisioner(d drivers.Driver) Provisioner {
 	g := GenericProvisioner{
 		DockerOptionsDir:  "/etc/docker",
 		DaemonOptionsFile: "/etc/systemd/system/docker.service",
-		OsReleaseId:       "centos",
+		OsReleaseID:       "centos",
 		Packages:          []string{},
 		Driver:            d,
 	}

--- a/libmachine/provision/centos_test.go
+++ b/libmachine/provision/centos_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCentosGenerateYumRepoList(t *testing.T) {
 	info := &OsRelease{
-		Id: "centos",
+		ID: "centos",
 	}
 	p := NewCentosProvisioner(nil)
 	p.SetOsReleaseInfo(info)

--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -16,10 +16,10 @@ type SwarmCommandContext struct {
 	ContainerName string
 	DockerDir     string
 	DockerPort    int
-	Ip            string
+	IP            string
 	Port          string
-	AuthOptions   auth.AuthOptions
-	SwarmOptions  swarm.SwarmOptions
+	AuthOptions   auth.Options
+	SwarmOptions  swarm.Options
 	SwarmImage    string
 }
 
@@ -46,7 +46,7 @@ func runSwarmCommandFromTemplate(p Provisioner, cmdTmpl string, swarmCmdContext 
 	return nil
 }
 
-func configureSwarm(p Provisioner, swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions) error {
+func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.Options) error {
 	if !swarmOptions.IsSwarm {
 		return nil
 	}
@@ -72,7 +72,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.SwarmOptions, authOptions 
 		ContainerName: "",
 		DockerDir:     dockerDir,
 		DockerPort:    2376,
-		Ip:            ip,
+		IP:            ip,
 		Port:          port,
 		AuthOptions:   authOptions,
 		SwarmOptions:  swarmOptions,

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -34,7 +34,7 @@ func NewCoreOSProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseId:       "coreos",
+			OsReleaseID:       "coreos",
 			Driver:            d,
 		},
 	}
@@ -128,7 +128,7 @@ func (provisioner *CoreOSProvisioner) Package(name string, action pkgaction.Pack
 	return nil
 }
 
-func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -26,7 +26,7 @@ func NewDebianProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseId:       "debian",
+			OsReleaseID:       "debian",
 			Packages: []string{
 				"curl",
 			},
@@ -121,7 +121,7 @@ func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions

--- a/libmachine/provision/engine_config_context.go
+++ b/libmachine/provision/engine_config_context.go
@@ -7,7 +7,7 @@ import (
 
 type EngineConfigContext struct {
 	DockerPort       int
-	AuthOptions      auth.AuthOptions
-	EngineOptions    engine.EngineOptions
+	AuthOptions      auth.Options
+	EngineOptions    engine.Options
 	DockerOptionsDir string
 }

--- a/libmachine/provision/fedora.go
+++ b/libmachine/provision/fedora.go
@@ -14,7 +14,7 @@ func NewFedoraProvisioner(d drivers.Driver) Provisioner {
 	g := GenericProvisioner{
 		DockerOptionsDir:  "/etc/docker",
 		DaemonOptionsFile: "/etc/systemd/system/docker.service",
-		OsReleaseId:       "fedora",
+		OsReleaseID:       "fedora",
 		Packages:          []string{},
 		Driver:            d,
 	}

--- a/libmachine/provision/fedora_test.go
+++ b/libmachine/provision/fedora_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestFedoraGenerateYumRepoList(t *testing.T) {
 	info := &OsRelease{
-		Id: "fedora",
+		ID: "fedora",
 	}
 	p := NewCentosProvisioner(nil)
 	p.SetOsReleaseInfo(info)

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -12,15 +12,15 @@ import (
 )
 
 type GenericProvisioner struct {
-	OsReleaseId       string
+	OsReleaseID       string
 	DockerOptionsDir  string
 	DaemonOptionsFile string
 	Packages          []string
 	OsReleaseInfo     *OsRelease
 	Driver            drivers.Driver
-	AuthOptions       auth.AuthOptions
-	EngineOptions     engine.EngineOptions
-	SwarmOptions      swarm.SwarmOptions
+	AuthOptions       auth.Options
+	EngineOptions     engine.Options
+	SwarmOptions      swarm.Options
 }
 
 func (provisioner *GenericProvisioner) Hostname() (string, error) {
@@ -57,10 +57,10 @@ func (provisioner *GenericProvisioner) SSHCommand(args string) (string, error) {
 }
 
 func (provisioner *GenericProvisioner) CompatibleWithHost() bool {
-	return provisioner.OsReleaseInfo.Id == provisioner.OsReleaseId
+	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID
 }
 
-func (provisioner *GenericProvisioner) GetAuthOptions() auth.AuthOptions {
+func (provisioner *GenericProvisioner) GetAuthOptions() auth.Options {
 	return provisioner.AuthOptions
 }
 

--- a/libmachine/provision/os_release.go
+++ b/libmachine/provision/os_release.go
@@ -19,13 +19,13 @@ type OsRelease struct {
 	AnsiColor    string `osr:"ANSI_COLOR"`
 	Name         string `osr:"NAME"`
 	Version      string `osr:"VERSION"`
-	Id           string `osr:"ID"`
-	IdLike       string `osr:"ID_LIKE"`
+	ID           string `osr:"ID"`
+	IDLike       string `osr:"ID_LIKE"`
 	PrettyName   string `osr:"PRETTY_NAME"`
-	VersionId    string `osr:"VERSION_ID"`
-	HomeUrl      string `osr:"HOME_URL"`
-	SupportUrl   string `osr:"SUPPORT_URL"`
-	BugReportUrl string `osr:"BUG_REPORT_URL"`
+	VersionID    string `osr:"VERSION_ID"`
+	HomeURL      string `osr:"HOME_URL"`
+	SupportURL   string `osr:"SUPPORT_URL"`
+	BugReportURL string `osr:"BUG_REPORT_URL"`
 }
 
 func stripQuotes(val string) string {

--- a/libmachine/provision/os_release_test.go
+++ b/libmachine/provision/os_release_test.go
@@ -59,13 +59,13 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 		AnsiColor:    "",
 		Name:         "Ubuntu",
 		Version:      "14.04, Trusty Tahr",
-		Id:           "ubuntu",
-		IdLike:       "debian",
+		ID:           "ubuntu",
+		IDLike:       "debian",
 		PrettyName:   "Ubuntu 14.04 LTS",
-		VersionId:    "14.04",
-		HomeUrl:      "http://www.ubuntu.com/",
-		SupportUrl:   "http://help.ubuntu.com/",
-		BugReportUrl: "http://bugs.launchpad.net/ubuntu/",
+		VersionID:    "14.04",
+		HomeURL:      "http://www.ubuntu.com/",
+		SupportURL:   "http://help.ubuntu.com/",
+		BugReportURL: "http://bugs.launchpad.net/ubuntu/",
 	}
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {
@@ -81,13 +81,13 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 		AnsiColor:    "1;32",
 		Name:         "Gentoo",
 		Version:      "",
-		Id:           "gentoo",
-		IdLike:       "",
+		ID:           "gentoo",
+		IDLike:       "",
 		PrettyName:   "Gentoo/Linux",
-		VersionId:    "",
-		HomeUrl:      "http://www.gentoo.org/",
-		SupportUrl:   "http://www.gentoo.org/main/en/support.xml",
-		BugReportUrl: "https://bugs.gentoo.org/",
+		VersionID:    "",
+		HomeURL:      "http://www.gentoo.org/",
+		SupportURL:   "http://www.gentoo.org/main/en/support.xml",
+		BugReportURL: "https://bugs.gentoo.org/",
 	}
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {
@@ -103,13 +103,13 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 		AnsiColor:    "",
 		Name:         "Ubuntu",
 		Version:      "14.04, Trusty Tahr",
-		Id:           "ubuntu",
-		IdLike:       "debian",
+		ID:           "ubuntu",
+		IDLike:       "debian",
 		PrettyName:   "",
-		VersionId:    "14.04",
-		HomeUrl:      "http://www.ubuntu.com/",
-		SupportUrl:   "http://help.ubuntu.com/",
-		BugReportUrl: "http://bugs.launchpad.net/ubuntu/",
+		VersionID:    "14.04",
+		HomeURL:      "http://www.ubuntu.com/",
+		SupportURL:   "http://help.ubuntu.com/",
+		BugReportURL: "http://bugs.launchpad.net/ubuntu/",
 	}
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {
@@ -124,13 +124,13 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 	expectedOsr = OsRelease{
 		Name:         "CentOS Linux",
 		Version:      "7 (Core)",
-		Id:           "centos",
-		IdLike:       "rhel fedora",
+		ID:           "centos",
+		IDLike:       "rhel fedora",
 		PrettyName:   "CentOS Linux 7 (Core)",
 		AnsiColor:    "0;31",
-		VersionId:    "7",
-		HomeUrl:      "https://www.centos.org/",
-		BugReportUrl: "https://bugs.centos.org/",
+		VersionID:    "7",
+		HomeURL:      "https://www.centos.org/",
+		BugReportURL: "https://bugs.centos.org/",
 	}
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -23,7 +23,7 @@ type Provisioner interface {
 	GetDockerOptionsDir() string
 
 	// Return the auth options used to configure remote connection for the daemon.
-	GetAuthOptions() auth.AuthOptions
+	GetAuthOptions() auth.Options
 
 	// Run a package action e.g. install
 	Package(name string, action pkgaction.PackageAction) error
@@ -43,7 +43,7 @@ type Provisioner interface {
 	//     3. Configure the daemon to accept connections over TLS.
 	//     4. Copy the needed certificates to the server and local config dir.
 	//     5. Configure / activate swarm if applicable.
-	Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error
+	Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error
 
 	// Perform action on a named service e.g. stop
 	Service(name string, action serviceaction.ServiceAction) error
@@ -87,7 +87,7 @@ func DetectProvisioner(d drivers.Driver) (Provisioner, error) {
 		provisioner.SetOsReleaseInfo(osReleaseInfo)
 
 		if provisioner.CompatibleWithHost() {
-			log.Debugf("found compatible host: %s", osReleaseInfo.Id)
+			log.Debugf("found compatible host: %s", osReleaseInfo.ID)
 			return provisioner, nil
 		}
 	}

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	versionsUrl  = "http://releases.rancher.com/os/versions.yml"
-	isoUrl       = "https://github.com/rancherio/os/releases/download/%s/machine-rancheros.iso"
+	versionsURL  = "http://releases.rancher.com/os/versions.yml"
+	isoURL       = "https://github.com/rancherio/os/releases/download/%s/machine-rancheros.iso"
 	hostnameTmpl = `sudo mkdir -p /var/lib/rancher/conf/cloud-config.d/  
 sudo tee /var/lib/rancher/conf/cloud-config.d/machine-hostname.yml << EOF
 #cloud-config
@@ -41,7 +41,7 @@ func NewRancherProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/var/lib/rancher/conf",
 			DaemonOptionsFile: "/var/lib/rancher/conf/docker",
-			OsReleaseId:       "rancheros",
+			OsReleaseID:       "rancheros",
 			Driver:            d,
 		},
 	}
@@ -87,7 +87,7 @@ func (provisioner *RancherProvisioner) Package(name string, action pkgaction.Pac
 	return nil
 }
 
-func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
@@ -206,8 +206,8 @@ func (provisioner *RancherProvisioner) upgradeIso() error {
 }
 
 func (provisioner *RancherProvisioner) getLatestISOURL() (string, error) {
-	log.Debugf("Reading %s", versionsUrl)
-	resp, err := http.Get(versionsUrl)
+	log.Debugf("Reading %s", versionsURL)
+	resp, err := http.Get(versionsURL)
 	if err != nil {
 		return "", err
 	}
@@ -219,7 +219,7 @@ func (provisioner *RancherProvisioner) getLatestISOURL() (string, error) {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "current: ") {
 			log.Debugf("Found %s", line)
-			return fmt.Sprintf(isoUrl, strings.Split(line, ":")[2]), err
+			return fmt.Sprintf(isoURL, strings.Split(line, ":")[2]), err
 		}
 	}
 

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -53,7 +53,7 @@ func NewRedHatProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner: GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseId:       "rhel",
+			OsReleaseID:       "rhel",
 			Packages: []string{
 				"curl",
 			},
@@ -196,7 +196,7 @@ func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
@@ -288,7 +288,7 @@ func generateYumRepoList(provisioner Provisioner) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	switch releaseInfo.Id {
+	switch releaseInfo.ID {
 	case "rhel", "centos":
 		// rhel and centos both use the "centos" repo
 		packageListInfo.OsRelease = "centos"

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRedHatGenerateYumRepoList(t *testing.T) {
 	info := &OsRelease{
-		Id: "rhel",
+		ID: "rhel",
 	}
 	p := NewRedHatProvisioner(nil)
 	p.SetOsReleaseInfo(info)

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -32,7 +32,7 @@ func NewOpenSUSEProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/sysconfig/docker",
-			OsReleaseId:       "opensuse",
+			OsReleaseID:       "opensuse",
 			Packages: []string{
 				"curl",
 			},
@@ -46,7 +46,7 @@ func NewSLEDProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/sysconfig/docker",
-			OsReleaseId:       "sled",
+			OsReleaseID:       "sled",
 			Packages: []string{
 				"curl",
 			},
@@ -60,7 +60,7 @@ func NewSLESProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/sysconfig/docker",
-			OsReleaseId:       "sles",
+			OsReleaseID:       "sles",
 			Packages: []string{
 				"curl",
 			},
@@ -129,7 +129,7 @@ func (provisioner *SUSEProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -24,7 +24,7 @@ func NewUbuntuProvisioner(d drivers.Driver) Provisioner {
 		GenericProvisioner{
 			DockerOptionsDir:  "/etc/docker",
 			DaemonOptionsFile: "/etc/default/docker",
-			OsReleaseId:       "ubuntu",
+			OsReleaseID:       "ubuntu",
 			Packages: []string{
 				"curl",
 			},
@@ -114,7 +114,7 @@ func (provisioner *UbuntuProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.SwarmOptions, authOptions auth.AuthOptions, engineOptions engine.EngineOptions) error {
+func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -42,7 +42,7 @@ func makeDockerOptionsDir(p Provisioner) error {
 	return nil
 }
 
-func setRemoteAuthOptions(p Provisioner) auth.AuthOptions {
+func setRemoteAuthOptions(p Provisioner) auth.Options {
 	dockerDir := p.GetDockerOptionsDir()
 	authOptions := p.GetAuthOptions()
 
@@ -146,11 +146,11 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	dockerUrl, err := driver.GetURL()
+	dockerURL, err := driver.GetURL()
 	if err != nil {
 		return err
 	}
-	u, err := url.Parse(dockerUrl)
+	u, err := url.Parse(dockerURL)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/utils_test.go
+++ b/libmachine/provision/utils_test.go
@@ -59,7 +59,7 @@ func TestGenerateDockerOptionsBoot2Docker(t *testing.T) {
 		Driver: &fakedriver.Driver{},
 	}
 	dockerPort := 1234
-	p.AuthOptions = auth.AuthOptions{
+	p.AuthOptions = auth.Options{
 		CaCertRemotePath:     "/test/ca-cert",
 		ServerKeyRemotePath:  "/test/server-key",
 		ServerCertRemotePath: "/test/server-cert",
@@ -97,8 +97,8 @@ func TestMachinePortBoot2Docker(t *testing.T) {
 		Driver: &fakedriver.Driver{},
 	}
 	dockerPort := 2376
-	bindUrl := fmt.Sprintf("tcp://0.0.0.0:%d", dockerPort)
-	p.AuthOptions = auth.AuthOptions{
+	bindURL := fmt.Sprintf("tcp://0.0.0.0:%d", dockerPort)
+	p.AuthOptions = auth.Options{
 		CaCertRemotePath:     "/test/ca-cert",
 		ServerKeyRemotePath:  "/test/server-key",
 		ServerCertRemotePath: "/test/server-cert",
@@ -119,8 +119,8 @@ func TestMachinePortBoot2Docker(t *testing.T) {
 	url := u[1]
 	url = strings.Replace(url, "'", "", -1)
 	url = strings.Replace(url, "\\\"", "", -1)
-	if url != bindUrl {
-		t.Errorf("expected url %s; received %s", bindUrl, url)
+	if url != bindURL {
+		t.Errorf("expected url %s; received %s", bindURL, url)
 	}
 }
 
@@ -129,8 +129,8 @@ func TestMachineCustomPortBoot2Docker(t *testing.T) {
 		Driver: &fakedriver.Driver{},
 	}
 	dockerPort := 3376
-	bindUrl := fmt.Sprintf("tcp://0.0.0.0:%d", dockerPort)
-	p.AuthOptions = auth.AuthOptions{
+	bindURL := fmt.Sprintf("tcp://0.0.0.0:%d", dockerPort)
+	p.AuthOptions = auth.Options{
 		CaCertRemotePath:     "/test/ca-cert",
 		ServerKeyRemotePath:  "/test/server-key",
 		ServerCertRemotePath: "/test/server-cert",
@@ -152,7 +152,7 @@ func TestMachineCustomPortBoot2Docker(t *testing.T) {
 	url := u[1]
 	url = strings.Replace(url, "'", "", -1)
 	url = strings.Replace(url, "\\\"", "", -1)
-	if url != bindUrl {
-		t.Errorf("expected url %s; received %s", bindUrl, url)
+	if url != bindURL {
+		t.Errorf("expected url %s; received %s", bindURL, url)
 	}
 }

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -35,15 +35,15 @@ type Auth struct {
 	Keys      []string
 }
 
-type SSHClientType string
+type ClientType string
 
 const (
 	maxDialAttempts = 10
 )
 
 const (
-	External SSHClientType = "external"
-	Native   SSHClientType = "native"
+	External ClientType = "external"
+	Native   ClientType = "native"
 )
 
 var (
@@ -58,10 +58,10 @@ var (
 		"-o", "ControlMaster=no", // disable ssh multiplexing
 		"-o", "ControlPath=no",
 	}
-	defaultClientType SSHClientType = External
+	defaultClientType = External
 )
 
-func SetDefaultClient(clientType SSHClientType) {
+func SetDefaultClient(clientType ClientType) {
 	// Allow over-riding of default client type, so that even if ssh binary
 	// is found in PATH we can still use the Go native implementation if
 	// desired.

--- a/libmachine/state/state.go
+++ b/libmachine/state/state.go
@@ -31,7 +31,6 @@ var states = []string{
 func (s State) String() string {
 	if int(s) >= 0 && int(s) < len(states) {
 		return states[s]
-	} else {
-		return ""
 	}
+	return ""
 }

--- a/libmachine/swarm/swarm.go
+++ b/libmachine/swarm/swarm.go
@@ -4,7 +4,7 @@ const (
 	DiscoveryServiceEndpoint = "https://discovery-stage.hub.docker.com/v1"
 )
 
-type SwarmOptions struct {
+type Options struct {
 	IsSwarm        bool
 	Address        string
 	Discovery      string

--- a/libmachine/version/version.go
+++ b/libmachine/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// ApiVersion dictates which version of the libmachine API this is.
-	ApiVersion = 1
+	APIVersion = 1
 
 	// ConfigVersion dictates which version of the config.json format is
 	// used. It needs to be bumped if there is a breaking change, and

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -34,6 +34,8 @@ ifeq ($(VERBOSE),true)
 	VERBOSE_GO := -v
 endif
 
+default: build
+
 include mk/build.mk
 include mk/coverage.mk
 include mk/release.mk
@@ -46,7 +48,6 @@ include mk/validate.mk
 .all_test: test-short test-long test-integration
 .all_validate: dco fmt vet lint
 
-default: build
 # Build native machine and all drivers
 build: build-machine build-plugins
 # Just build native machine itself
@@ -57,7 +58,7 @@ plugins: build-plugins
 cross: build-x
 
 clean: coverage-clean build-clean
-test: dco fmt test-short vet
-validate: dco fmt vet lint test-short test-long
+test: dco test-short fmt lint vet
+validate: .all_validate .all_test
 
 .PHONY: .all_build .all_coverage .all_release .all_test .all_validate test build validate clean

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -20,4 +20,4 @@ vet: build
 lint:
 	$(if $(GOLINT), , \
 		$(error Please install golint: go get -u github.com/golang/lint/golint))
-	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | grep -v Godeps/ | tee /dev/stderr)"
+	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | grep -v Godeps/ | grep -v "exported" | grep -v "amazonec2" | tee /dev/stderr)"


### PR DESCRIPTION
Following #2074 & #2075 on top of which this is based.

This contains the final base linting effort to libmachine, that is specially important before we can move to the externalized plugins.

Why does go lint matters?

 * don't fight the language - go is opinionated (unlike, say, ruby) and provide sane defaults and great tooling, which we should leverage, instead of fighting against
 * we are the only docker project (AFAIK) that does not lint
 * doing it after the plugins are outsourced will be impossible, or very painful

This PR also activates partial linting of the codebase as part of the `test` target, and enable linting on CI.

cc @docker/machine-maintainers 