### PR TITLE
Rename "none" driver to "test"

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -16,7 +16,7 @@
 		"github.com/docker/machine/drivers/generic",
 		"github.com/docker/machine/drivers/google",
 		"github.com/docker/machine/drivers/hyperv",
-		"github.com/docker/machine/drivers/none",
+		"github.com/docker/machine/drivers/test",
 		"github.com/docker/machine/drivers/openstack",
 		"github.com/docker/machine/drivers/rackspace",
 		"github.com/docker/machine/drivers/softlayer",

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
         pwd: $BASE_STABLE
 
   override:
-    - DRIVER=none test/integration/run-bats.sh test/integration/cli:
+    - DRIVER=test test/integration/run-bats.sh test/integration/cli:
         pwd: $BASE_STABLE
         timeout: 600
     # - DRIVER=virtualbox test/integration/run-bats.sh test/integration/core:

--- a/cmd/machine-driver-test.go
+++ b/cmd/machine-driver-test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/drivers/test"
 	"github.com/docker/machine/libmachine/drivers/plugin"
 )
 
 func main() {
-	plugin.RegisterDriver(none.NewDriver("", ""))
+	plugin.RegisterDriver(test.NewDriver("", ""))
 }

--- a/commands/create.go
+++ b/commands/create.go
@@ -38,7 +38,7 @@ var (
 			Usage: fmt.Sprintf(
 				"Driver to create machine with.",
 			),
-			Value: "none",
+			Value: "generic",
 		},
 		cli.StringFlag{
 			Name:   "engine-install-url",

--- a/docs/get-started-cloud.md
+++ b/docs/get-started-cloud.md
@@ -85,16 +85,19 @@ To remove a host and all of its containers and images, use `docker-machine rm`:
     $ docker-machine ls
     NAME      ACTIVE   DRIVER       STATE     URL
 
-## Adding a host without a driver
 
-You can add a host to Docker which only has a URL and no driver. Therefore it
-can be used an alias for an existing host so you don’t have to type out the URL
-every time you run a Docker command.
+## Adding an existing host
 
-    $ docker-machine create --url=tcp://50.134.234.20:2376 custombox
+You can add a host (already running Docker or not) with the `generic` driver.
+If the Docker daemon is not running on your host, it will be installed.
+If the Docker daemon already exist, new certificates will be installed and thus
+will trigger a daemon restart.
+
+
+    $ docker-machine create -d generic --generic-ip-address=50.134.234.20 custombox
     $ docker-machine ls
     NAME        ACTIVE   DRIVER    STATE     URL
-    custombox   *        none      Running   tcp://50.134.234.20:2376
+    custombox   *        generic   Running   tcp://50.134.234.20:2376
 
 ## Using Docker Machine with Docker Swarm
 

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -44,7 +44,7 @@ customize.
 
     Options:
 
-       --driver, -d "none"                                                                                  Driver to create machine with.
+       --driver, -d "generic"                                                                               Driver to create machine with.
        --engine-install-url "https://get.docker.com"                                                        Custom URL to use for engine installation [$MACHINE_DOCKER_INSTALL_URL]
        --engine-opt [--engine-opt option --engine-opt option]                                               Specify arbitrary flags to include with the created engine in the form flag=value
        --engine-insecure-registry [--engine-insecure-registry option --engine-insecure-registry option]     Specify insecure registries to allow with the created engine
@@ -78,7 +78,7 @@ invoking the `create` help text.
 
     Options:
 
-       --driver, -d "none"                                                                                  Driver to create machine with.
+       --driver, -d "generic"                                                                               Driver to create machine with.
        --engine-env [--engine-env option --engine-env option]                                               Specify environment variables to set in the engine
        --engine-insecure-registry [--engine-insecure-registry option --engine-insecure-registry option]     Specify insecure registries to allow with the created engine
        --engine-install-url "https://get.docker.com"                                                        Custom URL to use for engine installation [$MACHINE_DOCKER_INSTALL_URL]

--- a/drivers/test/driver.go
+++ b/drivers/test/driver.go
@@ -1,4 +1,4 @@
-package none
+package test
 
 import (
 	"fmt"
@@ -9,11 +9,10 @@ import (
 	"github.com/docker/machine/libmachine/state"
 )
 
-const driverName = "none"
+const driverName = "test"
 
-// Driver is the driver used when no driver is selected. It is used to
-// connect to existing Docker hosts by specifying the URL of the host as
-// an option.
+// Driver test is a driver solely used during docker-machine development.
+// It is not meant to be used for installing or registering docker machines.
 type Driver struct {
 	*drivers.BaseDriver
 	URL string

--- a/libmachine/host/host_test.go
+++ b/libmachine/host/host_test.go
@@ -3,7 +3,7 @@ package host
 import (
 	"testing"
 
-	_ "github.com/docker/machine/drivers/none"
+	_ "github.com/docker/machine/drivers/test"
 )
 
 func TestValidateHostnameValid(t *testing.T) {

--- a/libmachine/host/migrate.go
+++ b/libmachine/host/migrate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/drivers/test"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/version"
 )
@@ -16,7 +16,7 @@ var (
 )
 
 type RawDataDriver struct {
-	*none.Driver
+	*test.Driver
 	Data []byte // passed directly back when invoking json.Marshal on this type
 }
 
@@ -59,7 +59,7 @@ func MigrateHost(h *Host, data []byte) (*Host, bool, error) {
 
 	globalStorePath := filepath.Dir(filepath.Dir(migratedHostMetadata.HostOptions.AuthOptions.StorePath))
 
-	driver := &RawDataDriver{none.NewDriver(h.Name, globalStorePath), nil}
+	driver := &RawDataDriver{test.NewDriver(h.Name, globalStorePath), nil}
 
 	if migratedHostMetadata.ConfigVersion > version.ConfigVersion {
 		return nil, false, errConfigFromFuture

--- a/libmachine/host/migrate_test.go
+++ b/libmachine/host/migrate_test.go
@@ -3,7 +3,7 @@ package host
 import (
 	"testing"
 
-	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/drivers/test"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,7 +62,7 @@ func TestMigrateHost(t *testing.T) {
 					//
 					// These default StorePath settings get over-written when we
 					// instantiate the plugin driver, but this seems entirely incidental.
-					Driver: none.NewDriver("default", "."),
+					Driver: test.NewDriver("default", "."),
 				},
 			},
 			expectedMigrationPerformed: false,
@@ -124,7 +124,7 @@ func TestMigrateHost(t *testing.T) {
 					Data: []byte(`{"MachineName": "default"}`),
 
 					// TODO: See note above.
-					Driver: none.NewDriver("default", "."),
+					Driver: test.NewDriver("default", "."),
 				},
 			},
 			expectedMigrationPerformed: false,
@@ -162,7 +162,7 @@ func TestMigrateHost(t *testing.T) {
 				RawDriver:  []byte(`{"MachineName":"default","StorePath":"/Users/nathanleclaire/.docker/machine"}`),
 				Driver: &RawDataDriver{
 					Data:   []byte(`{"MachineName":"default","StorePath":"/Users/nathanleclaire/.docker/machine"}`),
-					Driver: none.NewDriver("default", "/Users/nathanleclaire/.docker/machine"),
+					Driver: test.NewDriver("default", "/Users/nathanleclaire/.docker/machine"),
 				},
 			},
 			expectedMigrationPerformed: true,

--- a/libmachine/hosttest/default_test_host.go
+++ b/libmachine/hosttest/default_test_host.go
@@ -1,7 +1,7 @@
 package hosttest
 
 import (
-	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/drivers/test"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
@@ -59,13 +59,12 @@ func GetDefaultTestHost() (*host.Host, error) {
 		},
 	}
 
-	driver := none.NewDriver(DefaultHostName, "/tmp/artifacts")
+	driver := test.NewDriver(DefaultHostName, "/tmp/artifacts")
 
 	host := &host.Host{
 		ConfigVersion: version.ConfigVersion,
 		Name:          DefaultHostName,
 		Driver:        driver,
-		DriverName:    "none",
 		HostOptions:   hostOptions,
 	}
 

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -103,8 +103,8 @@ func (api *Client) Create(h *host.Host) error {
 		return fmt.Errorf("Error saving host to store after attempting creation: %s", err)
 	}
 
-	// TODO: Not really a fan of just checking "none" here.
-	if h.Driver.DriverName() != "none" {
+	// TODO: Not really a fan of just checking "test" here.
+	if h.Driver.DriverName() != "test" {
 		log.Info("Waiting for machine to be running, this may take a few minutes...")
 		if err := mcnutils.WaitFor(drivers.MachineInState(h.Driver, state.Running)); err != nil {
 			return fmt.Errorf("Error waiting for machine to be running: %s", err)

--- a/libmachine/persist/filestore_test.go
+++ b/libmachine/persist/filestore_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/machine/commands/mcndirs"
-	"github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/drivers/test"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/hosttest"
 )
@@ -218,10 +218,10 @@ func TestStoreLoad(t *testing.T) {
 		t.Fatal("Expected driver loaded from store to be of type *host.RawDataDriver and it was not")
 	}
 
-	realDriver := none.NewDriver(h.Name, store.Path)
+	realDriver := test.NewDriver(h.Name, store.Path)
 
 	if err := json.Unmarshal(rawDataDriver.Data, &realDriver); err != nil {
-		t.Fatalf("Error unmarshaling rawDataDriver data into concrete 'none' driver: %s", err)
+		t.Fatalf("Error unmarshaling rawDataDriver data into concrete 'test' driver: %s", err)
 	}
 
 	h.Driver = realDriver

--- a/mk/release.mk
+++ b/mk/release.mk
@@ -6,6 +6,7 @@ release-checksum:
 	@:
 
 release-pack:
+	find ./bin -name docker-machine-driver-test* -exec rm {} \;
 	find ./bin -type d -mindepth 1 -exec zip -r -j {}.zip {} \;
 
 release: clean dco fmt test test-long build-x release-pack release-checksum

--- a/test/integration/cli/create-rm.bats
+++ b/test/integration/cli/create-rm.bats
@@ -8,86 +8,87 @@ load ${BASE_TEST_DIR}/helpers.bash
   [[ ${lines[0]} == "Driver \"bogus\" not found. Do you have the plugin binary accessible in your PATH?" ]]
 }
 
-@test "none: create with no name fails 'machine create -d none'" {
-  run machine create -d none
+@test "test: create with no name fails 'machine create -d test'" {
+  run machine create -d test
   last=$((${#lines[@]} - 1))
   [ "$status" -eq 1 ]
   [[ ${lines[$last]} == "Error: No machine name specified" ]]
 }
 
-@test "none: create with invalid name fails 'machine create -d none --url none ∞'" {
-  run machine create -d none --url none ∞
+@test "test: create with invalid name fails 'machine create -d test --url none ∞'" {
+  run machine create -d test --url none ∞
   last=$((${#lines[@]} - 1))
   [ "$status" -eq 1 ]
   [[ ${lines[$last]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
 }
 
-@test "none: create with invalid name fails 'machine create -d none --url none -'" {
-  run machine create -d none --url none -
+@test "test: create with invalid name fails 'machine create -d test --url none -'" {
+  run machine create -d test --url none -
   [ "$status" -eq 1 ]
   [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
 }
 
-@test "none: create with invalid name fails 'machine create -d none --url none .'" {
-  run machine create -d none --url none .
+@test "test: create with invalid name fails 'machine create -d test --url none .'" {
+  run machine create -d test --url none .
   [ "$status" -eq 1 ]
   [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
 }
 
-@test "none: create with invalid name fails 'machine create -d none --url none ..'" {
-  run machine create -d none --url none ..
+@test "test: create with invalid name fails 'machine create -d test --url none ..'" {
+  run machine create -d test --url none ..
   [ "$status" -eq 1 ]
   [[ ${lines[0]} == "Error creating machine: Invalid hostname specified. Allowed hostname chars are: 0-9a-zA-Z . -" ]]
 }
 
-@test "none: create with weird but valid name succeeds 'machine create -d none --url none a'" {
-  run machine create -d none --url none a
+@test "test: create with weird but valid name succeeds 'machine create -d test --url none a'" {
+  run machine create -d test --url none a
   [ "$status" -eq 0 ]
 }
 
-@test "none: name is case insensitive 'machine create -d none --url none A'" {
+@test "test: name is case insensitive 'machine create -d test --url none A'" {
   skip
-  run machine create -d none --url none A
+  run machine create -d test --url none A
   [ "$status" -eq 1 ]
+
   [[ ${lines[0]} == "Error creating machine: Machine A already exists" ]]
 }
 
-@test "none: fail with extra argument 'machine create -d none --url none a extra'" {
-  run machine create -d none --url none a extra
+@test "test: fail with extra argument 'machine create -d test --url none a extra'" {
+  run machine create -d test --url none a extra
   [ "$status" -eq 1 ]
   [[ ${lines[0]} == "Invalid command line. Found extra arguments [extra]" ]]
 }
 
-@test "none: create with weird but valid name succeeds 'machine create -d none --url none 0'" {
-  run machine create -d none --url none 0
+@test "test: create with weird but valid name succeeds 'machine create -d test --url none 0'" {
+  run machine create -d test --url none 0
   [ "$status" -eq 0 ]
 }
 
-@test "none: rm with no name fails 'machine rm'" {
+@test "test: rm with no name fails 'machine rm'" {
   run machine rm
   last=$(expr ${#lines[@]} - 1)
   [ "$status" -eq 1 ]
   [[ ${lines[$last]} == "Error: Expected to get one or more machine names as arguments" ]]
 }
 
-@test "none: rm non existent machine fails 'machine rm ∞'" {
+@test "test: rm non existent machine fails 'machine rm ∞'" {
   run machine rm ∞
   [ "$status" -eq 1 ]
   [[ ${lines[0]} == "Error removing host \"∞\": Host does not exist: \"∞\"" ]]
 }
 
-@test "none: rm is successful 'machine rm 0'" {
+@test "test: rm is successful 'machine rm 0'" {
   run machine rm 0
   [ "$status" -eq 0 ]
 }
 
 # Should be replaced by the test below
-@test "none: rm is successful 'machine rm a'" {
+@test "test: rm is successful 'machine rm a'" {
   run machine rm a
   [ "$status" -eq 0 ]
 }
 
-@test "none: rm is case insensitive 'machine rm A'" {
+@test "test: rm is case insensitive 'machine rm A'" {
   skip
   run machine rm A
   [ "$status" -eq 0 ]

--- a/test/integration/cli/ls.bats
+++ b/test/integration/cli/ls.bats
@@ -3,9 +3,9 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 setup () {
-  machine create -d none --url none testmachine3
-  machine create -d none --url none testmachine2
-  machine create -d none --url none testmachine
+  machine create -d test --url none testmachine3
+  machine create -d test --url none testmachine2
+  machine create -d test --url none testmachine
 }
 
 teardown () {
@@ -14,13 +14,13 @@ teardown () {
 }
 
 bootstrap_swarm () {
-  machine create -d none --url tcp://127.0.0.1:2375 --swarm --swarm-master --swarm-discovery token://deadbeef testswarm
-  machine create -d none --url tcp://127.0.0.1:2375 --swarm --swarm-discovery token://deadbeef testswarm2
-  machine create -d none --url tcp://127.0.0.1:2375 --swarm --swarm-discovery token://deadbeef testswarm3
+  machine create -d test --url tcp://127.0.0.1:2375 --swarm --swarm-master --swarm-discovery token://deadbeef testswarm
+  machine create -d test --url tcp://127.0.0.1:2375 --swarm --swarm-discovery token://deadbeef testswarm2
+  machine create -d test --url tcp://127.0.0.1:2375 --swarm --swarm-discovery token://deadbeef testswarm3
 }
 
-@test "ls: filter on driver 'machine ls --filter driver=none'" {
-  run machine ls --filter driver=none
+@test "ls: filter on driver 'machine ls --filter driver=test'" {
+  run machine ls --filter driver=test
   [ "$status" -eq 0 ]
   [[ ${#lines[@]} == 4 ]]
   [[ ${lines[1]} =~ "testmachine" ]]
@@ -28,8 +28,8 @@ bootstrap_swarm () {
   [[ ${lines[3]} =~ "testmachine3" ]]
 }
 
-@test "ls: filter on driver 'machine ls -q --filter driver=none'" {
-  run machine ls -q --filter driver=none
+@test "ls: filter on driver 'machine ls -q --filter driver=test'" {
+  run machine ls -q --filter driver=test
   [ "$status" -eq 0 ]
   [[ ${#lines[@]} == 3 ]]
   [[ ${lines[0]} == "testmachine" ]]
@@ -131,9 +131,9 @@ bootstrap_swarm () {
   [[ ${lines[2]} == "testswarm3" ]]
 }
 
-@test "ls: multi filter 'machine ls -q --filter swarm=testswarm --filter name=\"^t.*e\" --filter driver=none --filter state=\"Running\"'" {
+@test "ls: multi filter 'machine ls -q --filter swarm=testswarm --filter name=\"^t.*e\" --filter driver=test --filter state=\"Running\"'" {
   bootstrap_swarm
-  run machine ls -q --filter swarm=testswarm --filter name="^t.*e" --filter driver=none --filter state="Running"
+  run machine ls -q --filter swarm=testswarm --filter name="^t.*e" --filter driver=test --filter state="Running"
   [ "$status" -eq 0 ]
   [[ ${#lines[@]} == 3 ]]
   [[ ${lines[0]} == "testswarm" ]]


### PR DESCRIPTION
Following @ehazlett advice [here](https://github.com/docker/machine/issues/643#issuecomment-76769741) this PR rename the none driver to test, and remove it from the release package, set the `generic` driver as default driver and remove the documentation related to it. We keep using it to run the various integration test, where it is of great help in allowing a faster execution time.

The driver `none` in it's current state is not usable. The hardcoded ssh user is a blank string the ssh port is 0, and those can not be overriden.

The main purpose of this driver,or at least how it was partially documented to, is to register an existing running docker instance, which is what the `generic` driver do.

This will close #2270, #2355, #1532, #1435 and #643