### PR TITLE
Update default images to ubuntu 15.10

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -55,17 +55,17 @@ By default, the Amazon EC2 driver will use a daily image of Ubuntu 14.04 LTS.
 
 | Region         | AMI ID       |
 | -------------- | ------------ |
-| ap-northeast-1 | ami-f4b06cf4 |
-| ap-southeast-1 | ami-b899a2ea |
-| ap-southeast-2 | ami-b59ce48f |
-| cn-north-1     | ami-da930ee3 |
-| eu-west-1      | ami-45d8a532 |
-| eu-central-1   | ami-b6e0d9ab |
-| sa-east-1      | ami-1199190c |
-| us-east-1      | ami-5f709f34 |
-| us-west-1      | ami-615cb725 |
-| us-west-2      | ami-7f675e4f |
-| us-gov-west-1  | ami-99a9c9ba |
+| ap-northeast-1 | ami-b36d4edd |
+| ap-southeast-1 | ami-1069af73 |
+| ap-southeast-2 | ami-1d336a7e |
+| cn-north-1     | ami-79eb2214 |
+| eu-west-1      | ami-8aa67cf9 |
+| eu-central-1   | ami-ab0210c7 |
+| sa-east-1      | ami-185de774 |
+| us-east-1      | ami-26d5af4c |
+| us-west-1      | ami-9cbcd2fc |
+| us-west-2      | ami-16b1a077 |
+| us-gov-west-1  | ami-b0bad893 |
 
 Environment variables and default values:
 

--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -25,9 +25,9 @@ Grab your subscription ID from the portal, then run `docker-machine create` with
 
     $ docker-machine create -d azure --azure-subscription-id="SUB_ID" --azure-subscription-cert="mycert.pem" A-VERY-UNIQUE-NAME
 
-The Azure driver uses the `b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20140927-en-us-30GB`
+The Azure driver uses the `b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_10-amd64-server-20151116.1-en-us-30GB`
 image by default. Note, this image is not available in the Chinese regions. In China you should
- specify `b549f4301d0b4295b8e76ceb65df47d4__Ubuntu-14_04_1-LTS-amd64-server-20140927-en-us-30GB`.
+ specify `b549f4301d0b4295b8e76ceb65df47d4__Ubuntu-15_10-amd64-server-20151116.1-en-us-30GB`.
 
 You may need to `machine ssh` in to the virtual machine and reboot to ensure that the OS is updated.
 
@@ -49,7 +49,7 @@ Environment variables and default values:
 | CLI option                      | Environment variable          | Default                |
 | ------------------------------- | ----------------------------- | ---------------------- |
 | `--azure-docker-port`           | -                             | `2376`                 |
-| `--azure-image`                 | `AZURE_IMAGE`                 | _Ubuntu 14.04 LTS x64_ |
+| `--azure-image`                 | `AZURE_IMAGE`                 | _Ubuntu 15.10 x64_     |
 | `--azure-location`              | `AZURE_LOCATION`              | `West US`              |
 | `--azure-password`              | -                             | -                      |
 | `--azure-publish-settings-file` | `AZURE_PUBLISH_SETTINGS_FILE` | -                      |

--- a/docs/drivers/digital-ocean.md
+++ b/docs/drivers/digital-ocean.md
@@ -28,17 +28,17 @@ Options:
 -   `--digitalocean-backups`: Enable Digital Oceans backups for the droplet.
 -   `--digitalocean-userdata`: Path to file containing User Data for the droplet.
 
-The DigitalOcean driver will use `ubuntu-14-04-x64` as the default image.
+The DigitalOcean driver will use `ubuntu-15-10-x64` as the default image.
 
 Environment variables and default values:
 
-| CLI option                          | Environment variable              | Default  |
-| ----------------------------------- | --------------------------------- | -------- |
-| **`--digitalocean-access-token`**   | `DIGITALOCEAN_ACCESS_TOKEN`       | -        |
-| `--digitalocean-image`              | `DIGITALOCEAN_IMAGE`              | `docker` |
-| `--digitalocean-region`             | `DIGITALOCEAN_REGION`             | `nyc3`   |
-| `--digitalocean-size`               | `DIGITALOCEAN_SIZE`               | `512mb`  |
-| `--digitalocean-ipv6`               | `DIGITALOCEAN_IPV6`               | `false`  |
-| `--digitalocean-private-networking` | `DIGITALOCEAN_PRIVATE_NETWORKING` | `false`  |
-| `--digitalocean-backups`            | `DIGITALOCEAN_BACKUPS`            | `false`  |
-| `--digitalocean-userdata`           | `DIGITALOCEAN_USERDATA`           | -        |
+| CLI option                          | Environment variable              | Default            |
+| ----------------------------------- | --------------------------------- | ------------------ |
+| **`--digitalocean-access-token`**   | `DIGITALOCEAN_ACCESS_TOKEN`       | -                  |
+| `--digitalocean-image`              | `DIGITALOCEAN_IMAGE`              | `ubuntu-15-10-x64` |
+| `--digitalocean-region`             | `DIGITALOCEAN_REGION`             | `nyc3`             |
+| `--digitalocean-size`               | `DIGITALOCEAN_SIZE`               | `512mb`            |
+| `--digitalocean-ipv6`               | `DIGITALOCEAN_IPV6`               | `false`            |
+| `--digitalocean-private-networking` | `DIGITALOCEAN_PRIVATE_NETWORKING` | `false`            |
+| `--digitalocean-backups`            | `DIGITALOCEAN_BACKUPS`            | `false`            |
+| `--digitalocean-userdata`           | `DIGITALOCEAN_USERDATA`           | -                  |

