### PR TITLE
New option for virtualbox driver to set custom shared folder

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -137,8 +137,8 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			EnvVar: "VIRTUALBOX_SHARE_FOLDER",
-			Name: "virtualbox-share-folder",
-			Usage: "Mount the specified directory instead of the default home location. Format: dir:name",
+			Name:   "virtualbox-share-folder",
+			Usage:  "Mount the specified directory instead of the default home location. Format: dir:name",
 		},
 	}
 }


### PR DESCRIPTION
I'm an OSX user, who has his $HOME outside /Users. It was moved to a secondary hard drive.

With this setup, I had difficulties using docker volumes, so I've added a new parameter to docker-machine's virtualbox driver that I can use to specify the location of my alternative /Users directory.

The format is --virtualbox-share-folder /path/to/folder:sharename. Automatic mounting currently only works with sharename == Users, for custom sharenames some work is needed on the boot2docker side[1].

[1]: https://github.com/boot2docker/boot2docker/blob/master/rootfs/rootfs/etc/rc.d/vbox#L36