### PR TITLE
BugFix: IP in template need as per Structure

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -107,7 +107,7 @@ manage \
 {{range .Env}} -e {{.}}{{end}} \
 --name swarm-agent \
 {{.SwarmImage}} \
-join --advertise {{.Ip}}:{{.DockerPort}} {{.SwarmOptions.Discovery}}
+join --advertise {{.IP}}:{{.DockerPort}} {{.SwarmOptions.Discovery}}
 `
 
 	if swarmOptions.Master {


### PR DESCRIPTION
Lint changes in SwarmCommandOptions chnaged `Ip` to `IP`.
It required change in template code also.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>