### PR TITLE
Upgrade the boot2docker.iso cache if possible when creating a VirtualBox machine

### DIFF
--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -66,16 +66,6 @@ func (provisioner *Boot2DockerProvisioner) upgradeIso() error {
 	}
 	json.Unmarshal(jsonDriver, &d)
 
-	log.Info("Downloading latest boot2docker iso...")
-
-	// Usually we call this implicitly, but call it here explicitly to get
-	// the latest default boot2docker ISO.
-	if d.Boot2DockerURL == "" {
-		if err := b2dutils.DownloadLatestBoot2Docker(d.Boot2DockerURL); err != nil {
-			return err
-		}
-	}
-
 	log.Info("Stopping machine to do the upgrade...")
 
 	if err := provisioner.Driver.Stop(); err != nil {

--- a/test/integration/virtualbox/create-with-upgrading.bats
+++ b/test/integration/virtualbox/create-with-upgrading.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+only_if_env DRIVER virtualbox
+
+export CACHE_DIR="$MACHINE_STORAGE_PATH/cache"
+export ISO_PATH="$CACHE_DIR/boot2docker.iso"
+export OLD_ISO_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.4.1/boot2docker.iso"
+
+@test "$DRIVER: download the old version iso" {
+  run mkdir -p $CACHE_DIR
+  run curl $OLD_ISO_URL -L -o $ISO_PATH
+  echo ${output}
+  [ "$status" -eq 0  ]
+}
+
+@test "$DRIVER: create with upgrading" {
+  run machine create -d $DRIVER $NAME
+  echo ${output}
+  [ "$status" -eq 0  ]
+}
+
+@test "$DRIVER: create is correct version" {
+  SERVER_VERSION=$(docker $(machine config $NAME) version | grep 'Server version' | awk '{ print $3; }')
+  [[ "$SERVER_VERSION" != "1.4.1" ]]
+}


### PR DESCRIPTION
close #1790 

This PR will

- check the version of the local ISO cache and the latest release tag, then upgrade the ISO if possible when creating a VirtualBox machine from boot2docker.iso.
- add many unit tests for `B2dUtils`'s methods 

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>