### PR TITLE
Reject VirtualBox version<=3

### DIFF
--- a/docs/drivers/virtualbox.md
+++ b/docs/drivers/virtualbox.md
@@ -10,7 +10,7 @@ parent="smn_machine_drivers"
 
 # Oracle VirtualBox
 Create machines locally using [VirtualBox](https://www.virtualbox.org/).
-This driver requires VirtualBox to be installed on your host.
+This driver requires VirtualBox 4+ to be installed on your host.
 
     $ docker-machine create --driver=virtualbox vbox-test
 

--- a/drivers/virtualbox/vbm.go
+++ b/drivers/virtualbox/vbm.go
@@ -75,3 +75,11 @@ func (v *VBoxCmdManager) vbmOutErr(args ...string) (string, string, error) {
 
 	return stdout.String(), stderrStr, err
 }
+
+func checkVBoxManageVersion(version string) error {
+	if !strings.HasPrefix(version, "5.") && !strings.HasPrefix(version, "4.") {
+		return fmt.Errorf("We support Virtualbox starting with version 4. Your VirtualBox install is %q. Please upgrade at https://www.virtualbox.org", version)
+	}
+
+	return nil
+}

--- a/drivers/virtualbox/vbm_test.go
+++ b/drivers/virtualbox/vbm_test.go
@@ -1,0 +1,42 @@
+package virtualbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckVBoxManageVersionValid(t *testing.T) {
+	var tests = []struct {
+		version string
+	}{
+		{"5.0.8r103449"},
+		{"5.0"},
+		{"5.1"},
+		{"4.1"},
+		{"4.2.0"},
+		{"4.3.1"},
+	}
+
+	for _, test := range tests {
+		err := checkVBoxManageVersion(test.version)
+
+		assert.NoError(t, err)
+	}
+}
+
+func TestCheckVBoxManageVersionInvalid(t *testing.T) {
+	var tests = []struct {
+		version       string
+		expectedError string
+	}{
+		{"3.9", `We support Virtualbox starting with version 4. Your VirtualBox install is "3.9". Please upgrade at https://www.virtualbox.org`},
+		{"", `We support Virtualbox starting with version 4. Your VirtualBox install is "". Please upgrade at https://www.virtualbox.org`},
+	}
+
+	for _, test := range tests {
+		err := checkVBoxManageVersion(test.version)
+
+		assert.EqualError(t, err, test.expectedError)
+	}
+}

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -184,7 +184,13 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 // PreCreateCheck checks that VBoxManage exists and works
 func (d *Driver) PreCreateCheck() error {
 	// Check that VBoxManage exists and works
-	if err := d.vbm(); err != nil {
+	version, err := d.vbmOut("--version")
+	if err != nil {
+		return err
+	}
+
+	// Check that VBoxManage is of a supported version
+	if err = checkVBoxManageVersion(version); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Should we test the version of virtualbox and refuse to work with something different from `5.X`?

Signed-off-by: David Gageot <david@gageot.net>