### PR TITLE
Sanitize keynames by replacing dots with underscores

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -576,6 +576,7 @@ func (d *Driver) initNetwork() error {
 }
 
 func (d *Driver) createSSHKey() error {
+	sanitizeKeyPairName(&d.KeyPairName)
 	log.WithField("Name", d.KeyPairName).Debug("Creating Key Pair...")
 	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err
@@ -684,4 +685,8 @@ func (d *Driver) lookForIPAddress() error {
 
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
+}
+
+func sanitizeKeyPairName(s *string) {
+	*s = strings.Replace(*s, ".", "_", -1)
 }


### PR DESCRIPTION
From https://github.com/docker/machine/issues/2478 makes sense only replace dots.
Probably for other separators, we can just print a message and Exit().