### PR TITLE
docs: show "-" for "inactive" machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To see how to connect Docker to this machine, run: docker-machine env staging
 
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL                          SWARM
-dev                virtualbox     Running   tcp://192.168.99.127:2376
+dev       -        virtualbox     Running   tcp://192.168.99.127:2376
 staging   *        digitalocean   Running   tcp://104.236.253.181:2376
 ```
 

--- a/docs/get-started-cloud.md
+++ b/docs/get-started-cloud.md
@@ -81,7 +81,7 @@ the last section. If we look at `docker-machine ls`, we'll see it is now the
 ```
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL
-dev                virtualbox     Running   tcp://192.168.99.103:2376
+dev       -        virtualbox     Running   tcp://192.168.99.103:2376
 staging   *        digitalocean   Running   tcp://104.236.50.118:2376
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -56,7 +56,7 @@ command again:
 ```
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL                         SWARM
-dev             virtualbox   Running   tcp://192.168.99.100:2376
+dev    -        virtualbox   Running   tcp://192.168.99.100:2376
 ```
 
 Next, as noted in the output of the `docker-machine create` command, we have to

--- a/docs/reference/active.md
+++ b/docs/reference/active.md
@@ -16,7 +16,7 @@ See which machine is "active" (a machine is considered active if the
 ```
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL
-dev                virtualbox     Running   tcp://192.168.99.103:2376
+dev       -        virtualbox     Running   tcp://192.168.99.103:2376
 staging   *        digitalocean   Running   tcp://104.236.50.118:2376
 $ echo $DOCKER_HOST
 tcp://104.236.50.118:2376

--- a/docs/reference/ls.md
+++ b/docs/reference/ls.md
@@ -38,14 +38,14 @@ The currently supported filters are:
 ```
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL
-dev             virtualbox   Stopped
-foo0            virtualbox   Running   tcp://192.168.99.105:2376
-foo1            virtualbox   Running   tcp://192.168.99.106:2376
+dev    -        virtualbox   Stopped
+foo0   -        virtualbox   Running   tcp://192.168.99.105:2376
+foo1   -        virtualbox   Running   tcp://192.168.99.106:2376
 foo2   *        virtualbox   Running   tcp://192.168.99.107:2376
 ```
 
 ```
 $ docker-machine ls --filter driver=virtualbox --filter state=Stopped
 NAME   ACTIVE   DRIVER       STATE     URL   SWARM
-dev             virtualbox   Stopped
+dev    -        virtualbox   Stopped
 ```

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -17,10 +17,10 @@ on the cloud provider or virtualization management platform.
 ```
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL
-foo0            virtualbox   Running   tcp://192.168.99.105:2376
-foo1            virtualbox   Running   tcp://192.168.99.106:2376
+foo0   -        virtualbox   Running   tcp://192.168.99.105:2376
+foo1   -        virtualbox   Running   tcp://192.168.99.106:2376
 $ docker-machine rm foo1
 $ docker-machine ls
 NAME   ACTIVE   DRIVER       STATE     URL
-foo0            virtualbox   Running   tcp://192.168.99.105:2376
+foo0   -        virtualbox   Running   tcp://192.168.99.105:2376
 ```


### PR DESCRIPTION
v0.5 shows `-` for "inactive" machines instead of nothing.
This PR reflects the change to documents.