### PR TITLE
Fix DriverName missing in 0.3.1 => 0.5.0 migration

### DIFF
--- a/libmachine/host/migrate_v0_v1.go
+++ b/libmachine/host/migrate_v0_v1.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/machine/libmachine/swarm"
 )
 
-// In the 0.0.1 => 0.0.2 transition, the JSON representation of
+// In the 0.1.0 => 0.2.0 transition, the JSON representation of
 // machines changed from a "flat" to a more "nested" structure
 // for various options and configuration settings.  To preserve
 // compatibility with existing machines, these migration functions
@@ -17,11 +17,15 @@ import (
 // this is used for configuration updates
 func MigrateHostV0ToHostV1(hostV0 *HostV0) *HostV1 {
 	hostV1 := &HostV1{
-		Driver: hostV0.Driver,
+		Driver:     hostV0.Driver,
+		DriverName: hostV0.DriverName,
 	}
 
 	hostV1.HostOptions = &HostOptionsV1{}
-	hostV1.HostOptions.EngineOptions = &engine.EngineOptions{}
+	hostV1.HostOptions.EngineOptions = &engine.EngineOptions{
+		TlsVerify:  true,
+		InstallURL: "https://get.docker.com",
+	}
 	hostV1.HostOptions.SwarmOptions = &swarm.SwarmOptions{
 		Address:   "",
 		Discovery: hostV0.SwarmDiscovery,

--- a/libmachine/host/migrate_v0_v1_test.go
+++ b/libmachine/host/migrate_v0_v1_test.go
@@ -38,7 +38,10 @@ func TestMigrateHostV0ToV1(t *testing.T) {
 			ServerCertPath: "/tmp/migration/certs/server.pem",
 			ServerKeyPath:  "/tmp/migration/certs/server-key.pem",
 		},
-		EngineOptions: &engine.EngineOptions{},
+		EngineOptions: &engine.EngineOptions{
+			InstallURL: "https://get.docker.com",
+			TlsVerify:  true,
+		},
 	}
 
 	expectedHost := &HostV1{

--- a/libmachine/host/migrate_v0_v3_test.go
+++ b/libmachine/host/migrate_v0_v3_test.go
@@ -1,0 +1,23 @@
+package host
+
+import "testing"
+
+var (
+	v0conf = []byte(`{"DriverName":"virtualbox","Driver":{"IPAddress":"192.168.99.100","SSHUser":"docker","SSHPort":53507,"MachineName":"dev","CaCertPath":"/Users/ljrittle/.docker/machine/certs/ca.pem","PrivateKeyPath":"/Users/ljrittle/.docker/machine/certs/ca-key.pem","SwarmMaster":false,"SwarmHost":"tcp://0.0.0.0:3376","SwarmDiscovery":"","CPU":-1,"Memory":1024,"DiskSize":20000,"Boot2DockerURL":"","Boot2DockerImportVM":"","HostOnlyCIDR":""},"StorePath":"/Users/ljrittle/.docker/machine/machines/dev","HostOptions":{"Driver":"","Memory":0,"Disk":0,"EngineOptions":{"ArbitraryFlags":null,"Dns":null,"GraphDir":"","Ipv6":false,"InsecureRegistry":null,"Labels":null,"LogLevel":"","StorageDriver":"","SelinuxEnabled":false,"TlsCaCert":"","TlsCert":"","TlsKey":"","TlsVerify":false,"RegistryMirror":null,"InstallURL":""},"SwarmOptions":{"IsSwarm":false,"Address":"","Discovery":"","Master":false,"Host":"tcp://0.0.0.0:3376","Image":"","Strategy":"","Heartbeat":0,"Overcommit":0,"TlsCaCert":"","TlsCert":"","TlsKey":"","TlsVerify":false,"ArbitraryFlags":null},"AuthOptions":{"StorePath":"/Users/ljrittle/.docker/machine/machines/dev","CaCertPath":"/Users/ljrittle/.docker/machine/certs/ca.pem","CaCertRemotePath":"","ServerCertPath":"/Users/ljrittle/.docker/machine/certs/server.pem","ServerKeyPath":"/Users/ljrittle/.docker/machine/certs/server-key.pem","ClientKeyPath":"/Users/ljrittle/.docker/machine/certs/key.pem","ServerCertRemotePath":"","ServerKeyRemotePath":"","PrivateKeyPath":"/Users/ljrittle/.docker/machine/certs/ca-key.pem","ClientCertPath":"/Users/ljrittle/.docker/machine/certs/cert.pem"}}}`)
+)
+
+func TestMigrateHostV0ToHostV3(t *testing.T) {
+	h := &Host{}
+	migratedHost, migrationPerformed, err := MigrateHost(h, v0conf)
+	if err != nil {
+		t.Fatalf("Error attempting to migrate host: %s", err)
+	}
+
+	if !migrationPerformed {
+		t.Fatal("Expected a migration to be reported as performed but it was not")
+	}
+
+	if migratedHost.DriverName != "virtualbox" {
+		t.Fatalf("Expected %q, got %q for the driver name", "virtualbox", migratedHost.DriverName)
+	}
+}


### PR DESCRIPTION
Thanks to @dgageot for the primary fix

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>
Signed-off-by: David Gageot <david@gageot.net>