### PR TITLE
Fix create usage & description in cli

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -199,7 +199,8 @@ var Commands = []cli.Command{
 	{
 		Flags:           sharedCreateFlags,
 		Name:            "create",
-		Usage:           fmt.Sprintf("Create a machine.\n\nRun '%s create --driver name' to include the create flags for that driver in the help text.", os.Args[0]),
+		Usage:           "Create a machine",
+		Description:     fmt.Sprintf("Run '%s create --driver name' to include the create flags for that driver in the help text.", os.Args[0]),
 		Action:          fatalOnError(cmdCreateOuter),
 		SkipFlagParsing: true,
 	},


### PR DESCRIPTION
Before this PR:
Notice the double carriage return breaks just after 'create'
```
>docker-machine --help
.../...
Commands:
  active	Print which machine is active
  config	Print the connection config for machine
  create	Create a machine.

Run 'docker-machine create --driver name' to include the create flags for that driver in the help text.
  env			Display the commands to set up the environment for the Docker client

```
after
```
>docker-machine --help
.../...
Commands:
  active		Print which machine is active
  config		Print the connection config for machine
  create		Create a machine
  env			Display the commands to set up the environment for the Docker client
```

The relevant information is still available in the `docker-machine create` command
```
>docker-machine create
Usage: docker-machine create [OPTIONS] [arg...]

Create a machine

Description:
   Run './bin/docker-machine create --driver name' to include the create flags for that driver in the help text.
```