### PR TITLE
Fix the local development environment instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ example of cloning and preparing the correct environment `GOPATH`:
     cd docker-machine
     export GOPATH="$PWD"
     go get github.com/docker/machine
-    cd docker-machine/src/github.com/docker/machine
+    cd src/github.com/docker/machine
 ```
 
 At this point, simply run:


### PR DESCRIPTION
Omit the docker-machine/ path prefix from the last cd command. Having followed the instructions the user should already be in the docker-machine directory.