### PR TITLE
test/integration: Remove machine forcibly, without stopping

### DIFF
--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -15,8 +15,7 @@ function quiet_run () {
 
 function cleanup_machines() {
     if [[ $(machine ls -q | wc -l) -ne 0 ]]; then
-        quiet_run machine stop $(machine ls -q)
-        quiet_run machine rm $(machine ls -q)
+        quiet_run machine rm -f $(machine ls -q)
     fi
 }
 


### PR DESCRIPTION
Unlikely the "rm -f", commands "stop" and "rm" will be failed if machine doesn't exist.
Forced removing guarantees that integration tests won't fail on the cleanup step.

At this moment, the tests are terminating right after the first test is passing:
```
$ VERBOSE=1 DRIVER=virtualbox test/integration/run-bats.sh test/integration/drivers/virtualbox/
=> test/integration/drivers/virtualbox//bad-create-iso.bats
 ✓ virtualbox: Should not allow machine creation with bad ISO

1 test, 0 failures

/usr/local/bin/VBoxManage controlvm bats-virtualbox-test acpipowerbutton failed:
VBoxManage: error: Could not find a registered machine named 'bats-virtualbox-test'
VBoxManage: error: Details: code VBOX_E_OBJECT_NOT_FOUND (0x80bb0001), component VirtualBoxWrap, interface IVirtualBox, callee nsISupports
VBoxManage: error: Context: "FindMachine(Bstr(a->argv[0]).raw(), machine.asOutParam())" at line 96 of file VBoxManageControlVM.cpp

/usr/local/bin/VBoxManage controlvm bats-virtualbox-test acpipowerbutton failed:
VBoxManage: error: Could not find a registered machine named 'bats-virtualbox-test'
VBoxManage: error: Details: code VBOX_E_OBJECT_NOT_FOUND (0x80bb0001), component VirtualBoxWrap, interface IVirtualBox, callee nsISupports
VBoxManage: error: Context: "FindMachine(Bstr(a->argv[0]).raw(), machine.asOutParam())" at line 96 of file VBoxManageControlVM.cpp

$
```