### PR TITLE
Fixes issue #2310 - docker-machine ls --filter with engine label

### DIFF
--- a/test/integration/cli/ls.bats
+++ b/test/integration/cli/ls.bats
@@ -3,6 +3,8 @@
 load ${BASE_TEST_DIR}/helpers.bash
 
 setup () {
+  machine create -d none --url none --engine-label app=1 testmachine5
+  machine create -d none --url none --engine-label foo=bar --engine-label app=1 testmachine4
   machine create -d none --url none testmachine3
   machine create -d none --url none testmachine2
   machine create -d none --url none testmachine
@@ -19,19 +21,42 @@ bootstrap_swarm () {
   machine create -d none --url tcp://127.0.0.1:2375 --swarm --swarm-discovery token://deadbeef testswarm3
 }
 
+@test "ls: filter on label 'machine ls --filter label=foo=bar'" {
+  run machine ls --filter label=foo=bar
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} == 2 ]]
+  [[ ${lines[1]} =~ "testmachine4" ]]
+}
+
+@test "ls: mutiple filters on label 'machine ls --filter label=foo=bar --filter label=app=1'" {
+  run machine ls --filter label=foo=bar --filter label=app=1
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} == 3 ]]
+  [[ ${lines[1]} =~ "testmachine4" ]]
+  [[ ${lines[2]} =~ "testmachine5" ]]
+}
+
+@test "ls: non-existing filter on label 'machine ls --filter label=invalid=filter'" {
+  run machine ls --filter label=invalid=filter
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} == 1 ]]
+}
+
 @test "ls: filter on driver 'machine ls --filter driver=none'" {
   run machine ls --filter driver=none
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 4 ]]
+  [[ ${#lines[@]} == 6 ]]
   [[ ${lines[1]} =~ "testmachine" ]]
   [[ ${lines[2]} =~ "testmachine2" ]]
   [[ ${lines[3]} =~ "testmachine3" ]]
+  [[ ${lines[4]} =~ "testmachine4" ]]
+  [[ ${lines[5]} =~ "testmachine5" ]]
 }
 
 @test "ls: filter on driver 'machine ls -q --filter driver=none'" {
   run machine ls -q --filter driver=none
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
+  [[ ${#lines[@]} == 5 ]]
   [[ ${lines[0]} == "testmachine" ]]
   [[ ${lines[1]} == "testmachine2" ]]
   [[ ${lines[2]} == "testmachine3" ]]
@@ -41,7 +66,7 @@ bootstrap_swarm () {
   # Default state for 'none' driver is "Running"
   run machine ls --filter state="Running"
   [ "$status" -eq 0  ]
-  [[ ${#lines[@]} == 4 ]]
+  [[ ${#lines[@]} == 6 ]]
   [[ ${lines[1]} =~ "testmachine" ]]
   [[ ${lines[2]} =~ "testmachine2" ]]
   [[ ${lines[3]} =~ "testmachine3" ]]
@@ -73,7 +98,7 @@ bootstrap_swarm () {
 @test "ls: filter on state 'machine ls -q --filter state=\"Running\"'" {
   run machine ls -q --filter state="Running"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
+  [[ ${#lines[@]} == 5 ]]
   [[ ${lines[0]} == "testmachine" ]]
   [[ ${lines[1]} == "testmachine2" ]]
   [[ ${lines[2]} == "testmachine3" ]]
@@ -96,7 +121,7 @@ bootstrap_swarm () {
 @test "ls: filter on name with regex 'machine ls --filter name=\"^t.*e\"'" {
   run machine ls --filter name="^t.*e"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 4 ]]
+  [[ ${#lines[@]} == 6 ]]
   [[ ${lines[1]} =~ "testmachine" ]]
   [[ ${lines[2]} =~ "testmachine2" ]]
   [[ ${lines[3]} =~ "testmachine3" ]]
@@ -105,7 +130,7 @@ bootstrap_swarm () {
 @test "ls: filter on name with regex 'machine ls -q --filter name=\"^t.*e\"'" {
   run machine ls -q --filter name="^t.*e"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} == 3 ]]
+  [[ ${#lines[@]} == 5 ]]
   [[ ${lines[0]} == "testmachine" ]]
   [[ ${lines[1]} == "testmachine2" ]]
   [[ ${lines[2]} == "testmachine3" ]]


### PR DESCRIPTION
Changelog:
* Added a new members `Labels` to `FilterOptions struct`, and `EngineOptions` to `HostListItem struct`. `HostListItems` are already being read from the file store `config.json` store engine `labels`  
* Modified `parseFilters` and added new `func matchesLabel()` which compares the one or more label values provided as input.
* Also the changes include added tests for UT and integration. 
* Note: Have kept `--filter label=<key>=<value>` syntax as its similar to `docker images --filter` to keep the usability consistent.  

With these changes the filtering engine label would look something similar to the below:

```
$ PATH="$PWD/bin:$PATH" bin/docker-machine create --engine-label foo=bar1 --engine-label appengine=1 --driver none --url none stage
Running pre-create checks...
Creating machine...
To see how to connect Docker to this machine, run: bin/docker-machine env stage

$ PATH="$PWD/bin:$PATH" bin/docker-machine ls --filter label=appengine=1 --filter label=foo=bar1 
NAME         ACTIVE   DRIVER       STATE     URL    SWARM   ERRORS
dev9          -        virtualbox   Stopped                  
stage         -        none         Running   none           
prod          -         none         Running   none           

```
Please review and provide feedback. //cc @docker/machine-maintainers

Signed-off-by: Anil Belur <askb23@gmail.com>