### PR TITLE
Allow virtualbox DNSProxy override

### DIFF
--- a/docs/drivers/virtualbox.md
+++ b/docs/drivers/virtualbox.md
@@ -32,6 +32,7 @@ Options:
 -   `--virtualbox-hostonly-nictype`: Host Only Network Adapter Type. Possible values are are '82540EM' (Intel PRO/1000), 'Am79C973' (PCnet-FAST III) and 'virtio-net' Paravirtualized network adapter.
 -   `--virtualbox-hostonly-nicpromisc`: Host Only Network Adapter Promiscuous Mode. Possible options are deny , allow-vms, allow-all 
 -   `--virtualbox-no-share`: Disable the mount of your home directory
+-   `--virtualbox-dns-proxy`: Proxy all DNS requests to the host (Boolean value, default to false)
 
 The `--virtualbox-boot2docker-url` flag takes a few different forms. By
 default, if no value is specified for this flag, Machine will check locally for
@@ -72,3 +73,4 @@ Environment variables and default values:
 | `--virtualbox-hostonly-nictype`      | `VIRTUALBOX_HOSTONLY_NIC_TYPE`     | `82540EM`                |
 | `--virtualbox-hostonly-nicpromisc`   | `VIRTUALBOX_HOSTONLY_NIC_PROMISC`  | `deny`                   |
 | `--virtualbox-no-share`              | `VIRTUALBOX_NO_SHARE`              | `false`                  |
+| `--virtualbox-dns-proxy`             | `VIRTUALBOX_DNS_PROXY              | `false`                  |

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -97,6 +97,7 @@ invoking the `create` help text.
        --virtualbox-boot2docker-url                                                                         The URL of the boot2docker image. Defaults to the latest available version [$VIRTUALBOX_BOOT2DOCKER_URL]
        --virtualbox-cpu-count "1"                                                                           number of CPUs for the machine (-1 to use the number of CPUs available) [$VIRTUALBOX_CPU_COUNT]
        --virtualbox-disk-size "20000"                                                                       Size of disk for host in MB [$VIRTUALBOX_DISK_SIZE]
+       --virtualbox-dns-proxy                                                                               Proxy all DNS requests to the host [$VIRTUALBOX_DNS_PROXY]
        --virtualbox-hostonly-cidr "192.168.99.1/24"                                                         Specify the Host Only CIDR [$VIRTUALBOX_HOSTONLY_CIDR]
        --virtualbox-hostonly-nicpromisc "deny"                                                              Specify the Host Only Network Adapter Promiscuous Mode [$VIRTUALBOX_HOSTONLY_NIC_PROMISC]
        --virtualbox-hostonly-nictype "82540EM"                                                              Specify the Host Only Network Adapter Type [$VIRTUALBOX_HOSTONLY_NIC_TYPE]

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -56,6 +56,7 @@ type Driver struct {
 	HostOnlyNicType     string
 	HostOnlyPromiscMode string
 	NoShare             bool
+	DNSProxy            bool
 }
 
 // NewDriver creates a new VirtualBox driver with default settings.
@@ -132,6 +133,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Disable the mount of your home directory",
 			EnvVar: "VIRTUALBOX_NO_SHARE",
 		},
+		mcnflag.BoolFlag{
+			Name:   "virtualbox-dns-proxy",
+			Usage:  "Proxy all DNS requests to the host",
+			EnvVar: "VIRTUALBOX_DNS_PROXY",
+		},
 	}
 }
 
@@ -177,6 +183,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.HostOnlyNicType = flags.String("virtualbox-hostonly-nictype")
 	d.HostOnlyPromiscMode = flags.String("virtualbox-hostonly-nicpromisc")
 	d.NoShare = flags.Bool("virtualbox-no-share")
+	d.DNSProxy = flags.Bool("virtualbox-dns-proxy")
 
 	return nil
 }
@@ -302,6 +309,11 @@ func (d *Driver) Create() error {
 		cpus = 32
 	}
 
+	dnsProxy := "off"
+	if d.DNSProxy {
+		dnsProxy = "on"
+	}
+
 	if err := d.vbm("modifyvm", d.MachineName,
 		"--firmware", "bios",
 		"--bioslogofadein", "off",
@@ -315,7 +327,7 @@ func (d *Driver) Create() error {
 		"--ioapic", "on",
 		"--rtcuseutc", "on",
 		"--natdnshostresolver1", "off",
-		"--natdnsproxy1", "off",
+		"--natdnsproxy1", dnsProxy,
 		"--cpuhotplug", "off",
 		"--pae", "on",
 		"--hpet", "on",

--- a/test/integration/virtualbox/dns.bats
+++ b/test/integration/virtualbox/dns.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+only_if_env DRIVER virtualbox
+
+@test "$DRIVER: Create a vm with a dns proxy set" {
+  run machine create -d $DRIVER --virtualbox-dns-proxy=true $NAME
+  [[ ${status} -eq 0 ]]
+}
+
+@test "$DRIVER: Check DNSProxy flag is properly set during machine creation" {
+  run bash -c "cat ${MACHINE_STORAGE_PATH}/machines/$NAME/$NAME/Logs/VBox.log | grep DNSProxy | grep '(1)'"
+  [[ ${status} -eq 0 ]]
+}


### PR DESCRIPTION
Associated with #2448 will allow complete customization of virtualbox dns handling.

Each PR is independant from one another.