### PR TITLE
Swarm container net should be host. If use bridge, sometime containers…

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -88,6 +88,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 
 	swarmMasterCmdTemplate := `sudo docker run -d \
 --restart=always \
+--net=host \
 {{range .Env}} -e {{.}}{{end}} \
 --name swarm-agent-master \
 -p {{.Port}}:{{.Port}} \
@@ -104,6 +105,7 @@ manage \
 
 	swarmWorkerCmdTemplate := `sudo docker run -d \
 --restart=always \
+--net=host \
 {{range .Env}} -e {{.}}{{end}} \
 --name swarm-agent \
 {{.SwarmImage}} \


### PR DESCRIPTION
Swarm container network should be host. If use bridge, sometime containers ip addresses conflict.
For example, host A run a swarm agent C which ip is 10.10.0.1. Host B run a swarm agent D which ip is also 10.10.0.1. C and D all bridge to NICs which can connect to the switch. Then stop the iptables, conflict happend. With net=host is good. 

Each swarm agent or swarm agent master have to listen a port, no matter net=bridge or net=host. I think use net=host is more reasonable and can avoid potential ip address conflict. 

Signed-off-by: Mingxin Dong <dongmx@dmx.xyz>