### PR TITLE
Remove systemd-related driver duplication

### DIFF
--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -1,9 +1,7 @@
 package provision
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
@@ -23,37 +21,16 @@ func init() {
 
 func NewArchProvisioner(d drivers.Driver) Provisioner {
 	return &ArchProvisioner{
-		GenericProvisioner{
-			DockerOptionsDir:  "/etc/docker",
-			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseID:       "arch",
-			Packages:          []string{},
-			Driver:            d,
-		},
+		NewSystemdProvisioner("arch", d),
 	}
 }
 
 type ArchProvisioner struct {
-	GenericProvisioner
+	SystemdProvisioner
 }
 
 func (provisioner *ArchProvisioner) CompatibleWithHost() bool {
 	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID || provisioner.OsReleaseInfo.IDLike == provisioner.OsReleaseID
-}
-
-func (provisioner *ArchProvisioner) Service(name string, action serviceaction.ServiceAction) error {
-	// daemon-reload to catch config updates; systemd -- ugh
-	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
-		return err
-	}
-
-	command := fmt.Sprintf("sudo systemctl %s %s", action.String(), name)
-
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (provisioner *ArchProvisioner) Package(name string, action pkgaction.PackageAction) error {
@@ -166,38 +143,4 @@ func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOp
 	}
 
 	return nil
-}
-
-func (provisioner *ArchProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
-	var (
-		engineCfg bytes.Buffer
-	)
-
-	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
-	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
-
-	engineConfigTmpl := `[Service]
-ExecStart=/usr/bin/docker -d -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
-LimitCORE=infinity
-`
-	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
-	if err != nil {
-		return nil, err
-	}
-
-	engineConfigContext := EngineConfigContext{
-		DockerPort:    dockerPort,
-		AuthOptions:   provisioner.AuthOptions,
-		EngineOptions: provisioner.EngineOptions,
-	}
-
-	t.Execute(&engineCfg, engineConfigContext)
-
-	return &DockerOptions{
-		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: provisioner.DaemonOptionsFile,
-	}, nil
 }

--- a/libmachine/provision/centos.go
+++ b/libmachine/provision/centos.go
@@ -11,21 +11,11 @@ func init() {
 }
 
 func NewCentosProvisioner(d drivers.Driver) Provisioner {
-	g := GenericProvisioner{
-		DockerOptionsDir:  "/etc/docker",
-		DaemonOptionsFile: "/etc/systemd/system/docker.service",
-		OsReleaseID:       "centos",
-		Packages:          []string{},
-		Driver:            d,
+	return &CentosProvisioner{
+		NewRedHatProvisioner("centos", d),
 	}
-	p := &CentosProvisioner{
-		RedHatProvisioner{
-			GenericProvisioner: g,
-		},
-	}
-	return p
 }
 
 type CentosProvisioner struct {
-	RedHatProvisioner
+	*RedHatProvisioner
 }

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -45,7 +45,6 @@ type CoreOSProvisioner struct {
 }
 
 func (provisioner *CoreOSProvisioner) Service(name string, action serviceaction.ServiceAction) error {
-	// daemon-reload to catch config updates; systemd -- ugh
 	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
 		return err
 	}

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -1,9 +1,7 @@
 package provision
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
@@ -23,35 +21,12 @@ func init() {
 
 func NewDebianProvisioner(d drivers.Driver) Provisioner {
 	return &DebianProvisioner{
-		GenericProvisioner{
-			DockerOptionsDir:  "/etc/docker",
-			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseID:       "debian",
-			Packages: []string{
-				"curl",
-			},
-			Driver: d,
-		},
+		NewSystemdProvisioner("debian", d),
 	}
 }
 
 type DebianProvisioner struct {
-	GenericProvisioner
-}
-
-func (provisioner *DebianProvisioner) Service(name string, action serviceaction.ServiceAction) error {
-	// daemon-reload to catch config updates; systemd -- ugh
-	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
-		return err
-	}
-
-	command := fmt.Sprintf("sudo systemctl -f %s %s", action.String(), name)
-
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
+	SystemdProvisioner
 }
 
 func (provisioner *DebianProvisioner) Package(name string, action pkgaction.PackageAction) error {
@@ -178,42 +153,4 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 	}
 
 	return nil
-}
-
-func (provisioner *DebianProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
-	var (
-		engineCfg bytes.Buffer
-	)
-
-	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
-	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
-
-	engineConfigTmpl := `[Service]
-ExecStart=/usr/bin/docker -d -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
-LimitCORE=infinity
-Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
-`
-	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
-	if err != nil {
-		return nil, err
-	}
-
-	engineConfigContext := EngineConfigContext{
-		DockerPort:    dockerPort,
-		AuthOptions:   provisioner.AuthOptions,
-		EngineOptions: provisioner.EngineOptions,
-	}
-
-	t.Execute(&engineCfg, engineConfigContext)
-
-	return &DockerOptions{
-		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: provisioner.DaemonOptionsFile,
-	}, nil
 }

