### PR TITLE
Add -n to get port number for netstat

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -205,7 +205,7 @@ func checkDaemonUp(p Provisioner, dockerPort int) func() bool {
 	reDaemonListening := fmt.Sprintf(":%d.*LISTEN", dockerPort)
 	return func() bool {
 		// HACK: Check netstat's output to see if anyone's listening on the Docker API port.
-		netstatOut, err := p.SSHCommand("netstat -a")
+		netstatOut, err := p.SSHCommand("netstat -an")
 		if err != nil {
 			log.Warnf("Error running SSH command: %s", err)
 			return false


### PR DESCRIPTION
On Fedora the new "detect daemon is listening" method did not work because netstat needed the `-n` flag.

cc @tianon You might be curious to know that the `netstat` output actually _was_ different between distros.  Ah, the joys of OSS.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>