### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,46 @@
-Evan Hazlett <ejhazlett@gmail.com> (@ehazlett)
-Nathan LeClaire <nathan.leclaire@docker.com> (@nathanleclaire)
-David Gageot <david.gageot@docker.com> (@dgageot)
-Jean-Laurent de Morlhon <jeanlaurent@docker.com> (@jeanlaurent)
+# Machine maintainers file
+#
+# This file describes who runs the docker/machine project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"dgageot",
+			"ehazlett",
+			"jeanlaurent",
+			"nathanleclaire",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.dgageot]
+	Name = "David Gageot"
+	Email = "david.gageot@docker.com"
+	GitHub = "dgageot"
+
+	[people.ehazlett]
+	Name = "Evan Hazlett"
+	Email = "ejhazlett@gmail.com"
+	GitHub = "ehazlett"
+
+	[people.jeanlaurent]
+	Name = "Jean-Laurent de Morlhon"
+	Email = "jeanlaurent@docker.com>"
+	GitHub = "jeanlaurent"
+
+	[people.nathanleclaire]
+	Name = "Nathan LeClaire"
+	Email = "nathan.leclaire@docker.com"
+	GitHub = "nathanleclaire"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321