### PR TITLE
Introduce support for ubuntu 15.04 and higher

### DIFF
--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -1,0 +1,235 @@
+package provision
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"text/template"
+
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func init() {
+	Register("Ubuntu-SystemD", &RegisteredProvisioner{
+		New: NewUbuntuSystemdProvisioner,
+	})
+}
+
+func NewUbuntuSystemdProvisioner(d drivers.Driver) Provisioner {
+	return &UbuntuSystemdProvisioner{
+		GenericProvisioner{
+			DockerOptionsDir:  "/etc/docker",
+			DaemonOptionsFile: "/etc/systemd/system/docker.service",
+			OsReleaseID:       "ubuntu",
+			Packages: []string{
+				"curl",
+			},
+			Driver: d,
+		},
+	}
+}
+
+type UbuntuSystemdProvisioner struct {
+	GenericProvisioner
+}
+
+func (provisioner *UbuntuSystemdProvisioner) CompatibleWithHost() bool {
+	const FirstUbuntuSystemdVersion = 15.04
+
+	isUbuntu := provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID
+	if !isUbuntu {
+		return false
+	}
+	versionNumber, err := strconv.ParseFloat(provisioner.OsReleaseInfo.VersionID, 64)
+	if err != nil {
+		return false
+	}
+	return versionNumber >= FirstUbuntuSystemdVersion
+
+}
+
+func (provisioner *UbuntuSystemdProvisioner) Service(name string, action serviceaction.ServiceAction) error {
+	// daemon-reload to catch config updates; systemd -- ugh
+	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
+		return err
+	}
+
+	command := fmt.Sprintf("sudo systemctl -f %s %s", action.String(), name)
+
+	if _, err := provisioner.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	var packageAction string
+
+	updateMetadata := true
+
+	switch action {
+	case pkgaction.Install, pkgaction.Upgrade:
+		packageAction = "install"
+	case pkgaction.Remove:
+		packageAction = "remove"
+		updateMetadata = false
+	}
+
+	switch name {
+	case "docker":
+		name = "docker-engine"
+	}
+
+	if updateMetadata {
+		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+			return err
+		}
+	}
+
+	// handle the new docker-engine package; we can probably remove this
+	// after we have a few versions
+	if action == pkgaction.Upgrade && name == "docker-engine" {
+		// run the force remove on the existing lxc-docker package
+		// and remove the existing apt source list
+		// also re-run the get.docker.com script to properly setup
+		// the system again
+
+		commands := []string{
+			"rm /etc/apt/sources.list.d/docker.list || true",
+			"apt-get remove -y lxc-docker || true",
+			"curl -sSL https://get.docker.com | sh",
+		}
+
+		for _, cmd := range commands {
+			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
+			if _, err := provisioner.SSHCommand(command); err != nil {
+				return err
+			}
+		}
+	}
+
+	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+
+	log.Debugf("package: action=%s name=%s", action.String(), name)
+
+	if _, err := provisioner.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *UbuntuSystemdProvisioner) dockerDaemonResponding() bool {
+	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		return false
+	}
+
+	// The daemon is up if the command worked.  Carry on.
+	return true
+}
+
+func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	provisioner.SwarmOptions = swarmOptions
+	provisioner.AuthOptions = authOptions
+	provisioner.EngineOptions = engineOptions
+	swarmOptions.Env = engineOptions.Env
+
+	if provisioner.EngineOptions.StorageDriver == "" {
+		provisioner.EngineOptions.StorageDriver = "aufs"
+	}
+
+	// HACK: since debian does not come with sudo by default we install
+	log.Debug("installing sudo")
+	if _, err := provisioner.SSHCommand("if ! type sudo; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo; fi"); err != nil {
+		return err
+	}
+
+	log.Debug("setting hostname")
+	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		return err
+	}
+
+	log.Debug("installing base packages")
+	for _, pkg := range provisioner.Packages {
+		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
+			return err
+		}
+	}
+
+	log.Debug("installing docker")
+	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
+		return err
+	}
+
+	log.Debug("waiting for docker daemon")
+	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {
+		return err
+	}
+
+	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
+
+	log.Debug("configuring auth")
+	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("configuring swarm")
+	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
+		return err
+	}
+
+	// enable in systemd
+	log.Debug("enabling docker in systemd")
+	if err := provisioner.Service("docker", serviceaction.Enable); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *UbuntuSystemdProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
+	var (
+		engineCfg bytes.Buffer
+	)
+
+	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
+	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
+
+	engineConfigTmpl := `[Service]
+ExecStart=/usr/bin/docker -d -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
+
+[Install]
+WantedBy=multi-user.target
+`
+	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	engineConfigContext := EngineConfigContext{
+		DockerPort:    dockerPort,
+		AuthOptions:   provisioner.AuthOptions,
+		EngineOptions: provisioner.EngineOptions,
+	}
+
+	t.Execute(&engineCfg, engineConfigContext)
+
+	return &DockerOptions{
+		EngineOptions:     engineCfg.String(),
+		EngineOptionsPath: provisioner.DaemonOptionsFile,
+	}, nil
+}

