### PR TITLE
Display driver in error without crashing

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -18,12 +18,12 @@ func cmdActive(c CommandLine, api libmachine.API) error {
 		return errTooManyArguments
 	}
 
-	hosts, err := persist.LoadAllHosts(api)
+	hosts, hostsInError, err := persist.LoadAllHosts(api)
 	if err != nil {
 		return fmt.Errorf("Error getting active host: %s", err)
 	}
 
-	items := getHostListItems(hosts)
+	items := getHostListItems(hosts, hostsInError)
 
 	for _, item := range items {
 		if item.Active {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -64,9 +64,14 @@ func (c *contextCommandLine) Application() *cli.App {
 }
 
 func runAction(actionName string, c CommandLine, api libmachine.API) error {
-	hosts, err := persist.LoadHosts(api, c.Args())
-	if err != nil {
-		return err
+	hosts, hostsInError := persist.LoadHosts(api, c.Args())
+
+	if len(hostsInError) > 0 {
+		errs := []error{}
+		for _, err := range hostsInError {
+			errs = append(errs, err)
+		}
+		return consolidateErrs(errs)
 	}
 
 	if len(hosts) == 0 {


### PR DESCRIPTION
This will prevent `docker-machine ls` to crash with no explanation whenever you have a host in your configuration that is broken.

This is super useful, if you had a driver in your path and it has been removed.

step to reproduce.

1. Have an old release ( 0.5.0 for instance ) of docker machine installed in your path through toolbox
2. Setup a machine with the `none` driver for instance.
3. build and remove the none driver `make clean build && rm bin/docker-machine-driver-none`
4. setup your path to pickup your locally build binaries `export PATH=$(pwd)/bin:$PATH`
5. run `docker-machine ls`

docker-machine will pick-up the none driver from your path, and it will crash when run with the new client.

Final result ( check foo2 ) :
```
> docker-machine ls
NAME          ACTIVE   DRIVER       STATE     URL                         SWARM   ERRORS
default       *        virtualbox   Running   tcp://192.168.99.100:2376           
foo           -        generic      Running   tcp://178.32.221.192:2376           
foo2          -        not found    Error                                         rpc: can't find service RPCServerDriver.GetVersion
foo3          -        generic      Running   tcp://178.32.222.191:2376           
fromhome      -        virtualbox   Stopped                                       
tobekilled    -        virtualbox   Running   tcp://192.168.99.164:2376           
tobekilled3   -        virtualbox   Running   tcp://192.168.99.190:2376       
```

