### PR TITLE
Now the returned `err` is being checked to ensure its `Nil`

### DIFF
--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/docker/machine/drivers/fakedriver"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/state"
@@ -45,8 +46,9 @@ func TestParseFiltersAll(t *testing.T) {
 }
 
 func TestParseFiltersAllCase(t *testing.T) {
-	actual, _ := parseFilters([]string{"sWarM=foo", "DrIver=bar", "StaTe=Stopped", "NAMe=dev"})
+	actual, err := parseFilters([]string{"sWarM=foo", "DrIver=bar", "StaTe=Stopped", "NAMe=dev"})
 	assert.Equal(t, actual, FilterOptions{SwarmName: []string{"foo"}, DriverName: []string{"bar"}, State: []string{"Stopped"}, Name: []string{"dev"}})
+	assert.Nil(t, err, "err should be nil")
 }
 
 func TestParseFiltersDuplicates(t *testing.T) {


### PR DESCRIPTION
Now the returned `err` is being checked to ensure its `Nil`

This is a follow up for PR #2473 

Signed-off-by: Anil Belur <askb23@gmail.com>