### PR TITLE
Make user supplied input more obvious

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -21,7 +21,7 @@ type ErrCertInvalid struct {
 
 func (e ErrCertInvalid) Error() string {
 	return fmt.Sprintf(`There was an error validating certificates for host %q: %s
-You can attempt to regenerate them using 'docker-machine regenerate-certs name'.
+You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
 Be advised that this will trigger a Docker daemon restart which will stop running containers.
 `, e.hostURL, e.wrappedErr)
 }


### PR DESCRIPTION
The command example given does not make it obvious that `name` is to be supplied by the user. Add square bracket notation around it to indicate the need to replace it.