### PR TITLE
Global set for fish env

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -98,7 +98,7 @@ func set(c CommandLine) error {
 
 	switch userShell {
 	case "fish":
-		shellCfg.Prefix = "set -x "
+		shellCfg.Prefix = "set -gx "
 		shellCfg.Suffix = "\";\n"
 		shellCfg.Delimiter = " \""
 	case "powershell":

--- a/test/integration/core/env_shell.bats
+++ b/test/integration/core/env_shell.bats
@@ -44,11 +44,11 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: test fish notation" {
   run machine env --shell fish --no-proxy $NAME
-  [[ ${lines[0]} == "set -x DOCKER_TLS_VERIFY \"1\";" ]]
-  [[ ${lines[1]} == "set -x DOCKER_HOST \"$(machine url $NAME)\";" ]]
-  [[ ${lines[2]} == "set -x DOCKER_CERT_PATH \"$MACHINE_STORAGE_PATH/machines/$NAME\";" ]]
-  [[ ${lines[3]} == "set -x DOCKER_MACHINE_NAME \"$NAME\";" ]]
-  [[ ${lines[4]} == "set -x NO_PROXY \"$(machine ip $NAME)\";" ]]
+  [[ ${lines[0]} == "set -gx DOCKER_TLS_VERIFY \"1\";" ]]
+  [[ ${lines[1]} == "set -gx DOCKER_HOST \"$(machine url $NAME)\";" ]]
+  [[ ${lines[2]} == "set -gx DOCKER_CERT_PATH \"$MACHINE_STORAGE_PATH/machines/$NAME\";" ]]
+  [[ ${lines[3]} == "set -gx DOCKER_MACHINE_NAME \"$NAME\";" ]]
+  [[ ${lines[4]} == "set -gx NO_PROXY \"$(machine ip $NAME)\";" ]]
 }
 
 @test "$DRIVER: test no proxy with NO_PROXY already set" {


### PR DESCRIPTION
Using `set -x` only exports the variable in the local scope.
This is a limitation when an user needs to invoke `docker-machine` in a fish script.

Using `set -gx` instead exports the variable globally.