### PR TITLE
Digitalocean driver: Support for creating Droplets with Cloud-init User Data

### DIFF
--- a/docs/drivers/digital-ocean.md
+++ b/docs/drivers/digital-ocean.md
@@ -26,6 +26,7 @@ Options:
 -   `--digitalocean-ipv6`: Enable IPv6 support for the droplet.
 -   `--digitalocean-private-networking`: Enable private networking support for the droplet.
 -   `--digitalocean-backups`: Enable Digital Oceans backups for the droplet.
+-   `--digitalocean-userdata`: Path to file containing User Data for the droplet.
 
 The DigitalOcean driver will use `ubuntu-14-04-x64` as the default image.
 
@@ -40,3 +41,4 @@ Environment variables and default values:
 | `--digitalocean-ipv6`               | `DIGITALOCEAN_IPV6`               | `false`  |
 | `--digitalocean-private-networking` | `DIGITALOCEAN_PRIVATE_NETWORKING` | `false`  |
 | `--digitalocean-backups`            | `DIGITALOCEAN_BACKUPS`            | `false`  |
+| `--digitalocean-userdata`           | `DIGITALOCEAN_USERDATA`           | -        |


### PR DESCRIPTION
This PR enhances the Digitalocean driver to support bootstrapping droplets with Cloud-init User Data.
It adds a new create flag which allows users to pass a file containing User Data (e.g. cloud-config or shell script) to the driver.

#### New flag

**Path to user-data file**

* EnvVar: `DIGITALOCEAN_USERDATA`
* Name: `digitalocean-userdata`

#### Example usage for deploying CoreOS machine

```sh
$ cat <<EOF >>/tmp/cloud-config.yaml
#cloud-config
coreos:
  etcd2:
    discovery: https://discovery.etcd.io/ABC123456
    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
    initial-advertise-peer-urls: http://$private_ipv4:2380
    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
    listen-peer-urls: http://$private_ipv4:2380
  units:
    - name: etcd2.service
      command: start
    - name: fleet.service
      command: start
EOF
```
```sh
$ docker-machine create -d digitalocean digitalocean-access-token ABC123456 \
--digitalocean-image coreos-stable --digitalocean-private-networking \
--digitalocean-userdata /tmp/cloud-config.yaml test-droplet
```