### PR TITLE
add debug message in dockerDaemonResponding function due to helping f…

### DIFF
--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -72,8 +72,11 @@ func (provisioner *ArchProvisioner) Package(name string, action pkgaction.Packag
 }
 
 func (provisioner *ArchProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -87,8 +87,11 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 }
 
 func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -136,8 +136,11 @@ func (provisioner *RedHatProvisioner) installOfficialDocker() error {
 }
 
 func (provisioner *RedHatProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 

--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -123,8 +123,11 @@ func (provisioner *SUSEProvisioner) Package(name string, action pkgaction.Packag
 }
 
 func (provisioner *SUSEProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -103,8 +103,11 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 }
 
 func (provisioner *UbuntuSystemdProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -122,8 +122,11 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 }
 
 func (provisioner *UbuntuProvisioner) dockerDaemonResponding() bool {
-	if _, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
 		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
 		return false
 	}
 


### PR DESCRIPTION
…or troubleshooting of docker daemon state

It might be difficult to know why it was failed and what command was executed, instead, we only can see the following message:

```
WARNING >>> Error getting SSH command to check if the daemon is up: exit status 1
```

It shows an output message of the SSH command like the following if the user use ```--debug``` option of the ```docker-machine```.

```
WARNING >>> Error getting SSH command to check if the daemon is up:
Client:
 Version:      1.9.1
 API version:  1.21
 Go version:   go1.4.2
 Git commit:   a34a1d5
 Built:        Fri Nov 20 13:25:01 UTC 2015
 OS/Arch:      linux/amd64
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
 : exit status 1
```

The message may be helped for troubleshooting as I was.