### PR TITLE
Fail gracefully when plugin binary implements outdated API

### DIFF
--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
 	"github.com/docker/machine/libmachine/drivers/rpc"
+	"github.com/docker/machine/libmachine/version"
 )
 
 var (
@@ -20,9 +21,11 @@ var (
 
 func RegisterDriver(d drivers.Driver) {
 	if os.Getenv(localbinary.PluginEnvKey) != localbinary.PluginEnvVal {
-		fmt.Fprintln(os.Stderr, `This is a Docker Machine plugin binary.
+		fmt.Fprintf(os.Stderr, `This is a Docker Machine plugin binary.
 Plugin binaries are not intended to be invoked directly.
-Please use this plugin through the main 'docker-machine' binary.`)
+Please use this plugin through the main 'docker-machine' binary.
+(API version: %d)
+`, version.ApiVersion)
 		os.Exit(1)
 	}
 

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/state"
+	"github.com/docker/machine/libmachine/version"
 )
 
 var (
@@ -89,11 +90,15 @@ func NewRpcClientDriver(rawDriverData []byte, driverName string) (*RpcClientDriv
 		}
 	}(c)
 
-	var version int
-	if err := c.Client.Call("RpcServerDriver.GetVersion", struct{}{}, &version); err != nil {
+	var serverVersion int
+	if err := c.Client.Call("RpcServerDriver.GetVersion", struct{}{}, &serverVersion); err != nil {
 		return nil, err
 	}
-	log.Debug("Using API Version ", version)
+
+	if serverVersion != version.ApiVersion {
+		return nil, fmt.Errorf("Driver binary uses an incompatible API version (%d)", serverVersion)
+	}
+	log.Debug("Using API Version ", serverVersion)
 
 	if err := c.SetConfigRaw(rawDriverData); err != nil {
 		return nil, err


### PR DESCRIPTION
Since drivers will (mostly) be distributed separately it is too be expected that the docker-machine and  plugin binaries on users systems might eventually get out-of-sync in regards to the API version they implement.
E.g. after i upgraded to v0.5.0-rc4 today, docker-machine stopped working. Eventually i found out that this was caused by a third-party driver plugin that was built against v0.5.0-rc3 and didn't satisfy API methods introduced in rc4.

This patch makes sure  that docker-machine fails gracefully in case the driver binary API version is outdated.

Signed-off-by: Jan Broer <janeczku@yahoo.de>