### PR TITLE
Plugin's stdout shouldn't show `OUT`

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -19,7 +19,7 @@ var (
 )
 
 const (
-	pluginOutPrefix = "(%s) OUT | "
+	pluginOutPrefix = "(%s) "
 	pluginErrPrefix = "(%s) DBG | "
 	PluginEnvKey    = "MACHINE_PLUGIN_TOKEN"
 	PluginEnvVal    = "42"


### PR DESCRIPTION
This is just to get a nicer output from driver plugins.

Instead of:

```
$ ./bin/docker-machine create -d virtualbox machine
Running pre-create checks...
Creating machine...
(machine) OUT | Creating VirtualBox VM...
(machine) OUT | Creating SSH key...
(machine) OUT | Starting VirtualBox VM...
(machine) OUT | Starting VM...
Waiting for machine to be running, this may take a few minutes...
```

, the user will see

```
$ ./bin/docker-machine create -d virtualbox machine
Running pre-create checks...
Creating machine...
(machine) Creating VirtualBox VM...
(machine) Creating SSH key...
(machine) Starting VirtualBox VM...
(machine) Starting VM...
Waiting for machine to be running, this may take a few minutes...
```

Signed-off-by: David Gageot <david@gageot.net>