### PR TITLE
Fix DHCP server and host-only adapter IP address clash

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -672,7 +672,7 @@ func (d *Driver) setupHostOnlyNetwork(machineName string) error {
 		return err
 	}
 
-	dhcpAddr, err := getRandomIPinSubnet(network.IP)
+	dhcpAddr, err := getRandomIPinSubnet(ip)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When setting up a host-only network we need to pass the IP address
of the host adapter (e.g 192.168.99.1) to the getRandomIPinSubnet function.
Passing the network address (e.g 192.168.1.0) can result in bypassing the IP
clash check and having the same address assigned to both the DHCP server
and the host-only network interface.

Signed-off-by: Todor Minchev <todor.minchev@linux.intel.com>