### PR TITLE
[WIP] Inject the Store into commands

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -15,12 +15,10 @@ var (
 	errTooManyArguments = errors.New("Error: Too many arguments given")
 )
 
-func cmdActive(c CommandLine) error {
+func cmdActive(c CommandLine, store persist.Store) error {
 	if len(c.Args()) > 0 {
 		return errTooManyArguments
 	}
-
-	store := getStore(c)
 
 	host, err := getActiveHost(store)
 	if err != nil {
@@ -35,7 +33,7 @@ func cmdActive(c CommandLine) error {
 }
 
 func getActiveHost(store persist.Store) (*host.Host, error) {
-	hosts, err := listHosts(store)
+	hosts, err := store.List()
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +42,7 @@ func getActiveHost(store persist.Store) (*host.Host, error) {
 
 	for _, item := range hostListItems {
 		if item.Active {
-			return loadHost(store, item.Name)
+			return store.Load(item.Name)
 		}
 	}
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/machine/libmachine/cert"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/state"
 )
 
@@ -26,7 +27,7 @@ Be advised that this will trigger a Docker daemon restart which will stop runnin
 `, e.hostUrl, e.wrappedErr)
 }
 
-func cmdConfig(c CommandLine) error {
+func cmdConfig(c CommandLine, store persist.Store) error {
 	// Ensure that log messages always go to stderr when this command is
 	// being run (it is intended to be run in a subshell)
 	log.SetOutWriter(os.Stderr)
@@ -35,7 +36,7 @@ func cmdConfig(c CommandLine) error {
 		return ErrExpectedOneMachine
 	}
 
-	host, err := getFirstArgHost(c)
+	host, err := store.Load(c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/commands/create.go
+++ b/commands/create.go
@@ -1,20 +1,14 @@
 package commands
 
 import (
-	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
-	"strings"
 
-	"errors"
-
-	"github.com/docker/machine/cli"
 	"github.com/docker/machine/commands/mcndirs"
-	"github.com/docker/machine/drivers/errdriver"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
@@ -26,117 +20,49 @@ import (
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/drivers/errdriver"
 )
 
 var (
 	errNoMachineName = errors.New("Error: No machine name specified")
 )
 
-var (
-	sharedCreateFlags = []cli.Flag{
-		cli.StringFlag{
-			Name: "driver, d",
-			Usage: fmt.Sprintf(
-				"Driver to create machine with.",
-			),
-			Value: "none",
-		},
-		cli.StringFlag{
-			Name:   "engine-install-url",
-			Usage:  "Custom URL to use for engine installation",
-			Value:  "https://get.docker.com",
-			EnvVar: "MACHINE_DOCKER_INSTALL_URL",
-		},
-		cli.StringSliceFlag{
-			Name:  "engine-opt",
-			Usage: "Specify arbitrary flags to include with the created engine in the form flag=value",
-			Value: &cli.StringSlice{},
-		},
-		cli.StringSliceFlag{
-			Name:  "engine-insecure-registry",
-			Usage: "Specify insecure registries to allow with the created engine",
-			Value: &cli.StringSlice{},
-		},
-		cli.StringSliceFlag{
-			Name:  "engine-registry-mirror",
-			Usage: "Specify registry mirrors to use",
-			Value: &cli.StringSlice{},
-		},
-		cli.StringSliceFlag{
-			Name:  "engine-label",
-			Usage: "Specify labels for the created engine",
-			Value: &cli.StringSlice{},
-		},
-		cli.StringFlag{
-			Name:  "engine-storage-driver",
-			Usage: "Specify a storage driver to use with the engine",
-		},
-		cli.StringSliceFlag{
-			Name:  "engine-env",
-			Usage: "Specify environment variables to set in the engine",
-			Value: &cli.StringSlice{},
-		},
-		cli.BoolFlag{
-			Name:  "swarm",
-			Usage: "Configure Machine with Swarm",
-		},
-		cli.StringFlag{
-			Name:   "swarm-image",
-			Usage:  "Specify Docker image to use for Swarm",
-			Value:  "swarm:latest",
-			EnvVar: "MACHINE_SWARM_IMAGE",
-		},
-		cli.BoolFlag{
-			Name:  "swarm-master",
-			Usage: "Configure Machine to be a Swarm master",
-		},
-		cli.StringFlag{
-			Name:  "swarm-discovery",
-			Usage: "Discovery service to use with Swarm",
-			Value: "",
-		},
-		cli.StringFlag{
-			Name:  "swarm-strategy",
-			Usage: "Define a default scheduling strategy for Swarm",
-			Value: "spread",
-		},
-		cli.StringSliceFlag{
-			Name:  "swarm-opt",
-			Usage: "Define arbitrary flags for swarm",
-			Value: &cli.StringSlice{},
-		},
-		cli.StringFlag{
-			Name:  "swarm-host",
-			Usage: "ip/socket to listen on for Swarm master",
-			Value: "tcp://0.0.0.0:3376",
-		},
-		cli.StringFlag{
-			Name:  "swarm-addr",
-			Usage: "addr to advertise for Swarm (default: detect and use the machine IP)",
-			Value: "",
-		},
-	}
-)
-
-func cmdCreateInner(c CommandLine) error {
+func cmdCreate(c CommandLine, store persist.Store) error {
 	if len(c.Args()) > 1 {
 		return fmt.Errorf("Invalid command line. Found extra arguments %v", c.Args()[1:])
 	}
 
 	name := c.Args().First()
-	driverName := c.String("driver")
-	certInfo := getCertPathInfoFromContext(c)
-
-	storePath := c.GlobalString("storage-path")
-
-	store := &persist.Filestore{
-		Path:             storePath,
-		CaCertPath:       certInfo.CaCertPath,
-		CaPrivateKeyPath: certInfo.CaPrivateKeyPath,
-	}
-
 	if name == "" {
 		c.ShowHelp()
+
+		driverName := c.String("driver")
+		h, err := store.NewHost(name, driverName)
+		if err != nil {
+			return fmt.Errorf("Error getting new host: %q", err) // TODO
+		}
+
+		if _, ok := h.Driver.(*errdriver.Driver); ok {
+			return errdriver.ErrDriverNotLoadable{driverName}
+		}
+
+		createFlags := h.Driver.GetCreateFlags()
+		if len(createFlags) > 0 {
+			// TODO: This is just a prototype
+			//	sort.Sort(ByFlagName(cmd.Flags))
+			//--virtualbox-disk-size "20000"									Size of disk for host in MB [$VIRTUALBOX_DISK_SIZE]
+			//--virtualbox-hostonly-cidr "192.168.99.1/24"								Specify the Host Only CIDR [$VIRTUALBOX_HOSTONLY_CIDR]
+			//--virtualbox-import-boot2docker-vm 									The name of a Boot2Docker VM to import
+			//--virtualbox-memory "1024"										Size of memory for host in MB [$VIRTUALBOX_MEMORY_SIZE]
+
+			fmt.Println("\nDriver specific options:\n")
+			for _, f := range createFlags {
+				fmt.Printf("   --%s \"%v\"\t%s [%s]\n", f.String(), f.Default(), f.Description(), f.EnvVarName())
+			}
+
+			fmt.Println()
+		}
+
 		return errNoMachineName
 	}
 
@@ -149,25 +75,23 @@ func cmdCreateInner(c CommandLine) error {
 		return fmt.Errorf("Error parsing swarm discovery: %s", err)
 	}
 
-	// TODO: Fix hacky JSON solution
-	bareDriverData, err := json.Marshal(&drivers.BaseDriver{
-		MachineName: name,
-		StorePath:   c.GlobalString("storage-path"),
-	})
+	exists, err := store.Exists(name)
 	if err != nil {
-		return fmt.Errorf("Error attempting to marshal bare driver data: %s", err)
+		return fmt.Errorf("Error checking if host exists: %s", err)
+	}
+	if exists {
+		return mcnerror.ErrHostAlreadyExists{
+			Name: name,
+		}
 	}
 
-	driver, err := newPluginDriver(driverName, bareDriverData)
-	if err != nil {
-		return fmt.Errorf("Error loading driver %q: %s", driverName, err)
-	}
-
-	h, err := store.NewHost(driver)
+	driverName := c.String("driver")
+	h, err := store.NewHost(name, driverName)
 	if err != nil {
 		return fmt.Errorf("Error getting new host: %s", err)
 	}
 
+	certInfo := getCertPathInfoFromContext(c)
 	h.HostOptions = &host.HostOptions{
 		AuthOptions: &auth.AuthOptions{
 			CertDir:          mcndirs.GetMachineCertDir(),
@@ -201,24 +125,14 @@ func cmdCreateInner(c CommandLine) error {
 		},
 	}
 
-	exists, err := store.Exists(h.Name)
-	if err != nil {
-		return fmt.Errorf("Error checking if host exists: %s", err)
-	}
-	if exists {
-		return mcnerror.ErrHostAlreadyExists{
-			Name: h.Name,
-		}
-	}
-
 	// driverOpts is the actual data we send over the wire to set the
 	// driver parameters (an interface fulfilling drivers.DriverOptions,
 	// concrete type rpcdriver.RpcFlags).
-	mcnFlags := driver.GetCreateFlags()
+	mcnFlags := h.Driver.GetCreateFlags()
 	driverOpts := getDriverOpts(c, mcnFlags)
 
 	if err := h.Driver.SetConfigFromFlags(driverOpts); err != nil {
-		return fmt.Errorf("Error setting machine configuration from flags provided: %s", err)
+		return err
 	}
 
 	if err := libmachine.Create(store, h); err != nil {
@@ -232,101 +146,6 @@ func cmdCreateInner(c CommandLine) error {
 	log.Infof("To see how to connect Docker to this machine, run: %s", fmt.Sprintf("%s env %s", os.Args[0], name))
 
 	return nil
-}
-
-// The following function is needed because the CLI acrobatics that we're doing
-// (with having an "outer" and "inner" function each with their own custom
-// settings and flag parsing needs) are not well supported by codegangsta/cli.
-//
-// Instead of trying to make a convoluted series of flag parsing and relying on
-// codegangsta/cli internals work well, we simply read the flags we're
-// interested in from the outer function into module-level variables, and then
-// use them from the "inner" function.
-//
-// I'm not very pleased about this, but it seems to be the only decent
-// compromise without drastically modifying codegangsta/cli internals or our
-// own CLI.
-func flagHackLookup(flagName string) string {
-	// e.g. "-d" for "--driver"
-	flagPrefix := flagName[1:3]
-
-	// TODO: Should we support -flag-name (single hyphen) syntax as well?
-	for i, arg := range os.Args {
-		if strings.Contains(arg, flagPrefix) {
-			// format '--driver foo' or '-d foo'
-			if arg == flagPrefix || arg == flagName {
-				if i+1 < len(os.Args) {
-					return os.Args[i+1]
-				}
-			}
-
-			// format '--driver=foo' or '-d=foo'
-			if strings.HasPrefix(arg, flagPrefix+"=") || strings.HasPrefix(arg, flagName+"=") {
-				return strings.Split(arg, "=")[1]
-			}
-		}
-	}
-
-	return ""
-}
-
-func cmdCreateOuter(c CommandLine) error {
-	const (
-		flagLookupMachineName = "flag-lookup"
-	)
-	driverName := flagHackLookup("--driver")
-
-	// We didn't recognize the driver name.
-	if driverName == "" {
-		c.ShowHelp()
-		return nil // ?
-	}
-
-	// TODO: Fix hacky JSON solution
-	bareDriverData, err := json.Marshal(&drivers.BaseDriver{
-		MachineName: flagLookupMachineName,
-	})
-	if err != nil {
-		return fmt.Errorf("Error attempting to marshal bare driver data: %s", err)
-	}
-
-	driver, err := newPluginDriver(driverName, bareDriverData)
-	if err != nil {
-		return fmt.Errorf("Error loading driver %q: %s", driverName, err)
-	}
-
-	if _, ok := driver.(*errdriver.Driver); ok {
-		return errdriver.ErrDriverNotLoadable{driverName}
-	}
-
-	// TODO: So much flag manipulation and voodoo here, it seems to be
-	// asking for trouble.
-	//
-	// mcnFlags is the data we get back over the wire (type mcnflag.Flag)
-	// to indicate which parameters are available.
-	mcnFlags := driver.GetCreateFlags()
-
-	// This bit will actually make "create" display the correct flags based
-	// on the requested driver.
-	cliFlags, err := convertMcnFlagsToCliFlags(mcnFlags)
-	if err != nil {
-		return fmt.Errorf("Error trying to convert provided driver flags to cli flags: %s", err)
-	}
-
-	for i := range c.Application().Commands {
-		cmd := &c.Application().Commands[i]
-		if cmd.HasName("create") {
-			cmd = addDriverFlagsToCommand(cliFlags, cmd)
-		}
-	}
-
-	if rpcd, ok := driver.(*rpcdriver.RpcClientDriver); ok {
-		if err := rpcd.Close(); err != nil {
-			return err
-		}
-	}
-
-	return c.Application().Run(os.Args)
 }
 
 func getDriverOpts(c CommandLine, mcnflags []mcnflag.Flag) drivers.DriverOptions {
@@ -351,75 +170,17 @@ func getDriverOpts(c CommandLine, mcnflags []mcnflag.Flag) drivers.DriverOptions
 
 	for _, name := range c.FlagNames() {
 		getter, ok := c.Generic(name).(flag.Getter)
-		if !ok {
+		if ok {
+			driverOpts.Values[name] = getter.Get()
+		} else {
 			// TODO: This is pretty hacky.  StringSlice is the only
 			// type so far we have to worry about which is not a
 			// Getter, though.
 			driverOpts.Values[name] = c.StringSlice(name)
-			continue
 		}
-		driverOpts.Values[name] = getter.Get()
 	}
 
 	return driverOpts
-}
-
-func convertMcnFlagsToCliFlags(mcnFlags []mcnflag.Flag) ([]cli.Flag, error) {
-	cliFlags := []cli.Flag{}
-	for _, f := range mcnFlags {
-		switch t := f.(type) {
-		// TODO: It seems pretty wrong to just default "nil" to this,
-		// but cli.BoolFlag doesn't have a "Value" field (false is
-		// always the default)
-		case *mcnflag.BoolFlag:
-			f := f.(*mcnflag.BoolFlag)
-			cliFlags = append(cliFlags, cli.BoolFlag{
-				Name:   f.Name,
-				EnvVar: f.EnvVar,
-				Usage:  f.Usage,
-			})
-		case *mcnflag.IntFlag:
-			f := f.(*mcnflag.IntFlag)
-			cliFlags = append(cliFlags, cli.IntFlag{
-				Name:   f.Name,
-				EnvVar: f.EnvVar,
-				Usage:  f.Usage,
-				Value:  f.Value,
-			})
-		case *mcnflag.StringFlag:
-			f := f.(*mcnflag.StringFlag)
-			cliFlags = append(cliFlags, cli.StringFlag{
-				Name:   f.Name,
-				EnvVar: f.EnvVar,
-				Usage:  f.Usage,
-				Value:  f.Value,
-			})
-		case *mcnflag.StringSliceFlag:
-			f := f.(*mcnflag.StringSliceFlag)
-			cliFlags = append(cliFlags, cli.StringSliceFlag{
-				Name:   f.Name,
-				EnvVar: f.EnvVar,
-				Usage:  f.Usage,
-
-				//TODO: Is this used with defaults? Can we convert the literal []string to cli.StringSlice properly?
-				Value: &cli.StringSlice{},
-			})
-		default:
-			log.Warn("Flag is ", f)
-			return nil, fmt.Errorf("Flag is unrecognized flag type: %T", t)
-		}
-	}
-
-	return cliFlags, nil
-}
-
-func addDriverFlagsToCommand(cliFlags []cli.Flag, cmd *cli.Command) *cli.Command {
-	cmd.Flags = append(sharedCreateFlags, cliFlags...)
-	cmd.SkipFlagParsing = false
-	cmd.Action = fatalOnError(cmdCreateInner)
-	sort.Sort(ByFlagName(cmd.Flags))
-
-	return cmd
 }
 
 func validateSwarmDiscovery(discovery string) error {

--- a/commands/env.go
+++ b/commands/env.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
 const (
@@ -33,7 +34,7 @@ type ShellConfig struct {
 	NoProxyValue    string
 }
 
-func cmdEnv(c CommandLine) error {
+func cmdEnv(c CommandLine, store persist.Store) error {
 	// Ensure that log messages always go to stderr when this command is
 	// being run (it is intended to be run in a subshell)
 	log.SetOutWriter(os.Stderr)
@@ -42,7 +43,7 @@ func cmdEnv(c CommandLine) error {
 		return errImproperEnvArgs
 	}
 
-	host, err := getFirstArgHost(c)
+	host, err := store.Load(c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"text/template"
+
+	"github.com/docker/machine/libmachine/persist"
 )
 
 var funcMap = template.FuncMap{
@@ -18,13 +20,13 @@ var funcMap = template.FuncMap{
 	},
 }
 
-func cmdInspect(c CommandLine) error {
+func cmdInspect(c CommandLine, store persist.Store) error {
 	if len(c.Args()) == 0 {
 		c.ShowHelp()
 		return ErrExpectedOneMachine
 	}
 
-	host, err := getFirstArgHost(c)
+	host, err := store.Load(c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/commands/ip.go
+++ b/commands/ip.go
@@ -1,5 +1,9 @@
 package commands
 
-func cmdIP(c CommandLine) error {
-	return runActionWithContext("ip", c)
+import (
+	"github.com/docker/machine/libmachine/persist"
+)
+
+func cmdIP(c CommandLine, store persist.Store) error {
+	return runActionWithContext("ip", c, store)
 }

--- a/commands/kill.go
+++ b/commands/kill.go
@@ -1,5 +1,9 @@
 package commands
 
-func cmdKill(c CommandLine) error {
-	return runActionWithContext("kill", c)
+import (
+	"github.com/docker/machine/libmachine/persist"
+)
+
+func cmdKill(c CommandLine, store persist.Store) error {
+	return runActionWithContext("kill", c, store)
 }

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/skarademir/naturalsort"
@@ -39,15 +40,14 @@ type HostListItem struct {
 	SwarmOptions *swarm.SwarmOptions
 }
 
-func cmdLs(c CommandLine) error {
+func cmdLs(c CommandLine, store persist.Store) error {
 	quiet := c.Bool("quiet")
 	filters, err := parseFilters(c.StringSlice("filter"))
 	if err != nil {
 		return err
 	}
 
-	store := getStore(c)
-	hostList, err := listHosts(store)
+	hostList, err := store.List()
 	if err != nil {
 		return err
 	}

--- a/commands/regeneratecerts.go
+++ b/commands/regeneratecerts.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdRegenerateCerts(c CommandLine) error {
+func cmdRegenerateCerts(c CommandLine, store persist.Store) error {
 	if !c.Bool("force") {
 		ok, err := confirmInput("Regenerate TLS machine certs?  Warning: this is irreversible.")
 		if err != nil {
@@ -18,5 +19,5 @@ func cmdRegenerateCerts(c CommandLine) error {
 
 	log.Infof("Regenerating TLS certificates")
 
-	return runActionWithContext("configureAuth", c)
+	return runActionWithContext("configureAuth", c, store)
 }

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -2,10 +2,11 @@ package commands
 
 import (
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdRestart(c CommandLine) error {
-	if err := runActionWithContext("restart", c); err != nil {
+func cmdRestart(c CommandLine, store persist.Store) error {
+	if err := runActionWithContext("restart", c, store); err != nil {
 		return err
 	}
 

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -5,25 +5,23 @@ import (
 	"fmt"
 
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdRm(c CommandLine) error {
+func cmdRm(c CommandLine, store persist.Store) error {
 	if len(c.Args()) == 0 {
 		c.ShowHelp()
 		return errors.New("You must specify a machine name")
 	}
 
-	force := c.Bool("force")
-	store := getStore(c)
-
 	for _, hostName := range c.Args() {
-		h, err := loadHost(store, hostName)
+		h, err := store.Load(hostName)
 		if err != nil {
 			return fmt.Errorf("Error removing host %q: %s", hostName, err)
 		}
 
 		if err := h.Driver.Remove(); err != nil {
-			if !force {
+			if !c.Bool("force") {
 				log.Errorf("Provider error removing machine %q: %s", hostName, err)
 				continue
 			}

--- a/commands/scp.go
+++ b/commands/scp.go
@@ -44,7 +44,7 @@ type storeHostInfoLoader struct {
 }
 
 func (s *storeHostInfoLoader) load(name string) (HostInfo, error) {
-	host, err := loadHost(s.store, name)
+	host, err := s.store.Load(name)
 	if err != nil {
 		return nil, fmt.Errorf("Error loading host: %s", err)
 	}
@@ -52,7 +52,7 @@ func (s *storeHostInfoLoader) load(name string) (HostInfo, error) {
 	return host.Driver, nil
 }
 
-func cmdScp(c CommandLine) error {
+func cmdScp(c CommandLine, store persist.Store) error {
 	args := c.Args()
 	if len(args) != 2 {
 		c.ShowHelp()
@@ -62,7 +62,6 @@ func cmdScp(c CommandLine) error {
 	src := args[0]
 	dest := args[1]
 
-	store := getStore(c)
 	hostInfoLoader := &storeHostInfoLoader{store}
 
 	cmd, err := getScpCmd(src, dest, c.Bool("recursive"), hostInfoLoader)

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -3,10 +3,11 @@ package commands
 import (
 	"fmt"
 
+	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/state"
 )
 
-func cmdSSH(c CommandLine) error {
+func cmdSSH(c CommandLine, store persist.Store) error {
 	// Check for help flag -- Needed due to SkipFlagParsing
 	for _, arg := range c.Args() {
 		if arg == "-help" || arg == "--help" || arg == "-h" {
@@ -20,8 +21,7 @@ func cmdSSH(c CommandLine) error {
 		return ErrExpectedOneMachine
 	}
 
-	store := getStore(c)
-	host, err := loadHost(store, name)
+	host, err := store.Load(name)
 	if err != nil {
 		return err
 	}

--- a/commands/start.go
+++ b/commands/start.go
@@ -2,10 +2,11 @@ package commands
 
 import (
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdStart(c CommandLine) error {
-	if err := runActionWithContext("start", c); err != nil {
+func cmdStart(c CommandLine, store persist.Store) error {
+	if err := runActionWithContext("start", c, store); err != nil {
 		return err
 	}
 

--- a/commands/status.go
+++ b/commands/status.go
@@ -2,14 +2,15 @@ package commands
 
 import (
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdStatus(c CommandLine) error {
+func cmdStatus(c CommandLine, store persist.Store) error {
 	if len(c.Args()) != 1 {
 		return ErrExpectedOneMachine
 	}
 
-	host, err := getFirstArgHost(c)
+	host, err := store.Load(c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -1,5 +1,9 @@
 package commands
 
-func cmdStop(c CommandLine) error {
-	return runActionWithContext("stop", c)
+import (
+	"github.com/docker/machine/libmachine/persist"
+)
+
+func cmdStop(c CommandLine, store persist.Store) error {
+	return runActionWithContext("stop", c, store)
 }

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -1,5 +1,9 @@
 package commands
 
-func cmdUpgrade(c CommandLine) error {
-	return runActionWithContext("upgrade", c)
+import (
+	"github.com/docker/machine/libmachine/persist"
+)
+
+func cmdUpgrade(c CommandLine, store persist.Store) error {
+	return runActionWithContext("upgrade", c, store)
 }

--- a/commands/url.go
+++ b/commands/url.go
@@ -2,14 +2,16 @@ package commands
 
 import (
 	"fmt"
+
+	"github.com/docker/machine/libmachine/persist"
 )
 
-func cmdURL(c CommandLine) error {
+func cmdURL(c CommandLine, store persist.Store) error {
 	if len(c.Args()) != 1 {
 		return ErrExpectedOneMachine
 	}
 
-	host, err := getFirstArgHost(c)
+	host, err := store.Load(c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/libmachine/drivers/base_test.go
+++ b/libmachine/drivers/base_test.go
@@ -3,8 +3,9 @@ package drivers
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIP(t *testing.T) {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	ErrInvalidHostname     = errors.New("Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -")
-	ErrUnknownProviderType = errors.New("Unknown hypervisor type")
+	ErrInvalidHostname = errors.New("Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -")
 )
 
 type ErrHostDoesNotExist struct {

--- a/libmachine/mcnflag/flag.go
+++ b/libmachine/mcnflag/flag.go
@@ -5,6 +5,8 @@ import "fmt"
 type Flag interface {
 	fmt.Stringer
 	Default() interface{}
+	Description() string
+	EnvVarName() string
 }
 
 type StringFlag struct {
@@ -14,13 +16,20 @@ type StringFlag struct {
 	Value  string
 }
 
-// TODO: Could this be done more succinctly using embedding?
 func (f StringFlag) String() string {
 	return f.Name
 }
 
 func (f StringFlag) Default() interface{} {
 	return f.Value
+}
+
+func (f StringFlag) Description() string {
+	return f.Usage
+}
+
+func (f StringFlag) EnvVarName() string {
+	return f.EnvVar
 }
 
 type StringSliceFlag struct {
@@ -30,13 +39,20 @@ type StringSliceFlag struct {
 	Value  []string
 }
 
-// TODO: Could this be done more succinctly using embedding?
 func (f StringSliceFlag) String() string {
 	return f.Name
 }
 
 func (f StringSliceFlag) Default() interface{} {
 	return f.Value
+}
+
+func (f StringSliceFlag) Description() string {
+	return f.Usage
+}
+
+func (f StringSliceFlag) EnvVarName() string {
+	return f.EnvVar
 }
 
 type IntFlag struct {
@@ -46,7 +62,6 @@ type IntFlag struct {
 	Value  int
 }
 
-// TODO: Could this be done more succinctly using embedding?
 func (f IntFlag) String() string {
 	return f.Name
 }
@@ -55,17 +70,32 @@ func (f IntFlag) Default() interface{} {
 	return f.Value
 }
 
+func (f IntFlag) Description() string {
+	return f.Usage
+}
+
+func (f IntFlag) EnvVarName() string {
+	return f.EnvVar
+}
+
 type BoolFlag struct {
 	Name   string
 	Usage  string
 	EnvVar string
 }
 
-// TODO: Could this be done more succinctly using embedding?
 func (f BoolFlag) String() string {
 	return f.Name
 }
 
 func (f BoolFlag) Default() interface{} {
 	return nil
+}
+
+func (f BoolFlag) Description() string {
+	return f.Usage
+}
+
+func (f BoolFlag) EnvVarName() string {
+	return f.EnvVar
 }

--- a/libmachine/mcnflag/flag_test.go
+++ b/libmachine/mcnflag/flag_test.go
@@ -1,0 +1,62 @@
+package mcnflag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringFlag(t *testing.T) {
+	var flag Flag = &StringFlag{
+		Name:   "name",
+		Usage:  "usage",
+		EnvVar: "ENV",
+		Value:  "default",
+	}
+
+	assert.Equal(t, "name", flag.String())
+	assert.Equal(t, "usage", flag.Description())
+	assert.Equal(t, "ENV", flag.EnvVarName())
+	assert.Equal(t, "default", flag.Default())
+}
+
+func TestStringSliceFlag(t *testing.T) {
+	var flag Flag = &StringSliceFlag{
+		Name:   "name",
+		Usage:  "usage",
+		EnvVar: "ENV",
+		Value:  []string{"value1", "value2"},
+	}
+
+	assert.Equal(t, "name", flag.String())
+	assert.Equal(t, "usage", flag.Description())
+	assert.Equal(t, "ENV", flag.EnvVarName())
+	assert.Equal(t, []string{"value1", "value2"}, flag.Default())
+}
+
+func TestIntFlag(t *testing.T) {
+	var flag Flag = &IntFlag{
+		Name:   "name",
+		Usage:  "usage",
+		EnvVar: "ENV",
+		Value:  42,
+	}
+
+	assert.Equal(t, "name", flag.String())
+	assert.Equal(t, "usage", flag.Description())
+	assert.Equal(t, "ENV", flag.EnvVarName())
+	assert.Equal(t, 42, flag.Default())
+}
+
+func TestBoolFlag(t *testing.T) {
+	var flag Flag = &BoolFlag{
+		Name:   "name",
+		Usage:  "usage",
+		EnvVar: "ENV",
+	}
+
+	assert.Equal(t, "name", flag.String())
+	assert.Equal(t, "usage", flag.Description())
+	assert.Equal(t, "ENV", flag.EnvVarName())
+	assert.Equal(t, nil, flag.Default())
+}

--- a/libmachine/persist/store.go
+++ b/libmachine/persist/store.go
@@ -1,7 +1,6 @@
 package persist
 
 import (
-	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/host"
 )
 
@@ -10,7 +9,7 @@ type Store interface {
 	Exists(name string) (bool, error)
 
 	// NewHost will initialize a new host machine
-	NewHost(driver drivers.Driver) (*host.Host, error)
+	NewHost(name string, driverName string) (*host.Host, error)
 
 	// List returns a list of all hosts in the store
 	List() ([]*host.Host, error)


### PR DESCRIPTION
Testing the commands is still complicated. So I carried on with refactoring the code:

+ Inject the Store into command -> easy to mock.
+ Cleanup createInner and createOuter -> it's a mess to read and test.
+ Replace most helper methods on store be calls to store directly -> Easier to mock
+ Improve error messages by removing some long error chains that say the same thing 3x

Signed-off-by: David Gageot <david@gageot.net>