### PR TITLE
Typo in EC2 Driver

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -138,7 +138,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   "amazonec2-ssh-user",
-			Usage:  "set the name of the ssh user",
+			Usage:  "Set the name of the ssh user",
 			Value:  defaultSSHUser,
 			EnvVar: "AWS_SSH_USER",
 		},


### PR DESCRIPTION
Fix typo in Amazon EC2 driver. Will close stalled #2428