### PR TITLE
skip printing swarm info when host options swarm info is nil

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -91,7 +91,7 @@ func cmdLs(c CommandLine) error {
 
 		swarmInfo := ""
 
-		if item.SwarmOptions.Discovery != "" {
+		if item.SwarmOptions != nil && item.SwarmOptions.Discovery != "" {
 			swarmInfo = swarmMasters[item.SwarmOptions.Discovery]
 			if item.SwarmOptions.Master {
 				swarmInfo = fmt.Sprintf("%s (master)", swarmInfo)


### PR DESCRIPTION
Fixes #2252 #2280

It seems top level tests for commands do no exist, or I would have added a case. Since it was simply a pointer field and the information added was additional, I assumed it would be fine to check for a nil pointer and skip the info when it is nil.

Although we may also want to determine why nil swarm options are returned in the first place. But, it is a pointer, which means nil is valid :)

My first contribution here, let me know if I miss any of the guidelines. I ran the tests and gofmt.