### PR TITLE
Revise SSH help flow and add 'docker-machine ssh' test

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -9,14 +9,13 @@ import (
 
 func cmdSSH(c CommandLine, api libmachine.API) error {
 	// Check for help flag -- Needed due to SkipFlagParsing
-	for _, arg := range c.Args() {
-		if arg == "-help" || arg == "--help" || arg == "-h" {
-			c.ShowHelp()
-			return nil
-		}
+	firstArg := c.Args().First()
+	if firstArg == "-help" || firstArg == "--help" || firstArg == "-h" {
+		c.ShowHelp()
+		return nil
 	}
 
-	name := c.Args().First()
+	name := firstArg
 	if name == "" {
 		return ErrExpectedOneMachine
 	}

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/docker/machine/commands/commandstest"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/libmachinetest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdSSH(t *testing.T) {
+	testCases := []struct {
+		commandLine CommandLine
+		api         libmachine.API
+		expectedErr error
+		helpShown   bool
+	}{
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"-h"},
+			},
+			api:         &libmachinetest.FakeAPI{},
+			expectedErr: nil,
+			helpShown:   true,
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"--help"},
+			},
+			api:         &libmachinetest.FakeAPI{},
+			expectedErr: nil,
+			helpShown:   true,
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{""},
+			},
+			api:         &libmachinetest.FakeAPI{},
+			expectedErr: ErrExpectedOneMachine,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := cmdSSH(tc.commandLine, tc.api)
+		assert.Equal(t, err, tc.expectedErr)
+
+		if fcl, ok := tc.commandLine.(*commandstest.FakeCommandLine); ok {
+			assert.Equal(t, tc.helpShown, fcl.HelpShown)
+		}
+	}
+}


### PR DESCRIPTION
Noticed a bug where a command like `docker-machine ssh default df -h` would trip up the help text.  This fixes it so that only happens if the first argument is a `--help` type flag, and adds the first test for `cmdSSH` to cover this case and others.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>