### PR TITLE
Add xhyve driver

### DIFF
--- a/docs/AVAILABLE_DRIVER_PLUGINS.md
+++ b/docs/AVAILABLE_DRIVER_PLUGINS.md
@@ -25,3 +25,4 @@ with Docker Inc.  Use 3rd party plugins at your own risk.
 | Docker-In-Docker | https://github.com/nathanleclaire/docker-machine-driver-dind | [nathanleclaire](https://github.com/nathanleclaire) | nathan.leclaire@gmail.com |
 | Parallels for OSX | https://github.com/Parallels/docker-machine-parallels | [legal90](https://github.com/legal90) | legal90@gmail.com |
 | SAKURA CLOUD | https://github.com/yamamoto-febc/docker-machine-sakuracloud | [yamamoto-febc](https://github.com/yamamoto-febc) | yamamoto.febc@gmail.com |
+| xhyve | https://github.com/zchee/docker-machine-xhyve | [zchee](https://github.com/zchee) | zchee.io@gmail.com |


### PR DESCRIPTION
Add xhyve driver.

@nathanleclaire seems unable to launch the xhyve. https://github.com/zchee/docker-machine-xhyve/issues/9
but, I know at least two Japanese people were the able to launch.

Would you let me know what your thoughts are on this matter?

If you think this repository is too development-stage, I will once close the pull request.
And I will do best to develop.

/cc @nathanleclaire