### PR TITLE
Clarifying  description of hyperv-disk-size

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -61,7 +61,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.IntFlag{
 			Name:  "hyperv-disk-size",
-			Usage: "Hyper-V disk size for host in MB.",
+			Usage: "Hyper-V maximum size of dynamically expanding disk in MB.",
 			Value: defaultDiskSize,
 		},
 		mcnflag.IntFlag{


### PR DESCRIPTION
Making clear the value is a maximum for a dynamic disk not the actual size of a fixed size disk.