### PR TITLE
Ensure copy of certs to do not end up in pwd

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -71,18 +71,20 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	log.Info("Copying certs to the local machine directory...")
+	if authOptions.StorePath != "" {
+		log.Info("Copying certs to the local machine directory...")
 
-	if err := mcnutils.CopyFile(authOptions.CaCertPath, filepath.Join(authOptions.StorePath, "ca.pem")); err != nil {
-		return fmt.Errorf("Copying ca.pem to machine dir failed: %s", err)
-	}
+		if err := mcnutils.CopyFile(authOptions.CaCertPath, filepath.Join(authOptions.StorePath, "ca.pem")); err != nil {
+			return fmt.Errorf("Copying ca.pem to machine dir failed: %s", err)
+		}
 
-	if err := mcnutils.CopyFile(authOptions.ClientCertPath, filepath.Join(authOptions.StorePath, "cert.pem")); err != nil {
-		return fmt.Errorf("Copying cert.pem to machine dir failed: %s", err)
-	}
+		if err := mcnutils.CopyFile(authOptions.ClientCertPath, filepath.Join(authOptions.StorePath, "cert.pem")); err != nil {
+			return fmt.Errorf("Copying cert.pem to machine dir failed: %s", err)
+		}
 
-	if err := mcnutils.CopyFile(authOptions.ClientKeyPath, filepath.Join(authOptions.StorePath, "key.pem")); err != nil {
-		return fmt.Errorf("Copying key.pem to machine dir failed: %s", err)
+		if err := mcnutils.CopyFile(authOptions.ClientKeyPath, filepath.Join(authOptions.StorePath, "key.pem")); err != nil {
+			return fmt.Errorf("Copying key.pem to machine dir failed: %s", err)
+		}
 	}
 
 	log.Debugf("generating server cert: %s ca-key=%s private-key=%s org=%s",


### PR DESCRIPTION
When using the libMachine as a package, the certificates would
be copied in the pwd on each run.  A simple if statement was
added to ensure that copies only occur if the StorePath
was specified when the AuthOptions were created.

Signed-off-by: Clinton Kitson <clintonskitson@gmail.com>