### PR TITLE
Use rackspace's specialized client

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -218,6 +218,10 @@ func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
 }
 
+func (d *Driver) SetClient(client Client) {
+	d.client = client
+}
+
 func (d *Driver) DriverName() string {
 	return "openstack"
 }

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -87,10 +87,14 @@ func NewDriver(machineName, storePath string) drivers.Driver {
 	}).Debug("Instantiating Rackspace driver.")
 
 	inner := openstack.NewDerivedDriver(machineName, storePath)
-
-	return &Driver{
+	driver := &Driver{
 		Driver: inner,
 	}
+	inner.SetClient(&Client{
+		driver: driver,
+	})
+
+	return driver
 }
 
 // DriverName is the user-visible name of this driver.


### PR DESCRIPTION
`openstack.NewDerivedDriver` sets client to `openstack.GenericClient`
therefore `rackspace.Client` is getting ignored.

`rackspace.Client.Authenticate` has different semantics than
`openstack.GenericClient.Authenticate`, thus almost all operations with
`rackspace` driver fail at the moment.