### PR TITLE
Fix integration tests for bash versions < 4.1

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -48,7 +48,7 @@ include mk/validate.mk
 .all_coverage: coverage-generate coverage-html coverage-send coverage-serve coverage-clean
 .all_release: release-checksum release
 .all_test: test-short test-long test-integration
-.all_validate: dco fmt vet lint
+.all_validate: dco fmt vet lint lint-tests
 
 default: build
 # Build native machine and all drivers
@@ -65,6 +65,6 @@ install:
 
 clean: coverage-clean build-clean
 test: dco fmt test-short lint vet
-validate: dco fmt vet lint test-short test-long
+validate: dco fmt vet lint lint-tests test-short test-long
 
 .PHONY: .all_build .all_coverage .all_release .all_test .all_validate test build validate clean

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -21,3 +21,7 @@ lint:
 	$(if $(GOLINT), , \
 		$(error Please install golint: go get -u github.com/golang/lint/golint))
 	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | grep -v "cli/" | grep -v "amazonec2/" |grep -v "openstack/" |grep -v "softlayer/" | grep -v "should have comment" | tee /dev/stderr)"
+
+lint-tests:
+	@test -z "$$(python ./script/validate-test 2>&1 | tee /dev/stderr)"
+

--- a/script/validate-test
+++ b/script/validate-test
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import os
+import re
+
+# Make sure we're in the repo root
+abspath = os.path.abspath(__file__)
+dname = os.path.join(os.path.dirname(abspath), "../")
+os.chdir(dname)
+
+test_files = []
+
+# 1: Don't use [[ expr ]] without || false
+bad_conditional = r'\[\[.*\]\]$'
+err_bad_conditional = "conditional '[[ expr ]]' without '|| false'"
+
+errors = 0
+
+for (root, dirs, files) in os.walk("test/integration"):
+    for f in files:
+        if f.endswith(".bats"):
+            test_files.append(os.path.join(root, f))
+
+for fname in test_files:
+    with open(fname) as f:
+        lines = f.readlines()
+    for i in range(len(lines)):
+        if re.search(bad_conditional, lines[i]):
+            print("ERROR: {} line {}: {}".format(fname, i, err_bad_conditional))
+            errors += 1
+
+if (errors > 0):
+    print("{} errors found".format(errors))
+    exit(1)
+
+exit(0)

