### PR TITLE
Add a --vmwarefusion-no-share flag to disable the mounting of the /Users directory

### DIFF
--- a/docs/drivers/vm-fusion.md
+++ b/docs/drivers/vm-fusion.md
@@ -17,6 +17,7 @@ Options:
  - `--vmwarefusion-cpu-count`: Number of CPUs for the machine (-1 to use the number of CPUs available)
  - `--vmwarefusion-disk-size`: Size of disk for host VM (in MB).
  - `--vmwarefusion-memory-size`: Size of memory for host VM (in MB).
+ - `--vmwarefusion-no-share`: Disable the mount of your home directory.
 
 The VMware Fusion driver uses the latest boot2docker image.
 See [frapposelli/boot2docker](https://github.com/frapposelli/boot2docker/tree/vmware-64bit)
@@ -29,3 +30,4 @@ Environment variables and default values:
 | `--vmwarefusion-cpu-count`       | `FUSION_CPU_COUNT`       | `1`                      |
 | `--vmwarefusion-disk-size`       | `FUSION_DISK_SIZE`       | `20000`                  |
 | `--vmwarefusion-memory-size`     | `FUSION_MEMORY_SIZE`     | `1024`                   |
+| `--vmwarefusion-no-share`        | `FUSION_NO_SHARE`        | `false`                  |

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -46,6 +46,7 @@ type Driver struct {
 	SSHPassword    string
 	ConfigDriveISO string
 	ConfigDriveURL string
+	NoShare        bool
 }
 
 const (
@@ -102,6 +103,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "SSH password",
 			Value:  defaultSSHPass,
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "FUSION_NO_SHARE",
+			Name:   "vmwarefusion-no-share",
+			Usage:  "Disable the mount of your home directory",
+		},
 	}
 }
 
@@ -150,6 +156,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = flags.String("vmwarefusion-ssh-user")
 	d.SSHPassword = flags.String("vmwarefusion-ssh-password")
 	d.SSHPort = 22
+	d.NoShare = flags.Bool("vmwarefusion-no-share")
 
 	// We support a maximum of 16 cpu to be consistent with Virtual Hardware 10
 	// specs.
@@ -344,7 +351,7 @@ func (d *Driver) Create() error {
 		// TODO "linux" and "windows"
 	}
 
-	if shareDir != "" {
+	if shareDir != "" && !d.NoShare {
 		if _, err := os.Stat(shareDir); err != nil && !os.IsNotExist(err) {
 			return err
 		} else if !os.IsNotExist(err) {


### PR DESCRIPTION
Implement the functionality mentioned in issue #2196: Add a vmwarefusion driver flag to disable the mounting of the /Users directory. The code is derived from the corresponding --virtualbox-no-share implementation.

I do have a couple of lingering questions though:

 * Should the defaultNoShare constant be defined although it is not used anywhere? The virtualbox driver implementation also has such constant defined.

 * Should shared folders get enabled at all when the sharing is disabled? Currently the ```vmrun("-gu", B2DUser, "-gp", B2DPass, "enableSharedFolders", d.vmxPath())``` line gets called regardless of whether /Users mounting is enabled or disabled.