### PR TITLE
Global set for fish env

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -133,7 +133,7 @@ func cmdEnv(c *cli.Context) {
 
 	switch userShell {
 	case "fish":
-		shellCfg.Prefix = "set -x "
+		shellCfg.Prefix = "set -gx "
 		shellCfg.Suffix = "\";\n"
 		shellCfg.Delimiter = " \""
 	case "powershell":


### PR DESCRIPTION
Using `set -x` only exports the variable in the local scope.
This is a limitation when an user needs to invoke `docker-machine` in a fish script.

Using `set -gx` instead exports the variable globally.