--- a/test/integration/cli/create-rm.bats
+++ b/test/integration/cli/create-rm.bats
@@ -5,39 +5,39 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "bogus: non-existent driver fails 'machine create -d bogus bogus'" {
   run machine create -d bogus bogus
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Driver \"bogus\" not found. Do you have the plugin binary accessible in your PATH?" ]]
+  [ "${lines[0]}" == "Driver \"bogus\" not found. Do you have the plugin binary accessible in your PATH?" ]
 }
 
 @test "none: create with no name fails 'machine create -d none'" {
   run machine create -d none
   last=$((${#lines[@]} - 1))
   [ "$status" -eq 1 ]
-  [[ ${lines[$last]} == "Error: No machine name specified" ]]
+  [ "${lines[$last]}" == "Error: No machine name specified" ]
 }
 
 @test "none: create with invalid name fails 'machine create -d none --url none ∞'" {
   run machine create -d none --url none ∞
   last=$((${#lines[@]} - 1))
   [ "$status" -eq 1 ]
-  [[ ${lines[$last]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
+  [ "${lines[$last]}" == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]
 }
 
 @test "none: create with invalid name fails 'machine create -d none --url none -'" {
   run machine create -d none --url none -
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
+  [ "${lines[0]}" == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]
 }
 
 @test "none: create with invalid name fails 'machine create -d none --url none .'" {
   run machine create -d none --url none .
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
+  [ "${lines[0]}" == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]
 }
 
 @test "none: create with invalid name fails 'machine create -d none --url none ..'" {
   run machine create -d none --url none ..
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
+  [ "${lines[0]}" == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]
 }
 
 @test "none: create with weird but valid name succeeds 'machine create -d none --url none a'" {
@@ -49,13 +49,13 @@ load ${BASE_TEST_DIR}/helpers.bash
   skip
   run machine create -d none --url none A
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Error creating machine: Machine A already exists" ]]
+  [ "${lines[0]}" == "Error creating machine: Machine A already exists" ]
 }
 
 @test "none: fail with extra argument 'machine create -d none --url none a extra'" {
   run machine create -d none --url none a extra
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Invalid command line. Found extra arguments [extra]" ]]
+  [ "${lines[0]}" == "Invalid command line. Found extra arguments [extra]" ]
 }
 
 @test "none: create with weird but valid name succeeds 'machine create -d none --url none 0'" {
@@ -67,13 +67,13 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine rm
   last=$(expr ${#lines[@]} - 1)
   [ "$status" -eq 1 ]
-  [[ ${lines[$last]} == "You must specify a machine name" ]]
+  [ "${lines[$last]}" == "You must specify a machine name" ]
 }
 
 @test "none: rm non existent machine fails 'machine rm ∞'" {
   run machine rm ∞
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Error removing host \"∞\": Loading host from store failed: Host does not exist: \"∞\"" ]]
+  [ "${lines[0]}" == "Error removing host \"∞\": Loading host from store failed: Host does not exist: \"∞\"" ]
 }
 
 @test "none: rm is successful 'machine rm 0'" {

--- a/test/integration/cli/driver_help.bats
+++ b/test/integration/cli/driver_help.bats
@@ -3,13 +3,13 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 @test "no --help flag or command specified" {
-  [[ $(machine create -d ${DRIVER} 2>&1 | grep $DRIVER | wc -l) -gt 0 ]]
+  [ $(machine create -d ${DRIVER} 2>&1 | grep $DRIVER | wc -l) -gt 0 ]
 }
 
 @test "-h flag specified" {
-  [[ $(machine create -d ${DRIVER} 2>&1 -h | grep $DRIVER | wc -l) -gt 0 ]]
+  [ $(machine create -d ${DRIVER} 2>&1 -h | grep $DRIVER | wc -l) -gt 0 ]
 }
 
 @test "--help flag specified" {
-  [[ $(machine create -d ${DRIVER} --help 2>&1 | grep $DRIVER | wc -l) -gt 0 ]]
+  [ $(machine create -d ${DRIVER} --help 2>&1 | grep $DRIVER | wc -l) -gt 0 ]
 }

--- a/test/integration/cli/help.bats
+++ b/test/integration/cli/help.bats
@@ -5,126 +5,126 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "cli: show info" {
   run machine
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "Usage:"  ]]
-  [[ ${lines[1]} =~ "Create and manage machines running Docker"  ]]
+  [[ ${lines[0]} =~ "Usage:"  ]] || false
+  [[ ${lines[1]} =~ "Create and manage machines running Docker"  ]] || false
 }
 
 @test "cli: show active help" {
   run machine active -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine active"  ]]
+  [[ ${lines[0]} =~ "machine active"  ]] || false
 }
 
 @test "cli: show config help" {
   run machine config -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine config"  ]]
+  [[ ${lines[0]} =~ "machine config"  ]] || false
 }
 
 @test "cli: show create help" {
   run machine create -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine create"  ]]
+  [[ ${lines[0]} =~ "machine create"  ]] || false
 }
 
 @test "cli: show env help" {
   run machine env -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine env"  ]]
+  [[ ${lines[0]} =~ "machine env"  ]] || false
 }
 
 @test "cli: show inspect help" {
   run machine inspect -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine inspect"  ]]
+  [[ ${lines[0]} =~ "machine inspect"  ]] || false
 }
 
 @test "cli: show ip help" {
   run machine ip -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine ip"  ]]
+  [[ ${lines[0]} =~ "machine ip"  ]] || false
 }
 
 @test "cli: show kill help" {
   run machine kill -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine kill"  ]]
+  [[ ${lines[0]} =~ "machine kill"  ]] || false
 }
 
 @test "cli: show ls help" {
   run machine ls -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine ls"  ]]
+  [[ ${lines[0]} =~ "machine ls"  ]] || false
 }
 
 @test "cli: show regenerate-certs help" {
   run machine regenerate-certs -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine regenerate-certs"  ]]
+  [[ ${lines[0]} =~ "machine regenerate-certs"  ]] || false
 }
 
 @test "cli: show restart help" {
   run machine restart -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine restart"  ]]
+  [[ ${lines[0]} =~ "machine restart"  ]] || false
 }
 
 @test "cli: show rm help" {
   run machine rm -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine rm"  ]]
+  [[ ${lines[0]} =~ "machine rm"  ]] || false
 }
 
 @test "cli: show scp help" {
   run machine scp -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine scp"  ]]
+  [[ ${lines[0]} =~ "machine scp"  ]] || false
 }
 
 @test "cli: show ssh help" {
   run machine ssh -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine ssh"  ]]
+  [[ ${lines[0]} =~ "machine ssh"  ]] || false
 }
 
 @test "cli: show start help" {
   run machine start -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine start"  ]]
+  [[ ${lines[0]} =~ "machine start"  ]] || false
 }
 
 @test "cli: show status help" {
   run machine status -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine status"  ]]
+  [[ ${lines[0]} =~ "machine status"  ]] || false
 }
 
 @test "cli: show stop help" {
   run machine stop -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine stop"  ]]
+  [[ ${lines[0]} =~ "machine stop"  ]] || false
 }
 
 @test "cli: show upgrade help" {
   run machine upgrade -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine upgrade"  ]]
+  [[ ${lines[0]} =~ "machine upgrade"  ]] || false
 }
 
 @test "cli: show url help" {
   run machine url -h
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "machine url"  ]]
+  [[ ${lines[0]} =~ "machine url"  ]] || false
 }
 
 @test "flag: show version" {
   run machine -v
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "version"  ]]
+  [[ ${lines[0]} =~ "version"  ]] || false
 }
 
 @test "flag: show help" {
   run machine --help
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "Usage:"  ]]
+  [[ ${lines[0]} =~ "Usage:"  ]] || false
 }

--- a/test/integration/cli/inspect.bats
+++ b/test/integration/cli/inspect.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "inspect: show error in case of no args" {
   run machine inspect
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Expected one machine name as an argument"* ]] || false
 }

--- a/test/integration/cli/ls.bats
+++ b/test/integration/cli/ls.bats
@@ -22,121 +22,121 @@ bootstrap_swarm () {
 @test "ls: filter on driver 'machine ls --filter driver=none'" {
   run machine ls --filter driver=none
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 4 ]]
-  [[ ${lines[1]} =~ "testmachine" ]]
-  [[ ${lines[2]} =~ "testmachine2" ]]
-  [[ ${lines[3]} =~ "testmachine3" ]]
+  [ ${#lines[@]} == 4 ]
+  [[ ${lines[1]} =~ "testmachine" ]] || false
+  [[ ${lines[2]} =~ "testmachine2" ]] || false
+  [[ ${lines[3]} =~ "testmachine3" ]] || false
 }
 
 @test "ls: filter on driver 'machine ls -q --filter driver=none'" {
   run machine ls -q --filter driver=none
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
-  [[ ${lines[0]} == "testmachine" ]]
-  [[ ${lines[1]} == "testmachine2" ]]
-  [[ ${lines[2]} == "testmachine3" ]]
+  [ ${#lines[@]} == 3 ]
+  [ ${lines[0]} == "testmachine" ]
+  [ ${lines[1]} == "testmachine2" ]
+  [ ${lines[2]} == "testmachine3" ]
 }
 
 @test "ls: filter on state 'machine ls --filter state=\"Running\"'" {
   # Default state for 'none' driver is "Running"
   run machine ls --filter state="Running"
   [ "$status" -eq 0  ]
-  [[ ${#lines[@]} == 4 ]]
-  [[ ${lines[1]} =~ "testmachine" ]]
-  [[ ${lines[2]} =~ "testmachine2" ]]
-  [[ ${lines[3]} =~ "testmachine3" ]]
+  [ ${#lines[@]} == 4 ]
+  [[ ${lines[1]} =~ "testmachine" ]] || false
+  [[ ${lines[2]} =~ "testmachine2" ]] || false
+  [[ ${lines[3]} =~ "testmachine3" ]] || false
 
   # TODO: have machines in that state
   run machine ls --filter state="None"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Paused"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Saved"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Stopped"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Stopping"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Starting"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
   run machine ls --filter state="Error"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
+  [ ${#lines[@]} == 1 ]
 }
 
 @test "ls: filter on state 'machine ls -q --filter state=\"Running\"'" {
   run machine ls -q --filter state="Running"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
-  [[ ${lines[0]} == "testmachine" ]]
-  [[ ${lines[1]} == "testmachine2" ]]
-  [[ ${lines[2]} == "testmachine3" ]]
+  [ ${#lines[@]} == 3 ]
+  [ ${lines[0]} == "testmachine" ]
+  [ ${lines[1]} == "testmachine2" ]
+  [ ${lines[2]} == "testmachine3" ]
 }
 
 @test "ls: filter on name 'machine ls --filter name=\"testmachine2\"'" {
   run machine ls --filter name="testmachine2"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 2 ]]
-  [[ ${lines[1]} =~ "testmachine2" ]]
+  [ ${#lines[@]} == 2 ]
+  [[ ${lines[1]} =~ "testmachine2" ]] || false
 }
 
 @test "ls: filter on name 'machine ls -q --filter name=\"testmachine2\"'" {
   run machine ls -q --filter name="testmachine2"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 1 ]]
-  [[ ${lines[0]} == "testmachine2" ]]
+  [ ${#lines[@]} == 1 ]
+  [ ${lines[0]} == "testmachine2" ]
 }
 
 @test "ls: filter on name with regex 'machine ls --filter name=\"^t.*e\"'" {
   run machine ls --filter name="^t.*e"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 4 ]]
-  [[ ${lines[1]} =~ "testmachine" ]]
-  [[ ${lines[2]} =~ "testmachine2" ]]
-  [[ ${lines[3]} =~ "testmachine3" ]]
+  [ ${#lines[@]} == 4 ]
+  [[ ${lines[1]} =~ "testmachine" ]] || false
+  [[ ${lines[2]} =~ "testmachine2" ]] || false
+  [[ ${lines[3]} =~ "testmachine3" ]] || false
 }
 
 @test "ls: filter on name with regex 'machine ls -q --filter name=\"^t.*e\"'" {
   run machine ls -q --filter name="^t.*e"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
-  [[ ${lines[0]} == "testmachine" ]]
-  [[ ${lines[1]} == "testmachine2" ]]
-  [[ ${lines[2]} == "testmachine3" ]]
+  [ ${#lines[@]} == 3 ]
+  [ ${lines[0]} == "testmachine" ]
+  [ ${lines[1]} == "testmachine2" ]
+  [ ${lines[2]} == "testmachine3" ]
 }
 
 @test "ls: filter on swarm 'machine ls --filter swarm=testswarm" {
   bootstrap_swarm
   run machine ls --filter swarm=testswarm
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 4 ]]
-  [[ ${lines[1]} =~ "testswarm" ]]
-  [[ ${lines[2]} =~ "testswarm2" ]]
-  [[ ${lines[3]} =~ "testswarm3" ]]
+  [ ${#lines[@]} == 4 ]
+  [[ ${lines[1]} =~ "testswarm" ]] || false
+  [[ ${lines[2]} =~ "testswarm2" ]] || false
+  [[ ${lines[3]} =~ "testswarm3" ]] || false
 }
 
 @test "ls: filter on swarm 'machine ls -q --filter swarm=testswarm" {
   bootstrap_swarm
   run machine ls -q --filter swarm=testswarm
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
-  [[ ${lines[0]} == "testswarm" ]]
-  [[ ${lines[1]} == "testswarm2" ]]
-  [[ ${lines[2]} == "testswarm3" ]]
+  [ ${#lines[@]} == 3 ]
+  [ ${lines[0]} == "testswarm" ]
+  [ ${lines[1]} == "testswarm2" ]
+  [ ${lines[2]} == "testswarm3" ]
 }
 
 @test "ls: multi filter 'machine ls -q --filter swarm=testswarm --filter name=\"^t.*e\" --filter driver=none --filter state=\"Running\"'" {
   bootstrap_swarm
   run machine ls -q --filter swarm=testswarm --filter name="^t.*e" --filter driver=none --filter state="Running"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
-  [[ ${lines[0]} == "testswarm" ]]
-  [[ ${lines[1]} == "testswarm2" ]]
-  [[ ${lines[2]} == "testswarm3" ]]
+  [ ${#lines[@]} == 3 ]
+  [ ${lines[0]} == "testswarm" ]
+  [ ${lines[1]} == "testswarm2" ]
+  [ ${lines[2]} == "testswarm3" ]
 }

--- a/test/integration/cli/status.bats
+++ b/test/integration/cli/status.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "status: show error in case of no args" {
   run machine status
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Expected one machine name as an argument"* ]] || false
 }

--- a/test/integration/cli/url.bats
+++ b/test/integration/cli/url.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "url: show error in case of no args" {
   run machine url
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Expected one machine name as an argument"* ]] || false
 }

--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -6,7 +6,7 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine inspect $NAME
   echo ${output}
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Host \"$NAME\" does not exist" ]]
+  [ ${lines[0]} == "Host \"$NAME\" does not exist" ]
 }
 
 @test "$DRIVER: create" {
@@ -19,21 +19,21 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ls -q
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} == "$NAME" ]]
+  [ ${lines[0]} == "$NAME" ]
 }
 
 @test "$DRIVER: has status 'started' appearing in ls" {
   run machine ls -q --filter state=Running
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} == "$NAME" ]]
+  [ ${lines[0]} == "$NAME" ]
 }
 
 @test "$DRIVER: create with same name again fails" {
   run machine create -d $DRIVER $NAME
   echo ${output}
   [ "$status" -eq 1  ]
-  [[ ${lines[0]} == "Host already exists: \"$NAME\"" ]]
+  [ ${lines[0]} == "Host already exists: \"$NAME\"" ]
 }
 
 @test "$DRIVER: run busybox container" {
@@ -58,7 +58,7 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ssh $NAME -- ls -lah /
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[0]} =~ "total"  ]]
+  [[ ${lines[0]} =~ "total"  ]] || false
 }
 
 @test "$DRIVER: docker commands with the socket should work" {
@@ -76,27 +76,27 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ls
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Stopped"*  ]]
+  [[ ${lines[1]} == *"Stopped"*  ]] || false
 }
 
 @test "$DRIVER: url should show an error when machine is stopped" {
   run machine url $NAME
   echo ${output}
   [ "$status" -eq 1 ]
-  [[ ${output} == *"not running"* ]]
+  [[ ${output} == *"not running"* ]] || false
 }
 
 @test "$DRIVER: env should show an error when machine is stopped" {
   run machine env $NAME
   echo ${output}
   [ "$status" -eq 1 ]
-  [[ ${output} == *"not running. Please start"* ]]
+  [[ ${output} == *"not running. Please start"* ]] || false
 }
 
 @test "$DRIVER: machine should not allow upgrade when stopped" {
   run machine upgrade $NAME
   echo ${output}
-  [[ "$status" -eq 1 ]]
+  [ "$status" -eq 1 ]
 }
 
 @test "$DRIVER: start" {
@@ -109,7 +109,7 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ls
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Running"*  ]]
+  [[ ${lines[1]} == *"Running"*  ]] || false
 }
 
 @test "$DRIVER: kill" {
@@ -122,7 +122,7 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ls
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Stopped"*  ]]
+  [[ ${lines[1]} == *"Stopped"*  ]] || false
 }
 
 @test "$DRIVER: restart" {
@@ -135,12 +135,12 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine ls
   echo ${output}
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Running"*  ]]
+  [[ ${lines[1]} == *"Running"* ]] || false
 }
 
 @test "$DRIVER: status" {
   run machine status $NAME
   echo ${output}
   [ "$status" -eq 0 ]
-  [[ ${output} == *"Running"* ]]
+  [[ ${output} == *"Running"* ]] || false
 }

--- a/test/integration/core/env_shell.bats
+++ b/test/integration/core/env_shell.bats
@@ -17,44 +17,44 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: test powershell notation" {
   run machine env --shell powershell --no-proxy $NAME
-  [[ ${lines[0]} == "\$Env:DOCKER_TLS_VERIFY = \"1\"" ]]
-  [[ ${lines[1]} == "\$Env:DOCKER_HOST = \"$(machine url $NAME)\"" ]]
-  [[ ${lines[2]} == "\$Env:DOCKER_CERT_PATH = \"$MACHINE_STORAGE_PATH/machines/$NAME\"" ]]
-  [[ ${lines[3]} == "\$Env:DOCKER_MACHINE_NAME = \"$NAME\"" ]]
-  [[ ${lines[4]} == "\$Env:NO_PROXY = \"$(machine ip $NAME)\"" ]]
+  [ ${lines[0]} == "\$Env:DOCKER_TLS_VERIFY = \"1\"" ]
+  [ ${lines[1]} == "\$Env:DOCKER_HOST = \"$(machine url $NAME)\"" ]
+  [ ${lines[2]} == "\$Env:DOCKER_CERT_PATH = \"$MACHINE_STORAGE_PATH/machines/$NAME\"" ]
+  [ ${lines[3]} == "\$Env:DOCKER_MACHINE_NAME = \"$NAME\"" ]
+  [ ${lines[4]} == "\$Env:NO_PROXY = \"$(machine ip $NAME)\"" ]
 }
 
 @test "$DRIVER: test bash / zsh notation with no-proxy" {
   run machine env --no-proxy $NAME
-  [[ ${lines[0]} == "export DOCKER_TLS_VERIFY=\"1\"" ]]
-  [[ ${lines[1]} == "export DOCKER_HOST=\"$(machine url $NAME)\"" ]]
-  [[ ${lines[2]} == "export DOCKER_CERT_PATH=\"$MACHINE_STORAGE_PATH/machines/$NAME\"" ]]
-  [[ ${lines[3]} == "export DOCKER_MACHINE_NAME=\"$NAME\"" ]]
-  [[ ${lines[4]} == "export NO_PROXY=\"$(machine ip $NAME)\"" ]]
+  [ ${lines[0]} == "export DOCKER_TLS_VERIFY=\"1\"" ]
+  [ ${lines[1]} == "export DOCKER_HOST=\"$(machine url $NAME)\"" ]
+  [ ${lines[2]} == "export DOCKER_CERT_PATH=\"$MACHINE_STORAGE_PATH/machines/$NAME\"" ]
+  [ ${lines[3]} == "export DOCKER_MACHINE_NAME=\"$NAME\"" ]
+  [ ${lines[4]} == "export NO_PROXY=\"$(machine ip $NAME)\"" ]
 }
 
 @test "$DRIVER: test cmd.exe notation" {
   run machine env --shell cmd --no-proxy $NAME
-  [[ ${lines[0]} == "SET DOCKER_TLS_VERIFY=1" ]]
-  [[ ${lines[1]} == "SET DOCKER_HOST=$(machine url $NAME)" ]]
-  [[ ${lines[2]} == "SET DOCKER_CERT_PATH=$MACHINE_STORAGE_PATH/machines/$NAME" ]]
-  [[ ${lines[3]} == "SET DOCKER_MACHINE_NAME=$NAME" ]]
-  [[ ${lines[4]} == "SET NO_PROXY=$(machine ip $NAME)" ]]
+  [ ${lines[0]} == "SET DOCKER_TLS_VERIFY=1" ]
+  [ ${lines[1]} == "SET DOCKER_HOST=$(machine url $NAME)" ]
+  [ ${lines[2]} == "SET DOCKER_CERT_PATH=$MACHINE_STORAGE_PATH/machines/$NAME" ]
+  [ ${lines[3]} == "SET DOCKER_MACHINE_NAME=$NAME" ]
+  [ ${lines[4]} == "SET NO_PROXY=$(machine ip $NAME)" ]
 }
 
 @test "$DRIVER: test fish notation" {
   run machine env --shell fish --no-proxy $NAME
-  [[ ${lines[0]} == "set -x DOCKER_TLS_VERIFY \"1\";" ]]
-  [[ ${lines[1]} == "set -x DOCKER_HOST \"$(machine url $NAME)\";" ]]
-  [[ ${lines[2]} == "set -x DOCKER_CERT_PATH \"$MACHINE_STORAGE_PATH/machines/$NAME\";" ]]
-  [[ ${lines[3]} == "set -x DOCKER_MACHINE_NAME \"$NAME\";" ]]
-  [[ ${lines[4]} == "set -x NO_PROXY \"$(machine ip $NAME)\";" ]]
+  [ ${lines[0]} == "set -x DOCKER_TLS_VERIFY \"1\";" ]
+  [ ${lines[1]} == "set -x DOCKER_HOST \"$(machine url $NAME)\";" ]
+  [ ${lines[2]} == "set -x DOCKER_CERT_PATH \"$MACHINE_STORAGE_PATH/machines/$NAME\";" ]
+  [ ${lines[3]} == "set -x DOCKER_MACHINE_NAME \"$NAME\";" ]
+  [ ${lines[4]} == "set -x NO_PROXY \"$(machine ip $NAME)\";" ]
 }
 
 @test "$DRIVER: test no proxy with NO_PROXY already set" {
   export NO_PROXY=localhost
   run machine env --no-proxy $NAME
-  [[ ${lines[4]} == "export NO_PROXY=\"localhost,$(machine ip $NAME)\"" ]]
+  [ ${lines[4]} == "export NO_PROXY=\"localhost,$(machine ip $NAME)\"" ]
 }
 
 @test "$DRIVER: test unset with an args should fail" {

--- a/test/integration/core/inspect_format.bats
+++ b/test/integration/core/inspect_format.bats
@@ -9,15 +9,15 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: inspect format template" {
   run machine inspect -f '{{.DriverName}}' $NAME
-  [[ "$output" == "$DRIVER" ]]
+  [ "$output" == "$DRIVER" ]
 }
 
 @test "$DRIVER: inspect format template json directive" {
   run machine inspect -f '{{json .DriverName}}' $NAME
-  [[ "$output" == "\"$DRIVER\"" ]]
+  [ "$output" == "\"$DRIVER\"" ]
 }
 
 @test "$DRIVER: inspect format template pretty json directive" {
   linecount=$(machine inspect -f '{{prettyjson .Driver}}' $NAME | wc -l)
-  [[ "$linecount" -gt 1 ]]
+  [ "$linecount" -gt 1 ]
 }

--- a/test/integration/core/regenerate-certs.bats
+++ b/test/integration/core/regenerate-certs.bats
@@ -8,10 +8,10 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: regenerate the certs" {
   run machine regenerate-certs -f $NAME
-  [[ ${status} -eq 0 ]]
+  [ ${status} -eq 0 ]
 }
 
 @test "$DRIVER: make sure docker still works" {
   run docker $(machine config $NAME) version
-  [[ ${status} -eq 0 ]]
+  [ ${status} -eq 0 ]
 }

--- a/test/integration/core/scp.bats
+++ b/test/integration/core/scp.bats
@@ -6,13 +6,14 @@ export SECOND_MACHINE="$NAME-2"
 
 @test "$DRIVER: create" {
   run machine create -d $DRIVER $NAME
-  [[ ${status} -eq 0 ]]
+  [ ${status} -eq 0 ]
 }
 
 @test "$DRIVER: test machine scp command from remote to host" {
   machine ssh $NAME 'echo A file created remotely! >/tmp/foo.txt'
   machine scp $NAME:/tmp/foo.txt .
-  [[ $(cat foo.txt) == "A file created remotely!" ]]
+  [ -f foo.txt ]
+  [ "$(cat foo.txt)" == "A file created remotely!" ]
 }
 
 @test "$DRIVER: test machine scp command from host to remote" {
@@ -21,16 +22,16 @@ export SECOND_MACHINE="$NAME-2"
   }
   echo A file created locally! >foo.txt
   machine scp foo.txt $NAME:/tmp/foo.txt
-  [[ $(machine ssh $NAME cat /tmp/foo.txt) == "A file created locally!" ]]
+  [ "$(machine ssh $NAME cat /tmp/foo.txt)" == "A file created locally!" ]
 }
 
 @test "$DRIVER: create machine to test transferring files from machine to machine" {
   run machine create -d $DRIVER $SECOND_MACHINE
-  [[ ${status} -eq 0 ]]
+  [ ${status} -eq 0 ]
 }
 
 @test "$DRIVER: scp from one machine to another" {
-  run machine ssh $NAME 'echo A file hopping around! >/tmp/foo.txt'
+  run machine ssh $NAME 'echo A file hopping around >/tmp/foo.txt'
   run machine scp $NAME:/tmp/foo.txt $SECOND_MACHINE:/tmp/foo.txt
-  [[ $(machine ssh ${SECOND_MACHINE} cat /tmp/foo.txt) == "A file hopping around!" ]]
+  [ "$(machine ssh ${SECOND_MACHINE} cat /tmp/foo.txt)" == "A file hopping around" ]
 }

--- a/test/integration/core/ssh-backends.bats
+++ b/test/integration/core/ssh-backends.bats
@@ -6,27 +6,27 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create SSH test box" {
   run machine create -d $DRIVER $NAME
-  [[ "$status" -eq 0  ]]
+  [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: test external ssh backend" {
   run machine ssh $NAME df -h
-  [[ "$status" -eq 0 ]]
+  [ "$status" -eq 0 ]
 }
 
 @test "$DRIVER: test command did what it purported to -- external ssh" {
   run machine ssh $NAME echo foo
-  [[ "$output" == "foo"  ]]
+  [ "$output" == "foo"  ]
 }
 
 @test "$DRIVER: test native ssh backend" {
   run machine --native-ssh ssh $NAME df -h
-  [[ "$status" -eq 0  ]]
+  [ "$status" -eq 0  ]
 }
 
 @test "$DRIVER: test command did what it purported to -- native ssh" {
   run machine --native-ssh ssh $NAME echo foo
-  [[ "$output" =~ "foo"  ]]
+  [[ "$output" =~ "foo"  ]] || false
 }
 
 @test "$DRIVER: ensure that ssh extra arguments work" {
@@ -40,6 +40,6 @@ load ${BASE_TEST_DIR}/helpers.bash
   # like intended
   run machine ssh $NAME -C echo foo
 
-  [[ "$status" -eq 0 ]]
-  [[ "$output" == "foo" ]]
+  [ "$status" -eq 0 ]
+  [ "$output" == "foo" ]
 }

--- a/test/integration/core/supported-engine-options.bats
+++ b/test/integration/core/supported-engine-options.bats
@@ -14,10 +14,10 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: check for engine label" {
   spamlabel=$(docker $(machine config $NAME) info | grep spam)
-  [[ $spamlabel =~ "spam=eggs" ]]
+  [[ $spamlabel =~ "spam=eggs" ]] || false
 }
 
 @test "$DRIVER: check for engine storage driver" {
   storage_driver_info=$(docker $(machine config $NAME) info | grep "Storage Driver")
-  [[ $storage_driver_info =~ "overlay" ]]
+  [[ $storage_driver_info =~ "overlay" ]] || false
 }

--- a/test/integration/core/swarm-options.bats
+++ b/test/integration/core/swarm-options.bats
@@ -6,22 +6,22 @@ export TOKEN=$(curl -sS -X POST "https://discovery-stage.hub.docker.com/v1/clust
 @test "create swarm master" {
     run machine create -d $DRIVER --swarm --swarm-master --swarm-discovery "token://$TOKEN" --swarm-strategy binpack --swarm-opt heartbeat=5s queenbee
     echo ${output}
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "create swarm node" {
     run machine create -d $DRIVER --swarm --swarm-discovery "token://$TOKEN" workerbee
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "ensure strategy is correct" {
     strategy=$(docker $(machine config --swarm queenbee) info | grep "Strategy:" | awk '{ print $2 }')
     echo ${strategy}
-    [[ "$strategy" == "binpack" ]]
+    [ "$strategy" == "binpack" ]
 }
 
 @test "ensure heartbeat" {
     heartbeat_arg=$(docker $(machine config queenbee) inspect -f '{{index .Args 9}}' swarm-agent-master)
     echo ${heartbeat_arg}
-    [[ "$heartbeat_arg" == "--heartbeat=5s" ]]
+    [ "$heartbeat_arg" == "--heartbeat=5s" ]
 }

--- a/test/integration/drivers/virtualbox/bad-create-iso.bats
+++ b/test/integration/drivers/virtualbox/bad-create-iso.bats
@@ -8,5 +8,5 @@ export BAD_URL="http://dev.null:9111/bad.iso"
 
 @test "$DRIVER: Should not allow machine creation with bad ISO" {
   run machine create -d virtualbox --virtualbox-boot2docker-url $BAD_URL $NAME
-  [[ ${status} -eq 1 ]]
+  [ ${status} -eq 1 ]
 }

--- a/test/integration/drivers/virtualbox/certs-checksum.bats
+++ b/test/integration/drivers/virtualbox/certs-checksum.bats
@@ -22,5 +22,5 @@ force_env DRIVER virtualbox
   LOCAL_CHECKSUM=$(openssl dgst -sha256 $MACHINE_STORAGE_PATH/certs/ca.pem | awk '{ print $2 }')
   echo ${SERVER_CHECKSUM}
   echo ${LOCAL_CHECKSUM}
-  [[ ${SERVER_CHECKSUM} == ${LOCAL_CHECKSUM} ]]
+  [ ${SERVER_CHECKSUM} == ${LOCAL_CHECKSUM} ]
 }

--- a/test/integration/drivers/virtualbox/custom-mem-disk.bats
+++ b/test/integration/drivers/virtualbox/custom-mem-disk.bats
@@ -36,21 +36,21 @@ function findCPUCount() {
 
 @test "$DRIVER: check custom machine memory size" {
   findMemorySize
-  [[ ${output} == "$CUSTOM_MEMSIZE"  ]]
+  [ ${output} == "$CUSTOM_MEMSIZE"  ]
 }
 
 @test "$DRIVER: check custom machine disksize" {
   findDiskSize
-  [[ ${output} == *"$CUSTOM_DISKSIZE"* ]]
+  [[ ${output} == *"$CUSTOM_DISKSIZE"* ]] || false
 }
 
 @test "$DRIVER: check custom machine cpucount" {
   findCPUCount
-  [[ ${output} == "$CUSTOM_CPUCOUNT" ]]
+  [ ${output} == "$CUSTOM_CPUCOUNT" ]
 }
 
 @test "$DRIVER: machine should show running after create" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Running"*  ]]
+  [[ ${lines[1]} == *"Running"*  ]] || false
 }

--- a/test/integration/drivers/virtualbox/pause-save-start.bats
+++ b/test/integration/drivers/virtualbox/pause-save-start.bats
@@ -17,7 +17,7 @@ force_env DRIVER virtualbox
 @test "$DRIVER: machine should show paused after VBoxManage pause" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Paused"*  ]]
+  [[ ${lines[1]} == *"Paused"*  ]] || false
 }
 
 @test "$DRIVER: start after paused" {
@@ -28,7 +28,7 @@ force_env DRIVER virtualbox
 @test "$DRIVER: machine should show running after start" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Running"*  ]]
+  [[ ${lines[1]} == *"Running"*  ]] || false
 }
 
 @test "$DRIVER: VBoxManage savestate" {
@@ -39,8 +39,8 @@ force_env DRIVER virtualbox
 @test "$DRIVER: machine should show saved after VBoxManage savestate" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"$NAME"*  ]]
-  [[ ${lines[1]} == *"Saved"*  ]]
+  [[ ${lines[1]} == *"$NAME"*  ]] || false
+  [[ ${lines[1]} == *"Saved"*  ]] || false
 }
 
 @test "$DRIVER: start after saved" {
@@ -51,5 +51,5 @@ force_env DRIVER virtualbox
 @test "$DRIVER: machine should show running after start" {
   run machine ls
   [ "$status" -eq 0  ]
-  [[ ${lines[1]} == *"Running"*  ]]
+  [[ ${lines[1]} == *"Running"*  ]] || false
 }

--- a/test/integration/drivers/virtualbox/upgrade.bats
+++ b/test/integration/drivers/virtualbox/upgrade.bats
@@ -4,7 +4,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 force_env DRIVER virtualbox
 
-export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.4.1/boot2docker.iso"
+export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.8.3/boot2docker.iso"
 
 @test "$DRIVER: create for upgrade" {
   run machine create -d virtualbox --virtualbox-boot2docker-url $OLD_ISO_URL $NAME
@@ -12,8 +12,8 @@ export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download
 
 @test "$DRIVER: verify that docker version is old" {
   # Have to run this over SSH due to client/server mismatch restriction
-  SERVER_VERSION=$(machine ssh $NAME docker version | grep 'Server version' | awk '{ print $3; }')
-  [[ "$SERVER_VERSION" == "1.4.1" ]]
+  SERVER_VERSION=$(machine ssh $NAME docker version --format {{.Server.Version}})
+  [ "$SERVER_VERSION" == "1.8.3" ]
 }
 
 @test "$DRIVER: upgrade" {
@@ -23,6 +23,6 @@ export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download
 }
 
 @test "$DRIVER: upgrade is correct version" {
-  SERVER_VERSION=$(docker $(machine config $NAME) version | grep 'Server version' | awk '{ print $3; }')
-  [[ "$SERVER_VERSION" != "1.4.1" ]]
+  NEW_SERVER_VERSION=$(machine ssh $NAME docker version --format {{.Server.Version}})
+  [ "$NEW_SERVER_VERSION" != "1.8.3" ]
 }


### PR DESCRIPTION
Fixes #2200

Note:

- "virtualbox: check created engine option (log driver)" fails due to
  docker/docker#17761
- "virtualbox: upgrade is correct version" fails per #2195

Signed-off-by: Dave Tucker <dt@docker.com>