### PR TITLE
Smooth rough edges around create help text

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,10 +1,9 @@
+[![Coverage](http://gocover.io/_badge/github.com/codegangsta/cli?0)](http://gocover.io/github.com/codegangsta/cli)
 [![Build Status](https://travis-ci.org/codegangsta/cli.png?branch=master)](https://travis-ci.org/codegangsta/cli)
+[![GoDoc](https://godoc.org/github.com/codegangsta/cli?status.svg)](https://godoc.org/github.com/codegangsta/cli)
 
 # cli.go
 `cli.go` is simple, fast, and fun package for building command line apps in Go. The goal is to enable developers to write fast and distributable command line applications in an expressive way.
-
-You can view the API docs here:
-http://godoc.org/github.com/codegangsta/cli
 
 ## Overview
 Command line apps are usually so tiny that there is absolutely no reason why your code should *not* be self-documenting. Things like generating help text and parsing command flags/options should not hinder productivity when writing a command line app.
@@ -103,7 +102,7 @@ $ greet
 Hello friend!
 ```
 
-`cli.go` also generates some bitchass help text:
+`cli.go` also generates neat help text:
 
 ```
 $ greet help

--- a/cli/app.go
+++ b/cli/app.go
@@ -13,8 +13,12 @@ import (
 type App struct {
 	// The name of the program. Defaults to os.Args[0]
 	Name string
+	// Full name of command for help, defaults to Name
+	HelpName string
 	// Description of the program.
 	Usage string
+	// Description of the program argument format.
+	ArgsUsage string
 	// Version of the program
 	Version string
 	// List of commands to execute
@@ -67,6 +71,7 @@ func compileTime() time.Time {
 func NewApp() *App {
 	return &App{
 		Name:         os.Args[0],
+		HelpName:     os.Args[0],
 		Usage:        "A new cli application",
 		Version:      "0.0.0",
 		BashComplete: DefaultAppComplete,
@@ -81,6 +86,15 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Author != "" || a.Email != "" {
 		a.Authors = append(a.Authors, Author{Name: a.Author, Email: a.Email})
 	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
 
 	// append help to commands
 	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
@@ -123,11 +137,13 @@ func (a *App) Run(arguments []string) (err error) {
 		return nil
 	}
 
-	if checkHelp(context) {
+	if !a.HideHelp && checkHelp(context) {
+		ShowAppHelp(context)
 		return nil
 	}
 
-	if checkVersion(context) {
+	if !a.HideVersion && checkVersion(context) {
+		ShowVersion(context)
 		return nil
 	}
 
@@ -184,6 +200,15 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 			}
 		}
 	}
+
+	newCmds := []Command{}
+	for _, c := range a.Commands {
+		if c.HelpName == "" {
+			c.HelpName = fmt.Sprintf("%s %s", a.HelpName, c.Name)
+		}
+		newCmds = append(newCmds, c)
+	}
+	a.Commands = newCmds
 
 	// append flags
 	if a.EnableBashCompletion {

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -90,10 +90,10 @@ func ExampleAppHelp() {
 	app.Run(os.Args)
 	// Output:
 	// NAME:
-	//    describeit - use it to see a description
+	//    greet describeit - use it to see a description
 	//
 	// USAGE:
-	//    command describeit [arguments...]
+	//    greet describeit [arguments...]
 	//
 	// DESCRIPTION:
 	//    This is how we describe describeit the function
@@ -737,7 +737,7 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	app := NewApp()
 	buf := new(bytes.Buffer)
 	app.Writer = buf
-
+	app.Name = "command"
 	subCmd := Command{
 		Name:  "bar",
 		Usage: "does bar things",
@@ -755,10 +755,103 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "foo bar - does bar things") {
+	if !strings.Contains(output, "command foo bar - does bar things") {
 		t.Errorf("expected full path to subcommand: %s", output)
 	}
 	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_SubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "custom - does bar things") {
+		t.Errorf("expected HelpName for subcommand: %s", output)
+	}
+	if !strings.Contains(output, "custom [arguments...]") {
+		t.Errorf("expected HelpName to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "command"
+	subCmd := Command{
+		Name:  "bar",
+		Usage: "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		HelpName:    "custom",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "bar", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "command foo bar - does bar things") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "command foo bar [arguments...]") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+}
+
+func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
+	app := NewApp()
+	buf := new(bytes.Buffer)
+	app.Writer = buf
+	app.Name = "base"
+	subCmd := Command{
+		Name:     "bar",
+		HelpName: "custom",
+		Usage:    "does bar things",
+	}
+	cmd := Command{
+		Name:        "foo",
+		Description: "foo commands",
+		Subcommands: []Command{subCmd},
+	}
+	app.Commands = []Command{cmd}
+
+	err := app.Run([]string{"command", "foo", "--help"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "base foo - foo commands") {
+		t.Errorf("expected full path to subcommand: %s", output)
+	}
+	if !strings.Contains(output, "base foo command [command options] [arguments...]") {
 		t.Errorf("expected full path to subcommand: %s", output)
 	}
 }

--- a/cli/command.go
+++ b/cli/command.go
@@ -18,6 +18,8 @@ type Command struct {
 	Usage string
 	// A longer explanation of how the command works
 	Description string
+	// A short description of the arguments of this command
+	ArgsUsage string
 	// The function to call when checking for bash command completions
 	BashComplete func(context *Context)
 	// An action to execute before any sub-subcommands are run, but after the context is ready
@@ -37,6 +39,8 @@ type Command struct {
 	// Boolean to hide built-in help command
 	HideHelp bool
 
+	// Full name of command for help, defaults to full command name, including parent commands.
+	HelpName        string
 	commandNamePath []string
 }
 
@@ -70,39 +74,39 @@ func (c Command) Run(ctx *Context) error {
 	set := flagSet(c.Name, c.Flags)
 	set.SetOutput(ioutil.Discard)
 
-	firstFlagIndex := -1
-	terminatorIndex := -1
-	for index, arg := range ctx.Args() {
-		if arg == "--" {
-			terminatorIndex = index
-			break
-		} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
-			firstFlagIndex = index
-		}
-	}
-
 	var err error
-	if firstFlagIndex > -1 && !c.SkipFlagParsing {
-		args := ctx.Args()
-		regularArgs := make([]string, len(args[1:firstFlagIndex]))
-		copy(regularArgs, args[1:firstFlagIndex])
-
-		var flagArgs []string
-		if terminatorIndex > -1 {
-			flagArgs = args[firstFlagIndex:terminatorIndex]
-			regularArgs = append(regularArgs, args[terminatorIndex:]...)
-		} else {
-			flagArgs = args[firstFlagIndex:]
+	if !c.SkipFlagParsing {
+		firstFlagIndex := -1
+		terminatorIndex := -1
+		for index, arg := range ctx.Args() {
+			if arg == "--" {
+				terminatorIndex = index
+				break
+			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
+				firstFlagIndex = index
+			}
 		}
 
-		err = set.Parse(append(flagArgs, regularArgs...))
-	} else {
-		err = set.Parse(ctx.Args().Tail())
+		if firstFlagIndex > -1 {
+			args := ctx.Args()
+			regularArgs := make([]string, len(args[1:firstFlagIndex]))
+			copy(regularArgs, args[1:firstFlagIndex])
 
-		// Work around issue where if the first arg in ctx.Args.Tail()
-		// is a flag, set.Parse returns an error
+			var flagArgs []string
+			if terminatorIndex > -1 {
+				flagArgs = args[firstFlagIndex:terminatorIndex]
+				regularArgs = append(regularArgs, args[terminatorIndex:]...)
+			} else {
+				flagArgs = args[firstFlagIndex:]
+			}
+
+			err = set.Parse(append(flagArgs, regularArgs...))
+		} else {
+			err = set.Parse(ctx.Args().Tail())
+		}
+	} else {
 		if c.SkipFlagParsing {
-			err = nil
+			err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
 		}
 	}
 
@@ -159,6 +163,12 @@ func (c Command) startApp(ctx *Context) error {
 
 	// set the name and usage
 	app.Name = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	if c.HelpName == "" {
+		app.HelpName = c.HelpName
+	} else {
+		app.HelpName = fmt.Sprintf("%s %s", ctx.App.Name, c.Name)
+	}
+
 	if c.Description != "" {
 		app.Usage = c.Description
 	} else {

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -1,69 +1,43 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"testing"
 )
 
-func TestCommandDoNotIgnoreFlags(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "blah", "-break"}
-	set.Parse(test)
-
-	c := NewContext(app, set, nil)
-
-	command := Command{
-		Name:        "test-cmd",
-		Aliases:     []string{"tc"},
-		Usage:       "this is for testing",
-		Description: "testing",
-		Action:      func(_ *Context) {},
+func TestCommandFlagParsing(t *testing.T) {
+	cases := []struct {
+		testArgs        []string
+		skipFlagParsing bool
+		expectedErr     error
+	}{
+		{[]string{"blah", "blah", "-break"}, false, errors.New("flag provided but not defined: -break")}, // Test normal "not ignoring flags" flow
+		{[]string{"blah", "blah"}, true, nil},                                                            // Test SkipFlagParsing without any args that look like flags
+		{[]string{"blah", "-break"}, true, nil},                                                          // Test SkipFlagParsing with random flag arg
+		{[]string{"blah", "-help"}, true, nil},                                                           // Test SkipFlagParsing with "special" help flag arg
 	}
-	err := command.Run(c)
 
-	expect(t, err.Error(), "flag provided but not defined: -break")
-}
+	for _, c := range cases {
+		app := NewApp()
+		set := flag.NewFlagSet("test", 0)
+		set.Parse(c.testArgs)
 
-func TestCommandIgnoreFlags(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "blah"}
-	set.Parse(test)
+		context := NewContext(app, set, nil)
 
-	c := NewContext(app, set, nil)
+		command := Command{
+			Name:        "test-cmd",
+			Aliases:     []string{"tc"},
+			Usage:       "this is for testing",
+			Description: "testing",
+			Action:      func(_ *Context) {},
+		}
 
-	command := Command{
-		Name:            "test-cmd",
-		Aliases:         []string{"tc"},
-		Usage:           "this is for testing",
-		Description:     "testing",
-		Action:          func(_ *Context) {},
-		SkipFlagParsing: true,
+		command.SkipFlagParsing = c.skipFlagParsing
+
+		err := command.Run(context)
+
+		expect(t, err, c.expectedErr)
+		expect(t, []string(context.Args()), c.testArgs)
 	}
-	err := command.Run(c)
-
-	expect(t, err, nil)
-}
-
-// Fix bug with ignoring flag parsing that would still parse the first flag
-func TestCommandIgnoreFlagsIncludingFirstArgument(t *testing.T) {
-	app := NewApp()
-	set := flag.NewFlagSet("test", 0)
-	test := []string{"blah", "-break"}
-	set.Parse(test)
-
-	c := NewContext(app, set, nil)
-
-	command := Command{
-		Name:            "test-cmd",
-		Aliases:         []string{"tc"},
-		Usage:           "this is for testing",
-		Description:     "testing",
-		Action:          func(_ *Context) {},
-		SkipFlagParsing: true,
-	}
-	err := command.Run(c)
-
-	expect(t, err, nil)
 }

--- a/cli/help.go
+++ b/cli/help.go
@@ -15,7 +15,7 @@ var AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} [arguments...]
+   {{.HelpName}} {{if .Flags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
    {{if .Version}}
 VERSION:
    {{.Version}}
@@ -38,10 +38,10 @@ COPYRIGHT:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var CommandHelpTemplate = `NAME:
-   {{.FullName}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   command {{.FullName}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
+   {{.HelpName}}{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
 
 DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}
@@ -55,10 +55,10 @@ OPTIONS:
 // cli.go uses text/template to render templates. You can
 // render custom help text by setting this variable.
 var SubcommandHelpTemplate = `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} command{{if .Flags}} [command options]{{end}} [arguments...]
+   {{.HelpName}} command{{if .Flags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
 
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
@@ -69,9 +69,10 @@ OPTIONS:
 `
 
 var helpCommand = Command{
-	Name:    "help",
-	Aliases: []string{"h"},
-	Usage:   "Shows a list of commands or help for one command",
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
 	Action: func(c *Context) {
 		args := c.Args()
 		if args.Present() {
@@ -83,9 +84,10 @@ var helpCommand = Command{
 }
 
 var helpSubcommand = Command{
-	Name:    "help",
-	Aliases: []string{"h"},
-	Usage:   "Shows a list of commands or help for one command",
+	Name:      "help",
+	Aliases:   []string{"h"},
+	Usage:     "Shows a list of commands or help for one command",
+	ArgsUsage: "[command]",
 	Action: func(c *Context) {
 		args := c.Args()
 		if args.Present() {
@@ -184,21 +186,27 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 }
 
 func checkVersion(c *Context) bool {
-	if c.GlobalBool("version") || c.GlobalBool("v") || c.Bool("version") || c.Bool("v") {
-		ShowVersion(c)
-		return true
+	found := false
+	if VersionFlag.Name != "" {
+		eachName(VersionFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
 	}
-
-	return false
+	return found
 }
 
 func checkHelp(c *Context) bool {
-	if c.GlobalBool("h") || c.GlobalBool("help") || c.Bool("h") || c.Bool("help") {
-		ShowAppHelp(c)
-		return true
+	found := false
+	if HelpFlag.Name != "" {
+		eachName(HelpFlag.Name, func(name string) {
+			if c.GlobalBool(name) || c.Bool(name) {
+				found = true
+			}
+		})
 	}
-
-	return false
+	return found
 }
 
 func checkCommandHelp(c *Context, name string) bool {

--- a/cli/help_test.go
+++ b/cli/help_test.go
@@ -34,3 +34,61 @@ func Test_ShowAppHelp_NoVersion(t *testing.T) {
 		t.Errorf("expected\n%snot to include %s", output.String(), "VERSION:")
 	}
 }
+
+func Test_Help_Custom_Flags(t *testing.T) {
+	oldFlag := HelpFlag
+	defer func() {
+		HelpFlag = oldFlag
+	}()
+
+	HelpFlag = BoolFlag{
+		Name:  "help, x",
+		Usage: "show help",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, h"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("h") != true {
+				t.Errorf("custom help flag not set")
+			}
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-h"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}
+
+func Test_Version_Custom_Flags(t *testing.T) {
+	oldFlag := VersionFlag
+	defer func() {
+		VersionFlag = oldFlag
+	}()
+
+	VersionFlag = BoolFlag{
+		Name:  "version, V",
+		Usage: "show version",
+	}
+
+	app := App{
+		Flags: []Flag{
+			BoolFlag{Name: "foo, v"},
+		},
+		Action: func(ctx *Context) {
+			if ctx.Bool("v") != true {
+				t.Errorf("custom version flag not set")
+			}
+		},
+	}
+	output := new(bytes.Buffer)
+	app.Writer = output
+	app.Run([]string{"test", "-v"})
+	if output.Len() > 0 {
+		t.Errorf("unexpected output: %s", output.String())
+	}
+}

--- a/cli/helpers_test.go
+++ b/cli/helpers_test.go
@@ -7,13 +7,13 @@ import (
 
 /* Test Helpers */
 func expect(t *testing.T, a interface{}, b interface{}) {
-	if a != b {
+	if !reflect.DeepEqual(a, b) {
 		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }
 
 func refute(t *testing.T, a interface{}, b interface{}) {
-	if a == b {
+	if reflect.DeepEqual(a, b) {
 		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -168,7 +168,7 @@ var Commands = []cli.Command{
 	{
 		Flags:           sharedCreateFlags,
 		Name:            "create",
-		Usage:           "Create a machine.\n\nSpecify a driver with --driver to include the create flags for that driver in the help text.",
+		Usage:           fmt.Sprintf("Create a machine.\n\nRun '%s create --driver name' to include the create flags for that driver in the help text.", os.Args[0]),
 		Action:          fatalOnError(cmdCreateOuter),
 		SkipFlagParsing: true,
 	},

--- a/commands/create.go
+++ b/commands/create.go
@@ -270,6 +270,10 @@ func flagHackLookup(flagName string) string {
 }
 
 func cmdCreateOuter(c *cli.Context) error {
+	const (
+		flagLookupMachineName = "flag-lookup"
+	)
+
 	driverName := flagHackLookup("--driver")
 
 	// We didn't recognize the driver name.
@@ -278,11 +282,9 @@ func cmdCreateOuter(c *cli.Context) error {
 		return nil // ?
 	}
 
-	name := c.Args().First()
-
 	// TODO: Fix hacky JSON solution
 	bareDriverData, err := json.Marshal(&drivers.BaseDriver{
-		MachineName: name,
+		MachineName: flagLookupMachineName,
 	})
 	if err != nil {
 		return fmt.Errorf("Error attempting to marshal bare driver data: %s", err)

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -8,6 +8,14 @@ import (
 )
 
 func cmdSsh(c *cli.Context) error {
+	// Check for help flag -- Needed due to SkipFlagParsing
+	for _, arg := range c.Args() {
+		if arg == "-help" || arg == "--help" || arg == "-h" {
+			cli.ShowCommandHelp(c, "ssh")
+			return nil
+		}
+	}
+
 	name := c.Args().First()
 	if name == "" {
 		return ErrExpectedOneMachine

--- a/test/integration/cli/driver_help.bats
+++ b/test/integration/cli/driver_help.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+@test "no --help flag or command specified" {
+  [[ $(machine create -d ${DRIVER} 2>&1 | grep $DRIVER | wc -l) -gt 0 ]]
+}
+
+@test "-h flag specified" {
+  [[ $(machine create -d ${DRIVER} 2>&1 -h | grep $DRIVER | wc -l) -gt 0 ]]
+}
+
+@test "--help flag specified" {
+  [[ $(machine create -d ${DRIVER} --help 2>&1 | grep $DRIVER | wc -l) -gt 0 ]]
+}


### PR DESCRIPTION
Thanks for @tiborvass and others pointing it out, I noticed that `docker-machine create --help --driver virtualbox` would not include the driver-specific flags in the output, and also gives slightly misleading output when invoked via `docker-machine help create`.  This fixes these issues to a reasonable degree.

This adds a test to detect the issue but the test depends on https://github.com/codegangsta/cli/pull/283 getting merged to be valid (otherwise `SkipFlagParsing` does not honor its commitment and actually parses the flags, including `--help`).  The good news is that once that is merged, we can remove our terrible forked codegangsta/cli patch and go back to Good Old Fashioned Vendoring(tm).

Also includes a fix for a slightly silly behavior where the RPC client driver used to get the flags would have a name corresponding to `c.Args.First()` when really it's OK to simply hardcode it as something (I've done `flag-lookup` here).  Just in case help text is invoked with `--debug`, it makes things slightly clearer.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>