### PR TITLE
Add a "release-candidate" flag to machine creation

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -32,6 +32,10 @@ var (
 	errNoMachineName = errors.New("Error: No machine name specified")
 )
 
+const (
+	preReleaseInstallURL = "https://test.docker.com"
+)
+
 var (
 	sharedCreateFlags = []cli.Flag{
 		cli.StringFlag{
@@ -40,6 +44,10 @@ var (
 				"Driver to create machine with.",
 			),
 			Value: "none",
+		},
+		cli.BoolFlag{
+			Name:  "release-candidate",
+			Usage: "Use the latest release candidate versions of Docker",
 		},
 		cli.StringFlag{
 			Name:   "engine-install-url",
@@ -168,6 +176,11 @@ func cmdCreateInner(c CommandLine) error {
 		return fmt.Errorf("Error getting new host: %s", err)
 	}
 
+	installURL := c.String("engine-install-url")
+	if c.Bool("release-candidate") {
+		installURL = preReleaseInstallURL
+	}
+
 	h.HostOptions = &host.Options{
 		AuthOptions: &auth.Options{
 			CertDir:          mcndirs.GetMachineCertDir(),
@@ -187,7 +200,7 @@ func cmdCreateInner(c CommandLine) error {
 			RegistryMirror:   c.StringSlice("engine-registry-mirror"),
 			StorageDriver:    c.String("engine-storage-driver"),
 			TLSVerify:        true,
-			InstallURL:       c.String("engine-install-url"),
+			InstallURL:       installURL,
 		},
 		SwarmOptions: &swarm.Options{
 			IsSwarm:        c.Bool("swarm"),

--- a/drivers/errdriver/error.go
+++ b/drivers/errdriver/error.go
@@ -74,6 +74,10 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.Error, ErrDriverNotLoadable{d.Name}
 }
 
+func (d *Driver) GetReleaseCandidate() bool {
+	return false
+}
+
 func (d *Driver) Create() error {
 	return ErrDriverNotLoadable{d.Name}
 }

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -146,7 +146,7 @@ func (d *Driver) Create() error {
 	d.setMachineNameIfNotSet()
 
 	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-	if err := b2dutils.CopyIsoToMachineDir(d.boot2DockerURL, d.MachineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir(d.boot2DockerURL, d.MachineName, d.ReleaseCandidate); err != nil {
 		return err
 	}
 

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -176,7 +176,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.HostOnlyNicType = flags.String("virtualbox-hostonly-nictype")
 	d.HostOnlyPromiscMode = flags.String("virtualbox-hostonly-nicpromisc")
 	d.NoShare = flags.Bool("virtualbox-no-share")
-
+	d.ReleaseCandidate = flags.Bool("release-candidate")
 	return nil
 }
 
@@ -228,7 +228,7 @@ func (d *Driver) IsVTXDisabledInTheVM() (bool, error) {
 
 func (d *Driver) Create() error {
 	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName, d.ReleaseCandidate); err != nil {
 		return err
 	}
 

--- a/drivers/vmwarefusion/fusion.go
+++ b/drivers/vmwarefusion/fusion.go
@@ -200,7 +200,7 @@ func (d *Driver) GetState() (state.State, error) {
 
 func (d *Driver) Create() error {
 	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName, d.ReleaseCandidate); err != nil {
 		return err
 	}
 

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -223,7 +223,7 @@ func (d *Driver) Create() error {
 	}
 
 	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
-	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, d.MachineName, d.ReleaseCandidate); err != nil {
 		return err
 	}
 

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -15,15 +15,16 @@ const (
 // BaseDriver - Embed this struct into drivers to provide the common set
 // of fields and functions.
 type BaseDriver struct {
-	IPAddress      string
-	MachineName    string
-	SSHUser        string
-	SSHPort        int
-	SSHKeyPath     string
-	StorePath      string
-	SwarmMaster    bool
-	SwarmHost      string
-	SwarmDiscovery string
+	IPAddress        string
+	MachineName      string
+	SSHUser          string
+	SSHPort          int
+	SSHKeyPath       string
+	StorePath        string
+	SwarmMaster      bool
+	SwarmHost        string
+	SwarmDiscovery   string
+	ReleaseCandidate bool
 }
 
 // DriverName returns the name of the driver
@@ -81,4 +82,9 @@ func (d *BaseDriver) PreCreateCheck() error {
 // ResolveStorePath returns the store path where the machine is
 func (d *BaseDriver) ResolveStorePath(file string) string {
 	return filepath.Join(d.StorePath, "machines", d.MachineName, file)
+}
+
+// GetPreRelease returns whether a driver should use a pre-release image or not
+func (d *BaseDriver) GetReleaseCandidate() bool {
+	return d.ReleaseCandidate
 }

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -48,6 +48,9 @@ type Driver interface {
 	// GetState returns the state that the host is in (running, stopped, etc)
 	GetState() (state.State, error)
 
+	// GetReleaseCandidate returns whether a driver should use a pre-release image
+	GetReleaseCandidate() bool
+
 	// Kill stops a host forcefully
 	Kill() error
 

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -254,6 +254,16 @@ func (c *RpcClientDriver) GetState() (state.State, error) {
 	return s, nil
 }
 
+func (c *RpcClientDriver) GetReleaseCandidate() bool {
+	var pr bool
+
+	if err := c.Client.Call("RpcServerDriver.GetReleaseCandidate", struct{}{}, &pr); err != nil {
+		log.Warnf("Error attempting to get ReleaseCandidate value: %s", err)
+		return false
+	}
+	return pr
+}
+
 func (c *RpcClientDriver) PreCreateCheck() error {
 	return c.Client.Call("RpcServerDriver.PreCreateCheck", struct{}{}, nil)
 }

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -163,6 +163,11 @@ func (r *RpcServerDriver) GetState(_ *struct{}, reply *state.State) error {
 	return err
 }
 
+func (r *RpcServerDriver) GetReleaseCandidate(_ *struct{}, reply *bool) error {
+	*reply = r.ActualDriver.GetReleaseCandidate()
+	return nil
+}
+
 func (r *RpcServerDriver) Kill(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Kill()
 }

--- a/libmachine/mcnutils/b2d_test.go
+++ b/libmachine/mcnutils/b2d_test.go
@@ -11,18 +11,37 @@ import (
 
 func TestGetLatestBoot2DockerReleaseUrl(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		respText := `[{"tag_name": "0.1"}]`
+		respText := `[{"tag_name": "0.2rc1", "prerelease":true},{"tag_name": "0.1", "prerelease":false}]`
 		w.Write([]byte(respText))
 	}))
 	defer ts.Close()
 
 	b := NewB2dUtils("/tmp/isos")
-	isoURL, err := b.GetLatestBoot2DockerReleaseURL(ts.URL + "/repos/org/repo/releases")
+	isoURL, err := b.GetLatestBoot2DockerReleaseURL(ts.URL+"/repos/org/repo/releases", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expectedURL := fmt.Sprintf("%s/org/repo/releases/download/0.1/boot2docker.iso", ts.URL)
+	if isoURL != expectedURL {
+		t.Fatalf("expected url %s; received %s", expectedURL, isoURL)
+	}
+}
+
+func TestGetLatestBoot2DockerReleaseUrlPrerelease(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respText := `[{"tag_name": "0.2rc1", "prerelease":true},{"tag_name": "0.1", "prerelease":false}]`
+		w.Write([]byte(respText))
+	}))
+	defer ts.Close()
+
+	b := NewB2dUtils("/tmp/isos")
+	isoURL, err := b.GetLatestBoot2DockerReleaseURL(ts.URL+"/repos/org/repo/releases", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedURL := fmt.Sprintf("%s/org/repo/releases/download/0.2rc1/boot2docker.iso", ts.URL)
 	if isoURL != expectedURL {
 		t.Fatalf("expected url %s; received %s", expectedURL, isoURL)
 	}

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -86,13 +86,13 @@ func (provisioner *Boot2DockerProvisioner) upgradeIso() error {
 	// Usually we call this implicitly, but call it here explicitly to get
 	// the latest default boot2docker ISO.
 	if d.Boot2DockerURL == "" {
-		if err := b2dutils.DownloadLatestBoot2Docker(d.Boot2DockerURL); err != nil {
+		if err := b2dutils.DownloadLatestBoot2Docker(d.Boot2DockerURL, provisioner.Driver.GetReleaseCandidate()); err != nil {
 			return err
 		}
 	}
 	// Either download the latest version of the b2d url that was explicitly
 	// specified when creating the VM or copy the (updated) default ISO
-	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, machineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir(d.Boot2DockerURL, machineName, provisioner.Driver.GetReleaseCandidate()); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -193,7 +193,7 @@ func (provisioner *RancherProvisioner) upgradeIso() error {
 	}
 
 	// Copy the latest version of boot2docker ISO to the machine's directory
-	if err := b2dutils.CopyIsoToMachineDir("", machineName); err != nil {
+	if err := b2dutils.CopyIsoToMachineDir("", machineName, false); err != nil {
 		return err
 	}
 

--- a/test/integration/core/rc.bats
+++ b/test/integration/core/rc.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+@test "create release-candidate machine" {
+    run machine -D create -d $DRIVER --release-candidate $NAME
+    echo ${output}
+    [ $status -eq 0 ]
+}
+
+@test "ensure ReleaseCandidate is set" {
+    prerelease=$(machine inspect $NAME --format {{.Driver.ReleaseCandidate}})
+    [ "$prerelease" = "true" ]
+}
+
+@test "ensure install url is test.docker.com" {
+    installurl=$(machine inspect $NAME --format {{.HostOptions.EngineOptions.InstallURL}})
+    [ "$installurl" = "https://test.docker.com" ]
+}


### PR DESCRIPTION
This flag will allow a machine created with this flag to be `upgrade`ed to the latest RC

- Add filtering logic to b2d check latest release
- Only use b2d RC's if `--release-candidate` is set
- Set EngineOpts.InstallURL to test.docker.com with `--release-candidate`
  - This ensures that most provisioners will work with this option too

Updates #2098 

Signed-off-by: Dave Tucker <dt@docker.com>