### PR TITLE
Update some driver/plugin-related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Full documentation [is available here](https://docs.docker.com/machine/).
 
 Want to hack on Machine? Please start with the [Contributing Guide](https://github.com/docker/machine/blob/master/CONTRIBUTING.md).
 
+## Driver Plugins
+
+In addition to the core driver plugins bundled alongside Docker Machine, users
+can make and distribute their own plugin for any virtualization technology or
+cloud provider.  To browse the list of known Docker Machine plugins, please [see
+this document in our
+repo](https://github.com/docker/machine/blob/master/docs/AVAILABLE_DRIVER_PLUGINS.md).
+
 ## Troubleshooting
 
 Docker Machine tries to do the right thing in a variety of scenarios but

--- a/docs/AVAILABLE_DRIVER_PLUGINS.md
+++ b/docs/AVAILABLE_DRIVER_PLUGINS.md
@@ -1,0 +1,18 @@
+# Available driver plugins
+
+This document is intended to act as a reference for the available 3rd-party
+driver plugins available in the ecosystem beyond the core Machine drivers.  If
+you have created a Docker Machine driver, we highly encourage you to submit a
+pull request adding the relevant information to the list.  Submitting your
+driver here will allow others to discover it and the core Machine team to keep
+you informed of upstream changes.
+
+__NOTE__: The linked repositories are not maintained by or formally associated
+with Docker Inc.  Use 3rd party plugins at your own risk.
+
+| Name | Repository | Maintainer GitHub Handle  | Maintainer Email |
+| ---- | ---------- | ------------------------- | ---------------- |
+| BrightBox | https://github.com/brightbox/docker-machine-driver-brightbox | [NeilW](NeilW) | neil@aldur.co.uk |
+| Docker-In-Docker | https://github.com/nathanleclaire/docker-machine-driver-dind | [nathanleclaire](https://github.com/nathanleclaire) | nathan.leclaire@gmail.com |
+| Parallels for OSX | https://github.com/Parallels/docker-machine-parallels | [legal90](https://github.com/legal90) | legal90@gmail.com |
+| SAKURA CLOUD | https://github.com/yamamoto-febc/docker-machine-sakuracloud | [yamamoto-febc](https://github.com/yamamoto-febc) | ? |

--- a/docs/DRIVER_SPEC.md
+++ b/docs/DRIVER_SPEC.md
@@ -36,11 +36,6 @@ The provider must offer SSH access to control the instance.  This does not
 have to be public, but must offer it as Machine relies on SSH for system
 level maintenance.
 
-## Maintainer
-To be supported as an official driver, it will need to be maintained.  There
-can be multiple driver maintainers and they will be identified in the
-maintainers file.
-
 # Provider Operations
 The following instance operations should be supported by the provider.
 
@@ -84,16 +79,8 @@ Testing is strongly recommended for drivers.  Unit tests are preferred as well
 as inclusion into the [integration tests](https://github.com/docker/machine#integration-tests).
 
 # Maintaining
-Driver contributors are strongly encouraged to maintain the driver to keep
-it supported.  We recommend and encourage contributors to join in the weekly
-meetings to give feedback and participate in the development around Machine.
-Driver maintainers will be notified and consulted for issues regarding their
-driver.
-
-# Third Party Libraries
-If you want to use a third party library to interact with the provider, you
-will need to make sure it is compliant with the Docker license terms (non-GPL).
-For more information, contact a project maintainer.
+Driver plugin maintainers are encouraged to host their own repo and distribute
+the driver plugins as executables.
 
 # Implementation
 The following describes what is needed to create a Machine Driver.  The driver


### PR DESCRIPTION
The added text should be fairly self-explanatory.  I have been mentioning wanting to add this for a while and I want a way to keep track of which plugins are available in the ecosystem.  I've listed all the driver plugins I know of that seem maintained.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>