### PR TITLE
issue #2485, In generic driver If a permanent IP address and hostname has alread in /etc/hosts

### DIFF
--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -46,8 +46,15 @@ func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
 	}
 
 	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
-	if _, err := provisioner.SSHCommand(fmt.Sprintf(
-		"if grep -xq 127.0.1.1.* /etc/hosts; then sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; else echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; fi",
+	if _, err := provisioner.SSHCommand(fmt.Sprintf(`
+		if ! grep -xq .*%s /etc/hosts; then
+			if grep -xq 127.0.1.1.* /etc/hosts; then 
+				sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; 
+			else 
+				echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; 
+			fi
+		fi`,
+		hostname,
 		hostname,
 		hostname,
 	)); err != nil {


### PR DESCRIPTION
This comment in the source code. 
// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution

As the document says "For a system with a permanent IP address, that permanent IP address should be used here instead of 127.0.1.1."  
But if there is already a permanent IP address and hostname in /etc/hosts, docker-machine with insert a line "127.0.1.1 hostname" into /etc/hosts which cause one hostname multi addresses.

So I judge if the hostname has already in /etc/hosts, if true; do nothing, else do as usual.

Signed-off-by: Mingxin Dong <dongmx@dmx.xyz>