--- a/docs/drivers/exoscale.md
+++ b/docs/drivers/exoscale.md
@@ -36,6 +36,6 @@ Environment variables and default values:
 | **`--exoscale-api-secret-key`** | `EXOSCALE_API_SECRET`        | -                                 |
 | `--exoscale-instance-profile`   | `EXOSCALE_INSTANCE_PROFILE`  | `small`                           |
 | `--exoscale-disk-size`          | `EXOSCALE_DISK_SIZE`         | `50`                              |
-| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `ubuntu-14.04`                    |
+| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `ubuntu-15.10`                    |
 | `--exoscale-security-group`     | `EXOSCALE_SECURITY_GROUP`    | `docker-machine`                  |
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-gva-2`                        |

--- a/docs/drivers/gce.md
+++ b/docs/drivers/gce.md
@@ -51,7 +51,7 @@ To create a machine instance, specify `--driver google`, the project id and the 
     -   `--google-tags`: Instance tags (comma-separated).
     -   `--google-use-internal-ip`: When this option is used during create it will make docker-machine use internal rather than public NATed IPs. The flag is persistent in the sense that a machine created with it retains the IP. It's useful for managing docker machines from another machine on the same network e.g. while deploying swarm.
 
-The GCE driver will use the `ubuntu-1404-trusty-v20151113` instance image unless otherwise specified. To obtain a
+The GCE driver will use the `ubuntu-1510-wily-v20151114` instance image unless otherwise specified. To obtain a
 list of image URLs run:
 
     gcloud compute images list --uri
@@ -63,7 +63,7 @@ Environment variables and default values:
 | **`--google-project`**     | `GOOGLE_PROJECT`         | -                                    |
 | `--google-zone`            | `GOOGLE_ZONE`            | `us-central1-a`                      |
 | `--google-machine-type`    | `GOOGLE_MACHINE_TYPE`    | `f1-standard-1`                      |
-| `--google-machine-image`   | `GOOGLE_MACHINE_IMAGE`   | `ubuntu-1404-trusty-v20151113`       |
+| `--google-machine-image`   | `GOOGLE_MACHINE_IMAGE`   | `ubuntu-1510-wily-v20151114`         |
 | `--google-username`        | `GOOGLE_USERNAME`        | `docker-user`                        |
 | `--google-scopes`          | `GOOGLE_SCOPES`          | `devstorage.read_only,logging.write` |
 | `--google-disk-size`       | `GOOGLE_DISK_SIZE`       | `10`                                 |

--- a/docs/drivers/rackspace.md
+++ b/docs/drivers/rackspace.md
@@ -18,13 +18,13 @@ Options:
 -   `--rackspace-api-key`: **required** Rackspace API key.
 -   `--rackspace-region`: **required** Rackspace region name.
 -   `--rackspace-endpoint-type`: Rackspace endpoint type (`adminURL`, `internalURL` or the default `publicURL`).
--   `--rackspace-image-id`: Rackspace image ID. Default: Ubuntu 14.10 (Utopic Unicorn) (PVHVM).
+-   `--rackspace-image-id`: Rackspace image ID. Default: Ubuntu 15.10 (Wily Werewolf) (PVHVM).
 -   `--rackspace-flavor-id`: Rackspace flavor ID. Default: General Purpose 1GB.
 -   `--rackspace-ssh-user`: SSH user for the newly booted machine.
 -   `--rackspace-ssh-port`: SSH port for the newly booted machine.
 -   `--rackspace-docker-install`: Set if Docker has to be installed on the machine.
 
-The Rackspace driver will use `598a4282-f14b-4e50-af4c-b3e52749d9f9` (Ubuntu 14.04 LTS) by default.
+The Rackspace driver will use `59a3fadd-93e7-4674-886a-64883e17115f` (Ubuntu 15.10) by default.
 
 Environment variables and default values:
 
@@ -34,7 +34,7 @@ Environment variables and default values:
 | **`--rackspace-api-key`**    | `OS_API_KEY`         | -                                      |
 | **`--rackspace-region`**     | `OS_REGION_NAME`     | -                                      |
 | `--rackspace-endpoint-type`  | `OS_ENDPOINT_TYPE`   | `publicURL`                            |
-| `--rackspace-image-id`       | -                    | `598a4282-f14b-4e50-af4c-b3e52749d9f9` |
+| `--rackspace-image-id`       | -                    | `59a3fadd-93e7-4674-886a-64883e17115f` |
 | `--rackspace-flavor-id`      | `OS_FLAVOR_ID`       | `general1-1`                           |
 | `--rackspace-ssh-user`       | -                    | `root`                                 |
 | `--rackspace-ssh-port`       | -                    | `22`                                   |

--- a/drivers/amazonec2/utils.go
+++ b/drivers/amazonec2/utils.go
@@ -16,19 +16,20 @@ type region struct {
 	AmiId string
 }
 
-// Release 20150603
+// Release 15.10 20151116.1
+// See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1": {"ami-f4b06cf4"},
-	"ap-southeast-1": {"ami-b899a2ea"},
-	"ap-southeast-2": {"ami-b59ce48f"},
-	"cn-north-1":     {"ami-da930ee3"},
-	"eu-west-1":      {"ami-45d8a532"},
-	"eu-central-1":   {"ami-b6e0d9ab"},
-	"sa-east-1":      {"ami-1199190c"},
-	"us-east-1":      {"ami-5f709f34"},
-	"us-west-1":      {"ami-615cb725"},
-	"us-west-2":      {"ami-7f675e4f"},
-	"us-gov-west-1":  {"ami-99a9c9ba"},
+	"ap-northeast-1": {"ami-b36d4edd"},
+	"ap-southeast-1": {"ami-1069af73"},
+	"ap-southeast-2": {"ami-1d336a7e"},
+	"cn-north-1":     {"ami-79eb2214"},
+	"eu-west-1":      {"ami-8aa67cf9"},
+	"eu-central-1":   {"ami-ab0210c7"},
+	"sa-east-1":      {"ami-185de774"},
+	"us-east-1":      {"ami-26d5af4c"},
+	"us-west-1":      {"ami-9cbcd2fc"},
+	"us-west-2":      {"ami-16b1a077"},
+	"us-gov-west-1":  {"ami-b0bad893"},
 }
 
 func awsRegionsList() []string {

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -163,7 +163,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	if image == "" {
-		d.Image = "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20140927-en-us-30GB"
+		d.Image = "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_10-amd64-server-20151116.1-en-us-30GB"
 	} else {
 		d.Image = image
 	}

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -32,7 +32,7 @@ type Driver struct {
 }
 
 const (
-	defaultImage  = "ubuntu-14-04-x64"
+	defaultImage  = "ubuntu-15-10-x64"
 	defaultRegion = "nyc3"
 	defaultSize   = "512mb"
 )

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -35,7 +35,7 @@ type Driver struct {
 const (
 	defaultInstanceProfile  = "small"
 	defaultDiskSize         = 50
-	defaultImage            = "ubuntu-14.04"
+	defaultImage            = "ubuntu-15.10"
 	defaultAvailabilityZone = "ch-gva-2"
 )
 

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -32,7 +32,7 @@ const (
 	defaultZone        = "us-central1-a"
 	defaultUser        = "docker-user"
 	defaultMachineType = "n1-standard-1"
-	defaultImageName   = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20151113"
+	defaultImageName   = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20151114"
 	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write"
 	defaultDiskType    = "pd-standard"
 	defaultDiskSize    = 10

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -136,10 +136,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	if d.ImageId == "" {
-		// Default to the Ubuntu 14.04 image.
+		// Default to the Ubuntu 15.10 image.
 		// This is done here, rather than in the option registration, to keep the default value
 		// from making "machine create --help" ugly.
-		d.ImageId = "598a4282-f14b-4e50-af4c-b3e52749d9f9"
+		d.ImageId = "59a3fadd-93e7-4674-886a-64883e17115f"
 	}
 
 	if d.EndpointType != "publicURL" && d.EndpointType != "adminURL" && d.EndpointType != "internalURL" {


### PR DESCRIPTION
Updated the following drivers to use ubuntu 15.10 as default image:
* amazonec2 : tested on one region (eu-central-1)
* azure : tested the _classic_ image, not the image for Chinese regions
* exoscale : tested
* digital ocean : tested
* rackspace : tested
* google compute : tested

Non covered :  vCloud Air

Fix for #2361