--- a/libmachine/provision/fedora.go
+++ b/libmachine/provision/fedora.go
@@ -11,21 +11,11 @@ func init() {
 }
 
 func NewFedoraProvisioner(d drivers.Driver) Provisioner {
-	g := GenericProvisioner{
-		DockerOptionsDir:  "/etc/docker",
-		DaemonOptionsFile: "/etc/systemd/system/docker.service",
-		OsReleaseID:       "fedora",
-		Packages:          []string{},
-		Driver:            d,
+	return &FedoraProvisioner{
+		NewRedHatProvisioner("fedora", d),
 	}
-	p := &FedoraProvisioner{
-		RedHatProvisioner{
-			GenericProvisioner: g,
-		},
-	}
-	return p
 }
 
 type FedoraProvisioner struct {
-	RedHatProvisioner
+	*RedHatProvisioner
 }

--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -12,6 +12,7 @@ import (
 )
 
 type GenericProvisioner struct {
+	SSHCommander
 	OsReleaseID       string
 	DockerOptionsDir  string
 	DaemonOptionsFile string
@@ -21,6 +22,14 @@ type GenericProvisioner struct {
 	AuthOptions       auth.Options
 	EngineOptions     engine.Options
 	SwarmOptions      swarm.Options
+}
+
+type GenericSSHCmder struct {
+	Driver drivers.Driver
+}
+
+func (sshCmder GenericSSHCmder) SSHCommand(args string) (string, error) {
+	return drivers.RunSSHCommandFromDriver(sshCmder.Driver, args)
 }
 
 func (provisioner *GenericProvisioner) Hostname() (string, error) {
@@ -50,10 +59,6 @@ func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
 
 func (provisioner *GenericProvisioner) GetDockerOptionsDir() string {
 	return provisioner.DockerOptionsDir
-}
-
-func (provisioner *GenericProvisioner) SSHCommand(args string) (string, error) {
-	return drivers.RunSSHCommandFromDriver(provisioner.Driver, args)
 }
 
 func (provisioner *GenericProvisioner) CompatibleWithHost() bool {

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -14,8 +14,15 @@ import (
 
 var provisioners = make(map[string]*RegisteredProvisioner)
 
+type SSHCommander interface {
+	// Short-hand for accessing an SSH command from the driver.
+	SSHCommand(args string) (string, error)
+}
+
 // Provisioner defines distribution specific actions
 type Provisioner interface {
+	SSHCommander
+
 	// Create the files for the daemon to consume configuration settings (return struct of content and path)
 	GenerateDockerOptions(dockerPort int) (*DockerOptions, error)
 
@@ -50,9 +57,6 @@ type Provisioner interface {
 
 	// Get the driver which is contained in the provisioner.
 	GetDriver() drivers.Driver
-
-	// Short-hand for accessing an SSH command from the driver.
-	SSHCommand(args string) (string, error)
 
 	// Set the OS Release info depending on how it's represented
 	// internally

--- a/libmachine/provision/redhat_ssh_commander.go
+++ b/libmachine/provision/redhat_ssh_commander.go
@@ -1,0 +1,31 @@
+package provision
+
+import (
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/ssh"
+)
+
+type RedHatSSHCommander struct {
+	Driver drivers.Driver
+}
+
+func (sshCmder RedHatSSHCommander) SSHCommand(args string) (string, error) {
+	client, err := drivers.GetSSHClientFromDriver(sshCmder.Driver)
+	if err != nil {
+		return "", err
+	}
+
+	// redhat needs "-t" for tty allocation on ssh therefore we check for the
+	// external client and add as needed.
+	// Note: CentOS 7.0 needs multiple "-tt" to force tty allocation when ssh has
+	// no local tty.
+	switch c := client.(type) {
+	case ssh.ExternalClient:
+		c.BaseArgs = append(c.BaseArgs, "-tt")
+		client = c
+	case ssh.NativeClient:
+		return c.OutputWithPty(args)
+	}
+
+	return client.Output(args)
+}

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -9,7 +9,7 @@ func TestRedHatGenerateYumRepoList(t *testing.T) {
 	info := &OsRelease{
 		ID: "rhel",
 	}
-	p := NewRedHatProvisioner(nil)
+	p := NewRedHatProvisioner("rhel", nil)
 	p.SetOsReleaseInfo(info)
 
 	buf, err := generateYumRepoList(p)

--- a/libmachine/provision/systemd.go
+++ b/libmachine/provision/systemd.go
@@ -1,0 +1,92 @@
+package provision
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
+)
+
+type SystemdProvisioner struct {
+	GenericProvisioner
+}
+
+func NewSystemdProvisioner(osReleaseID string, d drivers.Driver) SystemdProvisioner {
+	return SystemdProvisioner{
+		GenericProvisioner{
+			SSHCommander:      GenericSSHCmder{Driver: d},
+			DockerOptionsDir:  "/etc/docker",
+			DaemonOptionsFile: "/etc/systemd/system/docker.service",
+			OsReleaseID:       osReleaseID,
+			Packages: []string{
+				"curl",
+			},
+			Driver: d,
+		},
+	}
+}
+
+func (p *SystemdProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
+	var (
+		engineCfg bytes.Buffer
+	)
+
+	driverNameLabel := fmt.Sprintf("provider=%s", p.Driver.DriverName())
+	p.EngineOptions.Labels = append(p.EngineOptions.Labels, driverNameLabel)
+
+	engineConfigTmpl := `[Service]
+ExecStart=/usr/bin/docker -d -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
+
+[Install]
+WantedBy=multi-user.target
+`
+	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	engineConfigContext := EngineConfigContext{
+		DockerPort:    dockerPort,
+		AuthOptions:   p.AuthOptions,
+		EngineOptions: p.EngineOptions,
+	}
+
+	t.Execute(&engineCfg, engineConfigContext)
+
+	return &DockerOptions{
+		EngineOptions:     engineCfg.String(),
+		EngineOptionsPath: p.DaemonOptionsFile,
+	}, nil
+}
+
+func (p *SystemdProvisioner) Service(name string, action serviceaction.ServiceAction) error {
+	reloadDaemon := false
+	switch action {
+	case serviceaction.Start, serviceaction.Restart:
+		reloadDaemon = true
+	}
+
+	// systemd needs reloaded when config changes on disk; we cannot
+	// be sure exactly when it changes from the provisioner so
+	// we call a reload on every restart to be safe
+	if reloadDaemon {
+		if _, err := p.SSHCommand("sudo systemctl daemon-reload"); err != nil {
+			return err
+		}
+	}
+
+	command := fmt.Sprintf("sudo systemctl -f %s %s", action.String(), name)
+
+	if _, err := p.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -1,10 +1,8 @@
 package provision
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
-	"text/template"
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/drivers"
@@ -24,20 +22,12 @@ func init() {
 
 func NewUbuntuSystemdProvisioner(d drivers.Driver) Provisioner {
 	return &UbuntuSystemdProvisioner{
-		GenericProvisioner{
-			DockerOptionsDir:  "/etc/docker",
-			DaemonOptionsFile: "/etc/systemd/system/docker.service",
-			OsReleaseID:       "ubuntu",
-			Packages: []string{
-				"curl",
-			},
-			Driver: d,
-		},
+		NewSystemdProvisioner("ubuntu", d),
 	}
 }
 
 type UbuntuSystemdProvisioner struct {
-	GenericProvisioner
+	SystemdProvisioner
 }
 
 func (provisioner *UbuntuSystemdProvisioner) CompatibleWithHost() bool {
@@ -53,21 +43,6 @@ func (provisioner *UbuntuSystemdProvisioner) CompatibleWithHost() bool {
 	}
 	return versionNumber >= FirstUbuntuSystemdVersion
 
-}
-
-func (provisioner *UbuntuSystemdProvisioner) Service(name string, action serviceaction.ServiceAction) error {
-	// daemon-reload to catch config updates; systemd -- ugh
-	if _, err := provisioner.SSHCommand("sudo systemctl daemon-reload"); err != nil {
-		return err
-	}
-
-	command := fmt.Sprintf("sudo systemctl -f %s %s", action.String(), name)
-
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgaction.PackageAction) error {
@@ -147,12 +122,6 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 		provisioner.EngineOptions.StorageDriver = "aufs"
 	}
 
-	// HACK: since debian does not come with sudo by default we install
-	log.Debug("installing sudo")
-	if _, err := provisioner.SSHCommand("if ! type sudo; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo; fi"); err != nil {
-		return err
-	}
-
 	log.Debug("setting hostname")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err
@@ -194,42 +163,4 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 	}
 
 	return nil
-}
-
-func (provisioner *UbuntuSystemdProvisioner) GenerateDockerOptions(dockerPort int) (*DockerOptions, error) {
-	var (
-		engineCfg bytes.Buffer
-	)
-
-	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
-	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
-
-	engineConfigTmpl := `[Service]
-ExecStart=/usr/bin/docker -d -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
-LimitCORE=infinity
-Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
-`
-	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
-	if err != nil {
-		return nil, err
-	}
-
-	engineConfigContext := EngineConfigContext{
-		DockerPort:    dockerPort,
-		AuthOptions:   provisioner.AuthOptions,
-		EngineOptions: provisioner.EngineOptions,
-	}
-
-	t.Execute(&engineCfg, engineConfigContext)
-
-	return &DockerOptions{
-		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: provisioner.DaemonOptionsFile,
-	}, nil
 }


### PR DESCRIPTION
cc @docker/machine-maintainers 

Especially with the introduction of the Ubuntu >15.04 systemd work, there was a lot of code duplicated all over `provision` that could easily be re-used instead.  This fixes it.  I've tested this patch on Ubuntu 15.04, Fedora 22, and CentOS 7, and it seems to work smoothly (barring an unrelated bug with Fedora `netstat` parsing).

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>