### PR TITLE
Fix for issue 2370, show machine state after kill is executed #2386

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -73,7 +73,7 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 		return ErrNoMachineSpecified
 	}
 
-	if errs := runActionForeachMachine(actionName, hosts); len(errs) > 0 {
+	if errs := runActionForeachMachine(actionName, hosts); len(errs) > 0 && len(errs) == len(hosts) {
 		return consolidateErrs(errs)
 	}
 
@@ -81,6 +81,10 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 		if err := api.Save(h); err != nil {
 			return fmt.Errorf("Error saving host to store: %s", err)
 		}
+	}
+
+	for _, h := range hosts {
+		log.Infof("Successfully ran action %q on machine %q", actionName, h.Name)
 	}
 
 	return nil


### PR DESCRIPTION
Hi,

This fixes #2370 "kill does not return any message to the user #2370". docker-machine kill displays machine(s) state after kill is executed.

Thanks...