### PR TITLE
Fixes #2451 - ensures ls filters `<key>` and `<value>` works case-insensitive

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -113,7 +113,7 @@ func parseFilters(filters []string) (FilterOptions, error) {
 		if len(kv) != 2 {
 			return options, errors.New("Unsupported filter syntax.")
 		}
-		key, value := kv[0], kv[1]
+		key, value := strings.ToLower(kv[0]), kv[1]
 
 		switch key {
 		case "swarm":
@@ -176,7 +176,7 @@ func matchesSwarmName(host *host.Host, swarmNames []string, swarmMasters map[str
 	}
 	for _, n := range swarmNames {
 		if host.HostOptions.SwarmOptions != nil {
-			if n == swarmMasters[host.HostOptions.SwarmOptions.Discovery] {
+			if strings.EqualFold(n, swarmMasters[host.HostOptions.SwarmOptions.Discovery]) {
 				return true
 			}
 		}
@@ -189,7 +189,7 @@ func matchesDriverName(host *host.Host, driverNames []string) bool {
 		return true
 	}
 	for _, n := range driverNames {
-		if host.DriverName == n {
+		if strings.EqualFold(host.DriverName, n) {
 			return true
 		}
 	}
@@ -205,7 +205,7 @@ func matchesState(host *host.Host, states []string) bool {
 		if err != nil {
 			log.Warn(err)
 		}
-		if n == s.String() {
+		if strings.EqualFold(n, s.String()) {
 			return true
 		}
 	}

--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -43,6 +43,11 @@ func TestParseFiltersAll(t *testing.T) {
 	assert.Equal(t, actual, FilterOptions{SwarmName: []string{"foo"}, DriverName: []string{"bar"}, State: []string{"Stopped"}, Name: []string{"dev"}})
 }
 
+func TestParseFiltersAllCase(t *testing.T) {
+	actual, _ := parseFilters([]string{"sWarM=foo", "DrIver=bar", "StaTe=Stopped", "NAMe=dev"})
+	assert.Equal(t, actual, FilterOptions{SwarmName: []string{"foo"}, DriverName: []string{"bar"}, State: []string{"Stopped"}, Name: []string{"dev"}})
+}
+
 func TestParseFiltersDuplicates(t *testing.T) {
 	actual, _ := parseFilters([]string{"swarm=foo", "driver=bar", "name=mark", "swarm=baz", "driver=qux", "state=Running", "state=Starting", "name=time"})
 	assert.Equal(t, actual, FilterOptions{SwarmName: []string{"foo", "baz"}, DriverName: []string{"bar", "qux"}, State: []string{"Running", "Starting"}, Name: []string{"mark", "time"}})
@@ -53,6 +58,16 @@ func TestParseFiltersValueWithEqual(t *testing.T) {
 	assert.Equal(t, actual, FilterOptions{DriverName: []string{"bar=baz"}})
 }
 
+func TestFilterHostsReturnsFiltersValuesCaseInsensitive(t *testing.T) {
+	opts := FilterOptions{
+		SwarmName:  []string{"fOo"},
+		DriverName: []string{"ViRtUaLboX"},
+		State:      []string{"StOPpeD"},
+	}
+	hosts := []*host.Host{}
+	actual := filterHosts(hosts, opts)
+	assert.EqualValues(t, actual, hosts)
+}
 func TestFilterHostsReturnsSameGivenNoFilters(t *testing.T) {
 	opts := FilterOptions{}
 	hosts := []*host.Host{


### PR DESCRIPTION
Fixes #2451 ensure filters `<key>` and `<value>` work when case-insensitive. Added tests to verify filters. Now the following filters should work properly. 

```
$ PATH="$PWD/bin:$PATH" bin/docker-machine ls --filter NAME=all*
NAME        ACTIVE   DRIVER   STATE     URL    SWARM   ERRORS
allstaged   -        none     Running   none           

$ PATH="$PWD/bin:$PATH" bin/docker-machine ls --filter dRiver=virtualBox
NAME   ACTIVE   DRIVER       STATE     URL   SWARM   ERRORS
dev    -        virtualbox   Stopped                 
dev9   -        virtualbox   Stopped                              

$ PATH="$PWD/bin:$PATH" bin/docker-machine ls --filter STATe=STOPPEd
NAME   ACTIVE   DRIVER       STATE     URL   SWARM   ERRORS
dev    -        virtualbox   Stopped                 
dev9   -        virtualbox   Stopped          
```

Signed-off-by: Anil Belur <askb23@gmail.com>