--- a/libmachine/provision/ubuntu_systemd_test.go
+++ b/libmachine/provision/ubuntu_systemd_test.go
@@ -1,0 +1,29 @@
+package provision
+
+import (
+	"testing"
+)
+
+func TestUbuntuSystemdCompatibleWithHost(t *testing.T) {
+	info := &OsRelease{
+		ID:        "ubuntu",
+		VersionID: "15.04",
+	}
+	p := NewUbuntuSystemdProvisioner(nil)
+	p.SetOsReleaseInfo(info)
+
+	compatible := p.CompatibleWithHost()
+
+	if !compatible {
+		t.Fatalf("expected to be compatible with ubuntu 15.04")
+	}
+
+	info.VersionID = "14.04"
+
+	compatible = p.CompatibleWithHost()
+
+	if compatible {
+		t.Fatalf("expected to NOT be compatible with ubuntu 14.04")
+	}
+
+}

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
@@ -14,7 +15,7 @@ import (
 )
 
 func init() {
-	Register("Ubuntu", &RegisteredProvisioner{
+	Register("Ubuntu-UpStart", &RegisteredProvisioner{
 		New: NewUbuntuProvisioner,
 	})
 }
@@ -35,6 +36,21 @@ func NewUbuntuProvisioner(d drivers.Driver) Provisioner {
 
 type UbuntuProvisioner struct {
 	GenericProvisioner
+}
+
+func (provisioner *UbuntuProvisioner) CompatibleWithHost() bool {
+	const FirstUbuntuSystemdVersion = 15.04
+	isUbuntu := provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID
+	if !isUbuntu {
+		return false
+	}
+	versionNumber, err := strconv.ParseFloat(provisioner.OsReleaseInfo.VersionID, 64)
+	if err != nil {
+		return false
+	}
+
+	return versionNumber < FirstUbuntuSystemdVersion
+
 }
 
 func (provisioner *UbuntuProvisioner) Service(name string, action serviceaction.ServiceAction) error {

--- a/libmachine/provision/ubuntu_upstart_test.go
+++ b/libmachine/provision/ubuntu_upstart_test.go
@@ -1,0 +1,29 @@
+package provision
+
+import (
+	"testing"
+)
+
+func TestUbuntuCompatibleWithHost(t *testing.T) {
+	info := &OsRelease{
+		ID:        "ubuntu",
+		VersionID: "14.04",
+	}
+	p := NewUbuntuProvisioner(nil)
+	p.SetOsReleaseInfo(info)
+
+	compatible := p.CompatibleWithHost()
+
+	if !compatible {
+		t.Fatalf("expected to be compatible with ubuntu 14.04")
+	}
+
+	info.VersionID = "15.04"
+
+	compatible = p.CompatibleWithHost()
+
+	if compatible {
+		t.Fatalf("expected to NOT be compatible with ubuntu 15.04")
+	}
+
+}


### PR DESCRIPTION
Starting with version 15.04, ubuntu is based on systemd. The existing
ubuntu provider did not support systemd.

This commit introduce a new provider dedicated to systemd based
versions.

The new ubuntu_systemd provider is heavily copied from debian provider. Let me know if you prefer an other option.

The previous provider is renamed to ubuntu_upstart.

Provider detection uses the /etc/os=release VERSION_ID.
Version ID is converted to a float value and then used to choose between
providers.

Unit tests are validating the provisioner compatibility.

Fixes #1891

Signed-off-by: Thomas Recloux <thomas.recloux@gmail.com>