### PR TITLE
Fixes #1931 - config.json integrity when disk is full

### DIFF
--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -31,7 +31,31 @@ func (s Filestore) GetMachinesDir() string {
 }
 
 func (s Filestore) saveToFile(data []byte, file string) error {
-	return ioutil.WriteFile(file, data, 0600)
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return ioutil.WriteFile(file, data, 0600)
+	}
+
+	tmpfi, err := ioutil.TempFile(filepath.Dir(file), "config.json.tmp")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpfi.Name())
+
+	err = ioutil.WriteFile(tmpfi.Name(), data, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(file)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(tmpfi.Name(), file)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s Filestore) Save(host *host.Host) error {

--- a/libmachine/persist/filestore_test.go
+++ b/libmachine/persist/filestore_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/docker/machine/commands/mcndirs"
@@ -51,6 +52,17 @@ func TestStoreSave(t *testing.T) {
 	path := filepath.Join(store.GetMachinesDir(), h.Name)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Fatalf("Host path doesn't exist: %s", path)
+	}
+
+	files, _ := ioutil.ReadDir(path)
+	for _, f := range files {
+		r, err := regexp.Compile("config.json.tmp*")
+		if err != nil {
+			t.Fatalf("Failed to compile regexp string")
+		}
+		if r.MatchString(f.Name()) {
+			t.Fatalf("Failed to remove temp filestore:%s", f.Name())
+		}
 	}
 }
 


### PR DESCRIPTION
Now this change ensures `config.json` is first written into a temp-file and
rename into the original file, if no errors from the FS. If ENOSPC occurs on write,
when the machine is restarted, the previous `config.json` is still available on startup.

Steps to reproduce the issue:
1. Have a already vm's which is already in running state  
2. Make sure directory "~/.machine" under partition is filled up. 
3. Now run `docker-machine stop dev1` (with the previous code the `config.json` file overwritten to empty file) 
4. Start `docker-machine start dev1`, returns error `Error getting migrated host: unexpected end of JSON input` 

Tested the the change manually, below the output:

* Have started 'dev7' 
```
$ PATH="$PWD/bin:$PATH" bin/docker-machine ls 
NAME               ACTIVE   DRIVER       STATE     URL                         SWARM   ERRORS
dev                -        virtualbox   Stopped                                       
dev7               -        virtualbox   Running   tcp://192.168.99.100:2376      
```

* Stop dev7 (after making sure the partition is filled up)
```
$ PATH="$PWD/bin:$PATH" bin/docker-machine stop dev7
(dev7) Stopping VM...

$ df -lh
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdb3       411G  387G  8.0K 100% /home
```

* With this change in effect the file store is saved into an temp-file, avoids corrupting the working `config.json` file.

```
$ PATH="$PWD/bin:$PATH" bin/docker-machine stop dev7
(dev7) Stopping VM...
Error saving host to store: write /home/user/.docker/machine/machines/dev7/config.json.tmp141651394: no space left on device
```

* Restarting the dev7 does not have issues, now with the fix:
``` 
$ PATH="$PWD/bin:$PATH" bin/docker-machine start dev7
(dev7) Starting VM...
Started machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
```

* Prior to this code change, machine stop ends up with the following output, overwritting `config.json`:
```
$ docker-machine stop dev8
(dev8) Stopping VM...
Error saving host to store: write /home/user/.docker/machine/machines/dev8/config.json: no space left on device
```

Would appreciate any feedback and suggestions on adding tests (unit or integration test) for this scenario, I am unable to automate for UT or integration-test/bats ?

Signed-off-by: Anil Belur <askb23@gmail.com>