### PR TITLE
Remove redundant flag in integration tests

### DIFF
--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -15,7 +15,7 @@ function quiet_run () {
 
 function cleanup_machines() {
     if [[ $(machine ls -q | wc -l) -ne 0 ]]; then
-        quiet_run machine rm -y -f $(machine ls -q)
+        quiet_run machine rm -f $(machine ls -q)
     fi
 }
 


### PR DESCRIPTION
This is a minor follow up to https://github.com/docker/machine/pull/2404

Signed-off-by: David Gageot <david@gageot.net>