### PR TITLE
Add a version command

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -71,7 +71,7 @@ OPTIONS:
 var helpCommand = Command{
 	Name:      "help",
 	Aliases:   []string{"h"},
-	Usage:     "Shows a list of commands or help for one command",
+	Usage:     "Show a list of commands or help for one command",
 	ArgsUsage: "[command]",
 	Action: func(c *Context) {
 		args := c.Args()
@@ -86,7 +86,7 @@ var helpCommand = Command{
 var helpSubcommand = Command{
 	Name:      "help",
 	Aliases:   []string{"h"},
-	Usage:     "Shows a list of commands or help for one command",
+	Usage:     "Show a list of commands or help for one command",
 	ArgsUsage: "[command]",
 	Action: func(c *Context) {
 		args := c.Args()

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -88,7 +88,7 @@ func main() {
 	app.Commands = commands.Commands
 	app.CommandNotFound = cmdNotFound
 	app.Usage = "Create and manage machines running Docker."
-	app.Version = version.Version + " (" + version.GitCommit + ")"
+	app.Version = version.FullVersion()
 
 	log.Debug("Docker Machine Version: ", app.Version)
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -29,6 +29,8 @@ var (
 type CommandLine interface {
 	ShowHelp()
 
+	ShowVersion()
+
 	Application() *cli.App
 
 	Args() cli.Args
@@ -52,6 +54,10 @@ type contextCommandLine struct {
 
 func (c *contextCommandLine) ShowHelp() {
 	cli.ShowCommandHelp(c.Context, c.Command.Name)
+}
+
+func (c *contextCommandLine) ShowVersion() {
+	cli.ShowVersion(c.Context)
 }
 
 func (c *contextCommandLine) Application() *cli.App {
@@ -346,6 +352,11 @@ var Commands = []cli.Command{
 		Usage:       "Get the URL of a machine",
 		Description: "Argument is a machine name.",
 		Action:      fatalOnError(cmdURL),
+	},
+	{
+		Name:   "version",
+		Usage:  "Show the Docker Machine version information",
+		Action: fatalOnError(cmdVersion),
 	},
 }
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,0 +1,6 @@
+package commands
+
+func cmdVersion(c CommandLine) error {
+	c.ShowVersion()
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+import "fmt"
+
 var (
 	// Version should be updated by hand at each release
 	Version = "0.5.2-dev"
@@ -7,3 +9,8 @@ var (
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"
 )
+
+// FullVersion formats the version to be printed
+func FullVersion() string {
+	return fmt.Sprintf("%s ( %s )", Version, GitCommit)
+}


### PR DESCRIPTION
Sounds like every other docker project has a `version` command, and we don't. I couldn't stand it anymore :smiley: , so here it is.