### PR TITLE
Change log driver check to be more future-safe

### DIFF
--- a/test/integration/core/arbitrary-engine-options.bats
+++ b/test/integration/core/arbitrary-engine-options.bats
@@ -12,8 +12,7 @@ load ${BASE_TEST_DIR}/helpers.bash
 
 @test "$DRIVER: check created engine option (log driver)" {
   docker $(machine config $NAME) run --name nolog busybox echo this should not be logged
-  run docker $(machine config $NAME) logs nolog
+  run docker $(machine config $NAME) inspect -f '{{.HostConfig.LogConfig.Type}}' nolog
   echo ${output}
-  [ $status -eq 0 ]
-  [[ ${lines[0]} =~ "no log driver named 'none' is registered" ]]
+  [ ${output} == "none" ]
 }


### PR DESCRIPTION
cc @docker/machine-maintainers 

I'm wondering if this method might be more future-safe since the exit code and output of the `docker run` changed between versions.

@jfrazelle @dcalavera @icecrime Would be good to get some input from you all about what you think the most robust (future-compatible) way to verify the creation with `--log-driver` on the daemon happened successfully is.  Reasoning for changing this is that exit code and message from `docker run` changed on us from 1.8.3 => 1.9.0 (which is fine, just wondering which might be least likely to change).

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>