### PR TITLE
Speed up Integration Tests

### DIFF
--- a/test/integration/core/env_shell.bats
+++ b/test/integration/core/env_shell.bats
@@ -3,8 +3,10 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: create" {
-  run machine create -d $DRIVER $NAME
-  [ "$status" -eq 0  ]
+  if [[ -z "$RECYCLE_MACHINE" ]]; then
+    run machine create -d $DRIVER $NAME
+    [ "$status" -eq 0  ]
+  fi
 }
 
 @test "$DRIVER: test basic bash / zsh notation" {

--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -4,6 +4,9 @@ set -e
 
 # Wrapper script to run bats tests for various drivers.
 # Usage: DRIVER=[driver] ./run-bats.sh [subtest]
+# or
+# If you just want to quickly run the test on an existing container
+# Usage: RECYCLE_MACHINE=[container name] ./run-bats.sh [subtest]
 
 function quiet_run () {
     if [[ "$VERBOSE" == "1" ]]; then
@@ -14,8 +17,12 @@ function quiet_run () {
 }
 
 function cleanup_machines() {
-    if [[ $(machine ls -q | wc -l) -ne 0 ]]; then
-        quiet_run machine rm -f $(machine ls -q)
+    if [[ -z "$RECYCLE_MACHINE" ]]; then
+        if [[ $(machine ls -q | wc -l) -ne 0 ]]; then
+            quiet_run machine rm -f $(machine ls -q)
+        fi
+    else
+        echo "Explicity using Container ${RECYCLE_MACHINE}, so not killing it, on your request..."
     fi
 }
 
@@ -44,7 +51,7 @@ function run_bats() {
 EXIT_STATUS=0
 export BATS_FILE="$1"
 
-if [[ -z "$DRIVER" ]]; then
+if [[ -z "$RECYCLE_MACHINE" ]] && [[ -z "$DRIVER" ]]; then
     echo "You must specify the DRIVER environment variable."
     exit 1
 fi
@@ -62,10 +69,18 @@ fi
 # TODO: Should the script bail out if these are set already?
 export BASE_TEST_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export MACHINE_ROOT="$BASE_TEST_DIR/../.."
-export NAME="bats-$DRIVER-test"
-export MACHINE_STORAGE_PATH="/tmp/machine-bats-test-$DRIVER"
+
+if [[ -z "$RECYCLE_MACHINE" ]]; then
+    export MACHINE_STORAGE_PATH="/tmp/machine-bats-test-$DRIVER"
+    export NAME="bats-$DRIVER-test"
+else
+    export DRIVER=$(docker-machine inspect "$RECYCLE_MACHINE" | grep DriverName | cut -d\" -f 4)
+    export NAME=$RECYCLE_MACHINE
+fi
+
 export MACHINE_BIN_NAME=docker-machine
 export BATS_LOG="$MACHINE_ROOT/bats.log"
+B2D_LOCATION=~/.docker/machine/cache/boot2docker.iso
 
 # This function gets used in the integration tests, so export it.
 export -f machine
@@ -73,10 +88,26 @@ export -f machine
 touch "$BATS_LOG"
 rm "$BATS_LOG"
 
+if [[ -z "$RECYCLE_MACHINE" ]]; then
+
+    if [[ -d "$MACHINE_STORAGE_PATH" ]]; then
+        rm -r "$MACHINE_STORAGE_PATH"
+    fi
+
+    if [[ "$b2dcache" == "1" ]] && [[ -f $B2D_LOCATION ]]; then
+        mkdir -p "${MACHINE_STORAGE_PATH}/cache"
+        cp $B2D_LOCATION "${MACHINE_STORAGE_PATH}/cache/boot2docker.iso"
+    fi
+
+fi
+
 run_bats "$BATS_FILE"
 
-if [[ -d "$MACHINE_STORAGE_PATH" ]]; then
-    rm -r "$MACHINE_STORAGE_PATH"
+if [[ -z "$RECYCLE_MACHINE" ]]; then
+
+    if [[ -d "$MACHINE_STORAGE_PATH" ]]; then
+        rm -r "$MACHINE_STORAGE_PATH"
+    fi
 fi
 
 set +e


### PR DESCRIPTION
This speedup integration tests in a number of ways :
* Copy boot2docker locally rather than download it each time for test using it.
* Allow to use an already running docker machine rather than create a new each time by specifying a `USECONTAINER=myowntestcontainer` instead of `DRIVER`
* cleanup properly the cache folder in case a test went :boom: kaboom :boom: before

Signed-off-by: Jean-Laurent de Morlhon <jeanlaurent@morlhon.net>