### PR TITLE
Add the --virtualbox-host-dns-resolver flag

### DIFF
--- a/docs/drivers/virtualbox.md
+++ b/docs/drivers/virtualbox.md
@@ -26,6 +26,7 @@ Options:
 -   `--virtualbox-memory`: Size of memory for the host in MB.
 -   `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to single CPU.
 -   `--virtualbox-disk-size`: Size of disk for the host in MB.
+-   `--virtualbox-host-dns-resolver`: Use the host DNS resolver. (Boolean value, defaults to false)
 -   `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
 -   `--virtualbox-import-boot2docker-vm`: The name of a Boot2Docker VM to import.
 -   `--virtualbox-hostonly-cidr`: The CIDR of the host only adapter.
@@ -67,6 +68,7 @@ Environment variables and default values:
 | `--virtualbox-memory`                | `VIRTUALBOX_MEMORY_SIZE`           | `1024`                   |
 | `--virtualbox-cpu-count`             | `VIRTUALBOX_CPU_COUNT`             | `1`                      |
 | `--virtualbox-disk-size`             | `VIRTUALBOX_DISK_SIZE`             | `20000`                  |
+| `--virtualbox-host-dns-resolver`     | `VIRTUALBOX_HOST_DNS_RESOLVER`     | `false`                  |
 | `--virtualbox-boot2docker-url`       | `VIRTUALBOX_BOOT2DOCKER_URL`       | _Latest boot2docker url_ |
 | `--virtualbox-import-boot2docker-vm` | `VIRTUALBOX_BOOT2DOCKER_IMPORT_VM` | `boot2docker-vm`         |
 | `--virtualbox-hostonly-cidr`         | `VIRTUALBOX_HOSTONLY_CIDR`         | `192.168.99.1/24`        |

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -97,6 +97,7 @@ invoking the `create` help text.
        --virtualbox-boot2docker-url                                                                         The URL of the boot2docker image. Defaults to the latest available version [$VIRTUALBOX_BOOT2DOCKER_URL]
        --virtualbox-cpu-count "1"                                                                           number of CPUs for the machine (-1 to use the number of CPUs available) [$VIRTUALBOX_CPU_COUNT]
        --virtualbox-disk-size "20000"                                                                       Size of disk for host in MB [$VIRTUALBOX_DISK_SIZE]
+       --virtualbox-host-dns-resolver                                                                       Use the host DNS resolver [$VIRTUALBOX_HOST_DNS_RESOLVER]
        --virtualbox-dns-proxy                                                                               Proxy all DNS requests to the host [$VIRTUALBOX_DNS_PROXY]
        --virtualbox-hostonly-cidr "192.168.99.1/24"                                                         Specify the Host Only CIDR [$VIRTUALBOX_HOSTONLY_CIDR]
        --virtualbox-hostonly-nicpromisc "deny"                                                              Specify the Host Only Network Adapter Promiscuous Mode [$VIRTUALBOX_HOSTONLY_NIC_PROMISC]

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -52,6 +52,7 @@ type Driver struct {
 	DiskSize            int
 	Boot2DockerURL      string
 	Boot2DockerImportVM string
+	HostDNSResolver     bool
 	HostOnlyCIDR        string
 	HostOnlyNicType     string
 	HostOnlyPromiscMode string
@@ -109,6 +110,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "The name of a Boot2Docker VM to import",
 			Value:  defaultBoot2DockerImportVM,
 			EnvVar: "VIRTUALBOX_BOOT2DOCKER_IMPORT_VM",
+		},
+		mcnflag.BoolFlag{
+			Name:   "virtualbox-host-dns-resolver",
+			Usage:  "Use the host DNS resolver",
+			EnvVar: "VIRTUALBOX_HOST_DNS_RESOLVER",
 		},
 		mcnflag.StringFlag{
 			Name:   "virtualbox-hostonly-cidr",
@@ -179,6 +185,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SwarmDiscovery = flags.String("swarm-discovery")
 	d.SSHUser = "docker"
 	d.Boot2DockerImportVM = flags.String("virtualbox-import-boot2docker-vm")
+	d.HostDNSResolver = flags.Bool("virtualbox-host-dns-resolver")
 	d.HostOnlyCIDR = flags.String("virtualbox-hostonly-cidr")
 	d.HostOnlyNicType = flags.String("virtualbox-hostonly-nictype")
 	d.HostOnlyPromiscMode = flags.String("virtualbox-hostonly-nicpromisc")
@@ -309,6 +316,11 @@ func (d *Driver) Create() error {
 		cpus = 32
 	}
 
+	hostDNSResolver := "off"
+	if d.HostDNSResolver {
+		hostDNSResolver = "on"
+	}
+
 	dnsProxy := "off"
 	if d.DNSProxy {
 		dnsProxy = "on"
@@ -326,7 +338,7 @@ func (d *Driver) Create() error {
 		"--acpi", "on",
 		"--ioapic", "on",
 		"--rtcuseutc", "on",
-		"--natdnshostresolver1", "off",
+		"--natdnshostresolver1", hostDNSResolver,
 		"--natdnsproxy1", dnsProxy,
 		"--cpuhotplug", "off",
 		"--pae", "on",


### PR DESCRIPTION
This adds a new flag, `--virtualbox-host-dns-resolver`, that tells VirtualBox to start the VM with `--natdnshostresolver1 on` instead of `off`.

A common problem I've run into is getting DNS to work correctly in VirtualBox VMs when I'm connected to a VPN that does special magic to the host's DNS resolver. This makes it easier to set up a Docker host with working DNS without having to shut it down and run the `VBoxManage` command manually.

The integration test for this isn't great, because I couldn't find a way to inspect the `natdnshostresolverX` property. I'd love to hear any suggestions for how to properly test this! :rainbow: 

Signed-off-by: Joe Friedl <joe@joefriedl.net>