### PR TITLE
Faster CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: required
 dist: trusty
 language: bash
 services: docker
-script: USE_CONTAINER=true make dco fmt lint vet test-short test-long coverage-send
+script: USE_CONTAINER=true make dco fmt lint vet test-long coverage-send

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# # Plain make targets if not requested inside a container
+# Plain make targets if not requested inside a container
 ifneq (,$(findstring test-integration,$(MAKECMDGOALS)))
 	include Makefile.inc
 	include mk/main.mk
@@ -7,34 +7,12 @@ else ifeq ($(USE_CONTAINER),)
 	include mk/main.mk
 else
 # Otherwise, with docker, swallow all targets and forward into a container
-DOCKER_IMAGE_NAME := "docker-machine-build"
-DOCKER_CONTAINER_NAME := "docker-machine-build-container"
+DOCKER_BUILD_DONE := ""
 
-.ignore:
-	@
+test: .DEFAULT
 
-test: .ignore
-%:
-		docker build -t $(DOCKER_IMAGE_NAME) .
-
-		test -z '$(shell docker ps -a | grep $(DOCKER_CONTAINER_NAME))' || docker rm -f $(DOCKER_CONTAINER_NAME)
-
-		docker run --name $(DOCKER_CONTAINER_NAME) \
-				-e DEBUG \
-				-e STATIC \
-				-e VERBOSE \
-				-e BUILDTAGS \
-				-e PARALLEL \
-				-e COVERAGE_DIR \
-				-e TARGET_OS \
-				-e TARGET_ARCH \
-				-e PREFIX \
-				-e TRAVIS_JOB_ID \
-				-e TRAVIS_PULL_REQUEST \
-				$(DOCKER_IMAGE_NAME) \
-				make $@
-
-		test ! -d bin || rm -Rf bin
-		test -z "$(findstring build,$(patsubst cross,build,$@))" || docker cp $(DOCKER_CONTAINER_NAME):/go/src/github.com/docker/machine/bin bin
+.DEFAULT:
+	@test ! -z "$(DOCKER_BUILD_DONE)" || ./script/build_in_container.sh $(MAKECMDGOALS)
+	$(eval DOCKER_BUILD_DONE := "done")
 
 endif

--- a/script/build_in_container.sh
+++ b/script/build_in_container.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_IMAGE_NAME="docker-machine-build"
+DOCKER_CONTAINER_NAME="docker-machine-build-container"
+
+if [[ $(docker ps -a | grep $DOCKER_CONTAINER_NAME) != "" ]]; then
+  docker rm -f $DOCKER_CONTAINER_NAME 2>/dev/null
+fi
+
+docker build -t $DOCKER_IMAGE_NAME .
+
+docker run --name $DOCKER_CONTAINER_NAME \
+  -e DEBUG \
+  -e STATIC \
+  -e VERBOSE \
+  -e BUILDTAGS \
+  -e PARALLEL \
+  -e COVERAGE_DIR \
+  -e TARGET_OS \
+  -e TARGET_ARCH \
+  -e PREFIX \
+  -e TRAVIS_JOB_ID \
+  -e TRAVIS_PULL_REQUEST \
+  $DOCKER_IMAGE_NAME \
+  make "$@"
+
+if [[ -d bin ]]; then
+  rm -Rf bin
+fi
+
+if [[ "$@" == *"build"* ]]; then
+  docker cp $DOCKER_CONTAINER_NAME:/go/src/github.com/docker/machine/bin bin
+fi


### PR DESCRIPTION
+ In-container build should start the docker container only once
+ No need to run short tests since test-long runs all tests