### PR TITLE
Delete bridge after powering daemon down

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -112,6 +112,10 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
+	if _, err := p.SSHCommand("sudo ip link delete docker0"); err != nil {
+		return err
+	}
+
 	// upload certs and configure TLS auth
 	caCert, err := ioutil.ReadFile(authOptions.CaCertPath)
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/docker/machine/issues/1455

cc @docker/machine-maintainers 

@dave-tucker @mavenugo @mrjana Can you please take a look at this and tell me if you think it seems safe / sane?  I've tested on boot2docker and it works swimmingly, but not on other distros.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>