### PR TITLE
Change godep command call to use the GODEP variable

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -1,9 +1,9 @@
 dep-save:
 	$(if $(GODEP), , \
 		$(error Please install godep: go get github.com/tools/godep))
-	godep save $(shell go list ./... | grep -v vendor/)
+	$(GODEP) save $(shell go list ./... | grep -v vendor/)
 
 dep-restore:
 	$(if $(GODEP), , \
 		$(error Please install godep: go get github.com/tools/godep))
-	godep restore -v
+	$(GODEP) restore -v


### PR DESCRIPTION
If not exists godep in $PATH , following error occurs.
```bash
make: godep: No such file or directory
```
Because it is calling directly godep command without a GODEP variable.
This PR fix it.

Signed-off-by: Kazumichi Yamamoto <yamamoto.febc@gmail.com>