### PR TITLE
Dependencies make helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,11 @@ Scrub build results:
     make lint
     make dco
 
+### Save and restore dependencies
+
+    make dep-save
+    make dep-restore
+
 ## Integration Tests
 
 ### Setup

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -1,0 +1,9 @@
+dep-save:
+	$(if $(GODEP), , \
+		$(error Please install godep: go get github.com/tools/godep))
+	godep save $(shell go list ./... | grep -v vendor/)
+
+dep-restore:
+	$(if $(GODEP), , \
+		$(error Please install godep: go get github.com/tools/godep))
+	godep restore $(shell go list ./... | grep -v vendor/)

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -3,7 +3,7 @@ GO_LDFLAGS := -X `go list ./version`.GitCommit=`git rev-parse --short HEAD 2>/de
 GO_GCFLAGS :=
 
 # Full package list
-PKGS := $(shell go list -tags "$(BUILDTAGS)" ./... | grep -v "/vendor/" | grep -v "/Godeps/" | grep -v "/cmd")
+PKGS := $(shell go list -tags "$(BUILDTAGS)" ./... | grep -v "/vendor/" | grep -v "/cmd")
 
 # Support go1.5 vendoring (let us avoid messing with GOPATH or using godep)
 export GO15VENDOREXPERIMENT = 1
@@ -11,6 +11,9 @@ export GO15VENDOREXPERIMENT = 1
 # Resolving binary dependencies for specific targets
 GOLINT_BIN := $(GOPATH)/bin/golint
 GOLINT := $(shell [ -x $(GOLINT_BIN) ] && echo $(GOLINT_BIN) || echo '')
+
+GODEP_BIN := $(GOPATH)/bin/godep
+GODEP := $(shell [ -x $(GODEP_BIN) ] && echo $(GODEP_BIN) || echo '')
 
 # Honor debug
 ifeq ($(DEBUG),true)
@@ -36,6 +39,7 @@ endif
 
 include mk/build.mk
 include mk/coverage.mk
+include mk/dev.mk
 include mk/release.mk
 include mk/test.mk
 include mk/validate.mk

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -10,7 +10,7 @@ dco:
 
 # Fmt
 fmt:
-	@test -z "$$(gofmt -s -l . 2>&1 | grep -v vendor/ | grep -v Godeps/ | tee /dev/stderr)"
+	@test -z "$$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 
 # Vet
 vet: build
@@ -20,4 +20,4 @@ vet: build
 lint:
 	$(if $(GOLINT), , \
 		$(error Please install golint: go get -u github.com/golang/lint/golint))
-	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | grep -v Godeps/ | tee /dev/stderr)"
+	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | tee /dev/stderr)"


### PR DESCRIPTION
This is the last one on godeps.

Commit message says it all: added and documented two simple helpers to ease managing deps.
Removed now obsolete references to `grep -v Godeps`