### PR TITLE
Bugfix#2504 Rename of temp file fails.

### DIFF
--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -41,18 +41,19 @@ func (s Filestore) saveToFile(data []byte, file string) error {
 	}
 	defer os.Remove(tmpfi.Name())
 
-	err = ioutil.WriteFile(tmpfi.Name(), data, 0600)
-	if err != nil {
+	if err = ioutil.WriteFile(tmpfi.Name(), data, 0600); err != nil {
 		return err
 	}
 
-	err = os.Remove(file)
-	if err != nil {
+	if err = tmpfi.Close(); err != nil {
 		return err
 	}
 
-	err = os.Rename(tmpfi.Name(), file)
-	if err != nil {
+	if err = os.Remove(file); err != nil {
+		return err
+	}
+
+	if err = os.Rename(tmpfi.Name(), file); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Tempfile was not closed, so rename opertion was failing.
Minor code refactor is done, to make function more readable.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>