### PR TITLE
FIX 2444 Command scp being called twice

### DIFF
--- a/commands/scp.go
+++ b/commands/scp.go
@@ -70,10 +70,6 @@ func cmdScp(c CommandLine, api libmachine.API) error {
 		return err
 	}
 
-	if err := runCmdWithStdIo(*cmd); err != nil {
-		return err
-	}
-
 	return runCmdWithStdIo(*cmd)
 }
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>