### PR TITLE
Simpler code for env usage hints.

### DIFF
--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -8,43 +8,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockCmdEnvFlags struct {
-	flags string
-}
-
-func (f *MockCmdEnvFlags) Bool(name string) bool {
-	return strings.Contains(f.flags, name)
-}
-
 func TestHints(t *testing.T) {
 	var tests = []struct {
 		userShell     string
-		flags         *MockCmdEnvFlags
+		commandLine   string
 		expectedHints string
 	}{
-		{"", &MockCmdEnvFlags{}, "# Run this command to configure your shell: \n# eval \"$(machine env default)\"\n"},
-		{"", &MockCmdEnvFlags{"--no-proxy"}, "# Run this command to configure your shell: \n# eval \"$(machine env --no-proxy default)\"\n"},
-		{"", &MockCmdEnvFlags{"--swarm"}, "# Run this command to configure your shell: \n# eval \"$(machine env --swarm default)\"\n"},
-		{"", &MockCmdEnvFlags{"--no-proxy --swarm"}, "# Run this command to configure your shell: \n# eval \"$(machine env --no-proxy --swarm default)\"\n"},
+		{"", "machine env default", "# Run this command to configure your shell: \n# eval \"$(machine env default)\"\n"},
+		{"", "machine env --no-proxy default", "# Run this command to configure your shell: \n# eval \"$(machine env --no-proxy default)\"\n"},
+		{"", "machine env --swarm default", "# Run this command to configure your shell: \n# eval \"$(machine env --swarm default)\"\n"},
+		{"", "machine env --no-proxy --swarm default", "# Run this command to configure your shell: \n# eval \"$(machine env --no-proxy --swarm default)\"\n"},
 
-		{"fish", &MockCmdEnvFlags{}, "# Run this command to configure your shell: \n# eval (machine env --shell=fish default)\n"},
-		{"fish", &MockCmdEnvFlags{"--no-proxy"}, "# Run this command to configure your shell: \n# eval (machine env --shell=fish --no-proxy default)\n"},
-		{"fish", &MockCmdEnvFlags{"--swarm"}, "# Run this command to configure your shell: \n# eval (machine env --shell=fish --swarm default)\n"},
-		{"fish", &MockCmdEnvFlags{"--no-proxy --swarm"}, "# Run this command to configure your shell: \n# eval (machine env --shell=fish --no-proxy --swarm default)\n"},
+		{"fish", "./machine env --shell=fish default", "# Run this command to configure your shell: \n# eval (./machine env --shell=fish default)\n"},
+		{"fish", "./machine env --shell=fish --no-proxy default", "# Run this command to configure your shell: \n# eval (./machine env --shell=fish --no-proxy default)\n"},
+		{"fish", "./machine env --shell=fish --swarm default", "# Run this command to configure your shell: \n# eval (./machine env --shell=fish --swarm default)\n"},
+		{"fish", "./machine env --shell=fish --no-proxy --swarm default", "# Run this command to configure your shell: \n# eval (./machine env --shell=fish --no-proxy --swarm default)\n"},
 
-		{"powershell", &MockCmdEnvFlags{}, "# Run this command to configure your shell: \n# machine env --shell=powershell default | Invoke-Expression\n"},
-		{"powershell", &MockCmdEnvFlags{"--no-proxy"}, "# Run this command to configure your shell: \n# machine env --shell=powershell --no-proxy default | Invoke-Expression\n"},
-		{"powershell", &MockCmdEnvFlags{"--swarm"}, "# Run this command to configure your shell: \n# machine env --shell=powershell --swarm default | Invoke-Expression\n"},
-		{"powershell", &MockCmdEnvFlags{"--no-proxy --swarm"}, "# Run this command to configure your shell: \n# machine env --shell=powershell --no-proxy --swarm default | Invoke-Expression\n"},
+		{"powershell", "./machine env --shell=powershell default", "# Run this command to configure your shell: \n# ./machine env --shell=powershell default | Invoke-Expression\n"},
+		{"powershell", "./machine env --shell=powershell --no-proxy default", "# Run this command to configure your shell: \n# ./machine env --shell=powershell --no-proxy default | Invoke-Expression\n"},
+		{"powershell", "./machine env --shell=powershell --swarm default", "# Run this command to configure your shell: \n# ./machine env --shell=powershell --swarm default | Invoke-Expression\n"},
+		{"powershell", "./machine env --shell=powershell --no-proxy --swarm default", "# Run this command to configure your shell: \n# ./machine env --shell=powershell --no-proxy --swarm default | Invoke-Expression\n"},
 
-		{"cmd", &MockCmdEnvFlags{}, "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('machine env --shell=cmd default') DO %i\n"},
-		{"cmd", &MockCmdEnvFlags{"--no-proxy"}, "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('machine env --shell=cmd --no-proxy default') DO %i\n"},
-		{"cmd", &MockCmdEnvFlags{"--swarm"}, "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('machine env --shell=cmd --swarm default') DO %i\n"},
-		{"cmd", &MockCmdEnvFlags{"--no-proxy --swarm"}, "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('machine env --shell=cmd --no-proxy --swarm default') DO %i\n"},
+		{"cmd", "./machine env --shell=cmd default", "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('./machine env --shell=cmd default') DO %i\n"},
+		{"cmd", "./machine env --shell=cmd --no-proxy default", "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('./machine env --shell=cmd --no-proxy default') DO %i\n"},
+		{"cmd", "./machine env --shell=cmd --swarm default", "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('./machine env --shell=cmd --swarm default') DO %i\n"},
+		{"cmd", "./machine env --shell=cmd --no-proxy --swarm default", "REM Run this command to configure your shell: \nREM \tFOR /f \"tokens=*\" %i IN ('./machine env --shell=cmd --no-proxy --swarm default') DO %i\n"},
 	}
 
 	for _, test := range tests {
-		hints := generateUsageHint("machine", "default", test.userShell, test.flags)
+		hints := generateUsageHint(test.userShell, strings.Split(test.commandLine, " "))
 
 		assert.Equal(t, test.expectedHints, hints)
 	}


### PR DESCRIPTION
We can just output the original os.Args in the
eval call.

Signed-off-by: David Gageot <david@gageot.net>