### PR TITLE
fix docs validation errors

### DIFF
--- a/docs/AVAILABLE_DRIVER_PLUGINS.md
+++ b/docs/AVAILABLE_DRIVER_PLUGINS.md
@@ -1,3 +1,12 @@
+<!--[metadata]>
++++
+draft = true
+title = "Machine plugins"
+description = "Machine plugins"
+keywords = ["Docker, documentation, manual, guide, reference, api"]
++++
+<![end-metadata]-->
+
 # Available driver plugins
 
 This document is intended to act as a reference for the available 3rd-party
@@ -12,7 +21,7 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
 
 | Name | Repository | Maintainer GitHub Handle  | Maintainer Email |
 | ---- | ---------- | ------------------------- | ---------------- |
-| BrightBox | https://github.com/brightbox/docker-machine-driver-brightbox | [NeilW](NeilW) | neil@aldur.co.uk |
+| BrightBox | https://github.com/brightbox/docker-machine-driver-brightbox | [NeilW](https://github.com/NeilW) | neil@aldur.co.uk |
 | Docker-In-Docker | https://github.com/nathanleclaire/docker-machine-driver-dind | [nathanleclaire](https://github.com/nathanleclaire) | nathan.leclaire@gmail.com |
 | Parallels for OSX | https://github.com/Parallels/docker-machine-parallels | [legal90](https://github.com/legal90) | legal90@gmail.com |
 | SAKURA CLOUD | https://github.com/yamamoto-febc/docker-machine-sakuracloud | [yamamoto-febc](https://github.com/yamamoto-febc) | ? |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,12 @@
+<!--[metadata]>
++++
+draft = true
+title = "Machine README"
+description = "Machine README"
+keywords = ["Docker, documentation, manual, guide, reference, api"]
++++
+<![end-metadata]-->
+
 # Contributing to the Docker Machine documentation
 
 The documentation in this directory is part of the [this documentation](https://docs.docker.com).  Docker uses [the Hugo static generator](http://gohugo.io/overview/introduction/) to convert project Markdown files to a static HTML site.

--- a/docs/install-machine.md
+++ b/docs/install-machine.md
@@ -78,6 +78,6 @@ You can find additional documentation in the comments at the
 
 ## Where to go next
 
-* [Docker Machine overview](/)
+* [Docker Machine overview](index.md)
 * [Docker Machine driver reference](drivers/index.md)
 * [Docker Machine subcommand reference](reference/index.md)


### PR DESCRIPTION
fix link which when published leads to the root of all the docs.docker.com site

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>