### PR TITLE
IT: cleanup properly before starting

### DIFF
--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -73,6 +73,11 @@ export -f machine
 touch "$BATS_LOG"
 rm "$BATS_LOG"
 
+cleanup_machines
+if [[ -d "$MACHINE_STORAGE_PATH" ]]; then
+    rm -r "$MACHINE_STORAGE_PATH"
+fi
+
 run_bats "$BATS_FILE"
 
 if [[ -d "$MACHINE_STORAGE_PATH" ]]; then


### PR DESCRIPTION
This ensure that, we cleanup properly the work directory AND running containers whenever a test fails or crash bats