### PR TITLE
Fix panic when using openstack driver

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -182,16 +182,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "OpenStack SSH port",
 			Value:  defaultSSHPort,
 		},
-		mcnflag.StringFlag{
-			Name:  "openstack-ssh-user",
-			Usage: "OpenStack SSH user",
-			Value: defaultSSHUser,
-		},
-		mcnflag.IntFlag{
-			Name:  "openstack-ssh-port",
-			Usage: "OpenStack SSH port",
-			Value: defaultSSHPort,
-		},
 		mcnflag.IntFlag{
 			EnvVar: "OS_ACTIVE_TIMEOUT",
 			Name:   "openstack-active-timeout",


### PR DESCRIPTION
The openstack driver was unusable because some cli flags were redifined.

That caused a runtime error like:
```
  create flag redefined: openstack-ssh-user
  panic: create flag redefined: openstack-ssh-user
```
Signed-off-by: Flavio Castelli <fcastelli@suse.com>