### PR TITLE
Fix its

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -6,7 +6,7 @@ test-short:
 test-long:
 	$(GO) test $(VERBOSE_GO) -race -tags "$(BUILDTAGS)" $(PKGS)
 
-test-integration:
+test-integration: build
 	$(eval TESTSUITE=$(filter-out $@,$(MAKECMDGOALS)))
 	test/integration/run-bats.sh $(TESTSUITE)
 

--- a/test/integration/core/arbitrary-engine-options.bats
+++ b/test/integration/core/arbitrary-engine-options.bats
@@ -14,5 +14,6 @@ load ${BASE_TEST_DIR}/helpers.bash
   docker $(machine config $NAME) run --name nolog busybox echo this should not be logged
   run docker $(machine config $NAME) logs nolog
   echo ${output}
-  [ $status -eq 1 ]
+  [ $status -eq 0 ]
+  [[ ${lines[0]} =~ "no log driver named 'none' is registered" ]]
 }

--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -6,7 +6,7 @@ load ${BASE_TEST_DIR}/helpers.bash
   run machine inspect $NAME
   echo ${output}
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} == "Host \"$NAME\" does not exist" ]]
+  [[ ${lines[0]} =~ "Host does not exist: \"$NAME\"" ]]
 }
 
 @test "$DRIVER: create" {

--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -26,6 +26,8 @@ function machine() {
 
 function run_bats() {
     for bats_file in $(find "$1" -name \*.bats); do
+        export NAME="bats-$DRIVER-test-$(date +%s)"
+
         # BATS returns non-zero to indicate the tests have failed, we shouldn't
         # neccesarily bail in this case, so that's the reason for the e toggle.
         set +e
@@ -62,7 +64,6 @@ fi
 # TODO: Should the script bail out if these are set already?
 export BASE_TEST_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 export MACHINE_ROOT="$BASE_TEST_DIR/../.."
-export NAME="bats-$DRIVER-test"
 export MACHINE_STORAGE_PATH="/tmp/machine-bats-test-$DRIVER"
 export MACHINE_BIN_NAME=docker-machine
 export BATS_LOG="$MACHINE_ROOT/bats.log"

--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -85,11 +85,4 @@ if [[ -d "$MACHINE_STORAGE_PATH" ]]; then
     rm -r "$MACHINE_STORAGE_PATH"
 fi
 
-set +e
-pkill docker-machine
-if [[ $? -eq 0 ]]; then
-    EXIT_STATUS=1
-fi
-set -e
-
 exit ${EXIT_STATUS}


### PR DESCRIPTION
With this PR, the virtualbox Integration tests will at last be all green!!

+ It makes sure everything is built before running the its
+ It fixes two tests that are broken because of a change in docker-machine and a change in docker
+ It removes the `pkill` thing at the end of the its because we don't need it anymore and it makes the its always fail
+ It gives a unique name to each machine created by the its. This has a huge effect on test robustness since a failing test won't break another test anymore.