### PR TITLE
Verbose ls

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -22,7 +22,7 @@ func cmdActive(c CommandLine, api libmachine.API) error {
 		return fmt.Errorf("Error getting active host: %s", err)
 	}
 
-	items := getHostListItems(hosts, hostsInError)
+	items := getHostListItems(hosts, hostsInError, false)
 
 	for _, item := range items {
 		if item.Active {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -211,6 +211,10 @@ var Commands = []cli.Command{
 				Name:  "quiet, q",
 				Usage: "Enable quiet mode",
 			},
+			cli.BoolFlag{
+				Name:  "verbose, v",
+				Usage: "Enable verbose mode",
+			},
 			cli.StringSliceFlag{
 				Name:  "filter",
 				Usage: "Filter output based on conditions provided",

--- a/commands/create.go
+++ b/commands/create.go
@@ -293,7 +293,7 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 	}
 
 	if _, ok := driver.(*errdriver.Driver); ok {
-		return errdriver.NotLoadable{driverName}
+		return errdriver.NotLoadable{Name: driverName}
 	}
 
 	// TODO: So much flag manipulation and voodoo here, it seems to be

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -167,9 +167,11 @@ func filterHosts(hosts []*host.Host, filters FilterOptions) []*host.Host {
 func getSwarmMasters(hosts []*host.Host) map[string]string {
 	swarmMasters := make(map[string]string)
 	for _, h := range hosts {
-		swarmOptions := h.HostOptions.SwarmOptions
-		if swarmOptions != nil && swarmOptions.Master {
-			swarmMasters[swarmOptions.Discovery] = h.Name
+		if h.HostOptions != nil {
+			swarmOptions := h.HostOptions.SwarmOptions
+			if swarmOptions != nil && swarmOptions.Master {
+				swarmMasters[swarmOptions.Discovery] = h.Name
+			}
 		}
 	}
 	return swarmMasters
@@ -189,7 +191,7 @@ func matchesSwarmName(host *host.Host, swarmNames []string, swarmMasters map[str
 		return true
 	}
 	for _, n := range swarmNames {
-		if host.HostOptions.SwarmOptions != nil {
+		if host.HostOptions != nil && host.HostOptions.SwarmOptions != nil {
 			if strings.EqualFold(n, swarmMasters[host.HostOptions.SwarmOptions.Discovery]) {
 				return true
 			}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -44,7 +44,6 @@ type HostListItem struct {
 }
 
 func cmdLs(c CommandLine, api libmachine.API) error {
-	quiet := c.Bool("quiet")
 	filters, err := parseFilters(c.StringSlice("filter"))
 	if err != nil {
 		return err
@@ -58,6 +57,7 @@ func cmdLs(c CommandLine, api libmachine.API) error {
 	hostList = filterHosts(hostList, filters)
 
 	// Just print out the names if we're being quiet
+	quiet := c.Bool("quiet")
 	if quiet {
 		for _, host := range hostList {
 			fmt.Println(host.Name)
@@ -69,7 +69,13 @@ func cmdLs(c CommandLine, api libmachine.API) error {
 	swarmInfo := make(map[string]string)
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
-	fmt.Fprintln(w, "NAME\tACTIVE\tDRIVER\tSTATE\tURL\tSWARM\tDOCKER\tERRORS")
+
+	verbose := c.Bool("verbose")
+	header := "NAME\tACTIVE\tDRIVER\tSTATE\tURL\tSWARM"
+	if verbose {
+		header += "\tDOCKER\tERRORS"
+	}
+	fmt.Fprintln(w, header)
 
 	for _, host := range hostList {
 		swarmOptions := host.HostOptions.SwarmOptions
@@ -82,7 +88,7 @@ func cmdLs(c CommandLine, api libmachine.API) error {
 		}
 	}
 
-	items := getHostListItems(hostList, hostInError)
+	items := getHostListItems(hostList, hostInError, verbose)
 
 	for _, item := range items {
 		activeString := "-"
@@ -98,8 +104,15 @@ func cmdLs(c CommandLine, api libmachine.API) error {
 				swarmInfo = fmt.Sprintf("%s (master)", swarmInfo)
 			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			item.Name, activeString, item.DriverName, item.State, item.URL, swarmInfo, item.DockerVersion, item.Error)
+
+		standardFields := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s",
+			item.Name, activeString, item.DriverName, item.State, item.URL, swarmInfo)
+
+		if verbose {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", standardFields, item.DockerVersion, item.Error)
+		} else {
+			fmt.Fprintf(w, "%s\n", standardFields)
+		}
 	}
 
 	w.Flush()
@@ -230,7 +243,7 @@ func matchesName(host *host.Host, names []string) bool {
 	return false
 }
 
-func attemptGetHostState(h *host.Host, stateQueryChan chan<- HostListItem) {
+func attemptGetHostState(h *host.Host, stateQueryChan chan<- HostListItem, verbose bool) {
 	url := ""
 	hostError := ""
 	dockerVersion := "Unknown"
@@ -239,20 +252,23 @@ func attemptGetHostState(h *host.Host, stateQueryChan chan<- HostListItem) {
 	if err == nil {
 		url, err = h.URL()
 	}
-	if err == nil {
-		dockerVersion, err = h.DockerVersion()
-		if err != nil {
-			dockerVersion = "Unknown"
-		} else {
-			dockerVersion = fmt.Sprintf("v%s", dockerVersion)
-		}
-	}
 
-	if err != nil {
-		hostError = err.Error()
-	}
-	if hostError == drivers.ErrHostIsNotRunning.Error() {
-		hostError = ""
+	if verbose {
+		if err == nil {
+			dockerVersion, err = h.DockerVersion()
+			if err != nil {
+				dockerVersion = "Unknown"
+			} else {
+				dockerVersion = fmt.Sprintf("v%s", dockerVersion)
+			}
+		}
+
+		if err != nil {
+			hostError = err.Error()
+		}
+		if hostError == drivers.ErrHostIsNotRunning.Error() {
+			hostError = ""
+		}
 	}
 
 	var swarmOptions *swarm.Options
@@ -272,12 +288,12 @@ func attemptGetHostState(h *host.Host, stateQueryChan chan<- HostListItem) {
 	}
 }
 
-func getHostState(h *host.Host, hostListItemsChan chan<- HostListItem) {
+func getHostState(h *host.Host, hostListItemsChan chan<- HostListItem, verbose bool) {
 	// This channel is used to communicate the properties we are querying
 	// about the host in the case of a successful read.
 	stateQueryChan := make(chan HostListItem)
 
-	go attemptGetHostState(h, stateQueryChan)
+	go attemptGetHostState(h, stateQueryChan, verbose)
 
 	select {
 	// If we get back useful information, great.  Forward it straight to
@@ -295,12 +311,12 @@ func getHostState(h *host.Host, hostListItemsChan chan<- HostListItem) {
 	}
 }
 
-func getHostListItems(hostList []*host.Host, hostsInError map[string]error) []HostListItem {
+func getHostListItems(hostList []*host.Host, hostsInError map[string]error, verbose bool) []HostListItem {
 	hostListItems := []HostListItem{}
 	hostListItemsChan := make(chan HostListItem)
 
 	for _, h := range hostList {
-		go getHostState(h, hostListItemsChan)
+		go getHostState(h, hostListItemsChan, verbose)
 	}
 
 	for range hostList {

--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -76,9 +76,8 @@ func TestFilterHostsReturnsSameGivenNoFilters(t *testing.T) {
 	opts := FilterOptions{}
 	hosts := []*host.Host{
 		{
-			Name:        "testhost",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
+			Name:       "testhost",
+			DriverName: "fakedriver",
 		},
 	}
 	actual := filterHosts(hosts, opts)
@@ -99,9 +98,8 @@ func TestFilterHostsReturnsEmptyGivenNonMatchingFilters(t *testing.T) {
 	}
 	hosts := []*host.Host{
 		{
-			Name:        "testhost",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
+			Name:       "testhost",
+			DriverName: "fakedriver",
 		},
 	}
 	assert.Empty(t, filterHosts(hosts, opts))
@@ -144,21 +142,18 @@ func TestFilterHostsByDriverName(t *testing.T) {
 	}
 	node1 :=
 		&host.Host{
-			Name:        "node1",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
+			Name:       "node1",
+			DriverName: "fakedriver",
 		}
 	node2 :=
 		&host.Host{
-			Name:        "node2",
-			DriverName:  "virtualbox",
-			HostOptions: &host.Options{},
+			Name:       "node2",
+			DriverName: "virtualbox",
 		}
 	node3 :=
 		&host.Host{
-			Name:        "node3",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
+			Name:       "node3",
+			DriverName: "fakedriver",
 		}
 	hosts := []*host.Host{node1, node2, node3}
 	expected := []*host.Host{node1, node3}
@@ -172,24 +167,21 @@ func TestFilterHostsByState(t *testing.T) {
 	}
 	node1 :=
 		&host.Host{
-			Name:        "node1",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused},
+			Name:       "node1",
+			DriverName: "fakedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused},
 		}
 	node2 :=
 		&host.Host{
-			Name:        "node2",
-			DriverName:  "virtualbox",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Stopped},
+			Name:       "node2",
+			DriverName: "virtualbox",
+			Driver:     &fakedriver.Driver{MockState: state.Stopped},
 		}
 	node3 :=
 		&host.Host{
-			Name:        "node3",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Running},
+			Name:       "node3",
+			DriverName: "fakedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Running},
 		}
 	hosts := []*host.Host{node1, node2, node3}
 	expected := []*host.Host{node1, node2}
@@ -203,31 +195,27 @@ func TestFilterHostsByName(t *testing.T) {
 	}
 	node1 :=
 		&host.Host{
-			Name:        "fire",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "fire"},
+			Name:       "fire",
+			DriverName: "fakedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused, MockName: "fire"},
 		}
 	node2 :=
 		&host.Host{
-			Name:        "ice",
-			DriverName:  "adriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "ice"},
+			Name:       "ice",
+			DriverName: "adriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused, MockName: "ice"},
 		}
 	node3 :=
 		&host.Host{
-			Name:        "air",
-			DriverName:  "nodriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "air"},
+			Name:       "air",
+			DriverName: "nodriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused, MockName: "air"},
 		}
 	node4 :=
 		&host.Host{
-			Name:        "water",
-			DriverName:  "falsedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused, MockName: "water"},
+			Name:       "water",
+			DriverName: "falsedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused, MockName: "water"},
 		}
 	hosts := []*host.Host{node1, node2, node3, node4}
 	expected := []*host.Host{node1, node2, node3}
@@ -242,21 +230,18 @@ func TestFilterHostsMultiFlags(t *testing.T) {
 	}
 	node1 :=
 		&host.Host{
-			Name:        "node1",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
+			Name:       "node1",
+			DriverName: "fakedriver",
 		}
 	node2 :=
 		&host.Host{
-			Name:        "node2",
-			DriverName:  "virtualbox",
-			HostOptions: &host.Options{},
+			Name:       "node2",
+			DriverName: "virtualbox",
 		}
 	node3 :=
 		&host.Host{
-			Name:        "node3",
-			DriverName:  "softlayer",
-			HostOptions: &host.Options{},
+			Name:       "node3",
+			DriverName: "softlayer",
 		}
 	hosts := []*host.Host{node1, node2, node3}
 	expected := []*host.Host{node1, node2}
@@ -269,38 +254,31 @@ func TestFilterHostsDifferentFlagsProduceAND(t *testing.T) {
 		DriverName: []string{"virtualbox"},
 		State:      []string{"Running"},
 	}
-	node1 :=
-		&host.Host{
-			Name:        "node1",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Paused},
-		}
-	node2 :=
-		&host.Host{
-			Name:        "node2",
-			DriverName:  "virtualbox",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Stopped},
-		}
-	node3 :=
-		&host.Host{
-			Name:        "node3",
-			DriverName:  "fakedriver",
-			HostOptions: &host.Options{},
-			Driver:      &fakedriver.Driver{MockState: state.Running},
-		}
-	hosts := []*host.Host{node1, node2, node3}
-	expected := []*host.Host{}
 
-	assert.EqualValues(t, filterHosts(hosts, opts), expected)
+	hosts := []*host.Host{
+		&host.Host{
+			Name:       "node1",
+			DriverName: "fakedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Paused},
+		},
+		&host.Host{
+			Name:       "node2",
+			DriverName: "virtualbox",
+			Driver:     &fakedriver.Driver{MockState: state.Stopped},
+		},
+		&host.Host{
+			Name:       "node3",
+			DriverName: "fakedriver",
+			Driver:     &fakedriver.Driver{MockState: state.Running},
+		},
+	}
+
+	assert.Empty(t, filterHosts(hosts, opts))
 }
 
-func TestGetHostListItemsVerbose(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9"}
-	defer mcndockerclient.CleanupDockerVersioner()
-
+func TestGetHostListItems(t *testing.T) {
 	// TODO: Ideally this would mockable via interface instead.
+	defer func(host string) { os.Setenv("DOCKER_HOST", host) }(os.Getenv("DOCKER_HOST"))
 	os.Setenv("DOCKER_HOST", "tcp://active.host.com:2376")
 
 	hosts := []*host.Host{
@@ -310,17 +288,11 @@ func TestGetHostListItemsVerbose(t *testing.T) {
 				MockState: state.Running,
 				MockIP:    "active.host.com",
 			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
-			},
 		},
 		{
 			Name: "bar100",
 			Driver: &fakedriver.Driver{
 				MockState: state.Stopped,
-			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
 			},
 		},
 		{
@@ -328,8 +300,56 @@ func TestGetHostListItemsVerbose(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Error,
 			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
+		},
+	}
+
+	expected := []struct {
+		name   string
+		state  state.State
+		active bool
+	}{
+		{"bar10", state.Error, false},
+		{"bar100", state.Stopped, false},
+		{"foo", state.Running, true},
+	}
+
+	items := getHostListItems(hosts, map[string]error{}, false)
+
+	for i := range expected {
+		assert.Equal(t, expected[i].name, items[i].Name)
+		assert.Equal(t, expected[i].state, items[i].State)
+		assert.Equal(t, expected[i].active, items[i].Active)
+		assert.Equal(t, "Unknown", items[i].DockerVersion)
+		assert.Equal(t, "", items[i].Error)
+	}
+}
+
+func TestGetHostListItemsVerbose(t *testing.T) {
+	defer func(versioner mcndockerclient.DockerVersioner) { mcndockerclient.CurrentDockerVersioner = versioner }(mcndockerclient.CurrentDockerVersioner)
+	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9"}
+
+	// TODO: Ideally this would mockable via interface instead.
+	defer func(host string) { os.Setenv("DOCKER_HOST", host) }(os.Getenv("DOCKER_HOST"))
+	os.Setenv("DOCKER_HOST", "tcp://active.host.com:2376")
+
+	hosts := []*host.Host{
+		{
+			Name: "foo",
+			Driver: &fakedriver.Driver{
+				MockState: state.Running,
+				MockIP:    "active.host.com",
+			},
+		},
+		{
+			Name: "bar100",
+			Driver: &fakedriver.Driver{
+				MockState: state.Stopped,
+			},
+		},
+		{
+			Name: "bar10",
+			Driver: &fakedriver.Driver{
+				MockState: state.Error,
 			},
 		},
 	}
@@ -355,85 +375,10 @@ func TestGetHostListItemsVerbose(t *testing.T) {
 		assert.Equal(t, expected[i].version, items[i].DockerVersion)
 		assert.Equal(t, expected[i].error, items[i].Error)
 	}
-
-	os.Unsetenv("DOCKER_HOST")
 }
 
-func TestGetHostListItems(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9"}
-	defer mcndockerclient.CleanupDockerVersioner()
-
-	// TODO: Ideally this would mockable via interface instead.
-	os.Setenv("DOCKER_HOST", "tcp://active.host.com:2376")
-
-	hosts := []*host.Host{
-		{
-			Name: "foo",
-			Driver: &fakedriver.Driver{
-				MockState: state.Running,
-				MockIP:    "active.host.com",
-			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
-			},
-		},
-		{
-			Name: "bar100",
-			Driver: &fakedriver.Driver{
-				MockState: state.Stopped,
-			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
-			},
-		},
-		{
-			Name: "bar10",
-			Driver: &fakedriver.Driver{
-				MockState: state.Error,
-			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{},
-			},
-		},
-	}
-
-	expected := []struct {
-		name    string
-		state   state.State
-		active  bool
-		version string
-		error   string
-	}{
-		{"bar10", state.Error, false, "Unknown", ""},
-		{"bar100", state.Stopped, false, "Unknown", ""},
-		{"foo", state.Running, true, "Unknown", ""},
-	}
-
-	items := getHostListItems(hosts, map[string]error{}, false)
-
-	for i := range expected {
-		assert.Equal(t, expected[i].name, items[i].Name)
-		assert.Equal(t, expected[i].state, items[i].State)
-		assert.Equal(t, expected[i].active, items[i].Active)
-		assert.Equal(t, expected[i].version, items[i].DockerVersion)
-		assert.Equal(t, expected[i].error, items[i].Error)
-	}
-
-	os.Unsetenv("DOCKER_HOST")
-}
-
-// issue #1908
 func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9"}
-	defer mcndockerclient.CleanupDockerVersioner()
-
-	orgDockerHost := os.Getenv("DOCKER_HOST")
-	defer func() {
-		// revert DOCKER_HOST
-		os.Setenv("DOCKER_HOST", orgDockerHost)
-	}()
-
-	// unset DOCKER_HOST
+	defer func(host string) { os.Setenv("DOCKER_HOST", host) }(os.Getenv("DOCKER_HOST"))
 	os.Unsetenv("DOCKER_HOST")
 
 	hosts := []*host.Host{
@@ -443,25 +388,11 @@ func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
 				MockState: state.Running,
 				MockIP:    "120.0.0.1",
 			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{
-					Master:    false,
-					Address:   "",
-					Discovery: "",
-				},
-			},
 		},
 		{
 			Name: "bar",
 			Driver: &fakedriver.Driver{
 				MockState: state.Stopped,
-			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{
-					Master:    false,
-					Address:   "",
-					Discovery: "",
-				},
 			},
 		},
 		{
@@ -469,34 +400,25 @@ func TestGetHostListItemsEnvDockerHostUnset(t *testing.T) {
 			Driver: &fakedriver.Driver{
 				MockState: state.Saved,
 			},
-			HostOptions: &host.Options{
-				SwarmOptions: &swarm.Options{
-					Master:    false,
-					Address:   "",
-					Discovery: "",
-				},
-			},
 		},
 	}
 
 	expected := map[string]struct {
-		state   state.State
-		active  bool
-		version string
+		state  state.State
+		active bool
 	}{
-		"foo": {state.Running, false, "v1.9"},
-		"bar": {state.Stopped, false, "Unknown"},
-		"baz": {state.Saved, false, "Unknown"},
+		"foo": {state.Running, false},
+		"bar": {state.Stopped, false},
+		"baz": {state.Saved, false},
 	}
 
-	items := getHostListItems(hosts, map[string]error{}, true)
+	items := getHostListItems(hosts, map[string]error{}, false)
 
 	for _, item := range items {
 		expected := expected[item.Name]
 
 		assert.Equal(t, expected.state, item.State)
 		assert.Equal(t, expected.active, item.Active)
-		assert.Equal(t, expected.version, item.DockerVersion)
 	}
 }
 
@@ -521,12 +443,13 @@ func TestIsActive(t *testing.T) {
 
 		actual := isActive(c.state, "tcp://1.2.3.4:2376")
 
-		assert.Equal(t, c.expected, actual, "IsActive(%s, \"%s\") should return %v, but didn't", c.state, c.dockerHost, c.expected)
+		assert.Equal(t, c.expected, actual)
 	}
 }
 
 func TestGetHostStateTimeout(t *testing.T) {
-	originalTimeout := stateTimeoutDuration
+	defer func(timeout time.Duration) { stateTimeoutDuration = timeout }(stateTimeoutDuration)
+	stateTimeoutDuration = 1 * time.Millisecond
 
 	hosts := []*host.Host{
 		{
@@ -537,15 +460,11 @@ func TestGetHostStateTimeout(t *testing.T) {
 		},
 	}
 
-	stateTimeoutDuration = 1 * time.Millisecond
-	hostItems := getHostListItems(hosts, map[string]error{}, true)
-	hostItem := hostItems[0]
+	hostItem := getHostListItems(hosts, nil, false)[0]
 
 	assert.Equal(t, "foo", hostItem.Name)
 	assert.Equal(t, state.Timeout, hostItem.State)
 	assert.Equal(t, "Driver", hostItem.DriverName)
-
-	stateTimeoutDuration = originalTimeout
 }
 
 func TestGetHostStateError(t *testing.T) {
@@ -558,8 +477,7 @@ func TestGetHostStateError(t *testing.T) {
 		},
 	}
 
-	hostItems := getHostListItems(hosts, map[string]error{}, true)
-	hostItem := hostItems[0]
+	hostItem := getHostListItems(hosts, nil, true)[0]
 
 	assert.Equal(t, "foo", hostItem.Name)
 	assert.Equal(t, state.Error, hostItem.State)
@@ -569,10 +487,7 @@ func TestGetHostStateError(t *testing.T) {
 	assert.Nil(t, hostItem.SwarmOptions)
 }
 
-func TestGetSomeHostInEror(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9"}
-	defer mcndockerclient.CleanupDockerVersioner()
-
+func TestGetSomeHostInError(t *testing.T) {
 	hosts := []*host.Host{
 		{
 			Name: "foo",
@@ -585,11 +500,10 @@ func TestGetSomeHostInEror(t *testing.T) {
 		"bar": errors.New("invalid memory address or nil pointer dereference"),
 	}
 
-	hostItems := getHostListItems(hosts, hostsInError, true)
+	hostItems := getHostListItems(hosts, hostsInError, false)
 	assert.Equal(t, 2, len(hostItems))
 
 	hostItem := hostItems[0]
-
 	assert.Equal(t, "bar", hostItem.Name)
 	assert.Equal(t, state.Error, hostItem.State)
 	assert.Equal(t, "not found", hostItem.DriverName)
@@ -598,7 +512,6 @@ func TestGetSomeHostInEror(t *testing.T) {
 	assert.Nil(t, hostItem.SwarmOptions)
 
 	hostItem = hostItems[1]
-
 	assert.Equal(t, "foo", hostItem.Name)
 	assert.Equal(t, state.Running, hostItem.State)
 }

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -46,8 +46,8 @@ func TestCmdVersionNotFound(t *testing.T) {
 }
 
 func TestCmdVersionOnHost(t *testing.T) {
+	defer func(versioner mcndockerclient.DockerVersioner) { mcndockerclient.CurrentDockerVersioner = versioner }(mcndockerclient.CurrentDockerVersioner)
 	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Version: "1.9.1"}
-	defer mcndockerclient.CleanupDockerVersioner()
 
 	commandLine := &commandstest.FakeCommandLine{
 		CliArgs: []string{"machine"},
@@ -68,8 +68,8 @@ func TestCmdVersionOnHost(t *testing.T) {
 }
 
 func TestCmdVersionFailure(t *testing.T) {
+	defer func(versioner mcndockerclient.DockerVersioner) { mcndockerclient.CurrentDockerVersioner = versioner }(mcndockerclient.CurrentDockerVersioner)
 	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{Err: errors.New("connection failure")}
-	defer mcndockerclient.CleanupDockerVersioner()
 
 	commandLine := &commandstest.FakeCommandLine{
 		CliArgs: []string{"machine"},

--- a/libmachine/mcndockerclient/fake_docker_versioner.go
+++ b/libmachine/mcndockerclient/fake_docker_versioner.go
@@ -1,11 +1,5 @@
 package mcndockerclient
 
-var originalDockerVersioner = CurrentDockerVersioner
-
-func CleanupDockerVersioner() {
-	CurrentDockerVersioner = originalDockerVersioner
-}
-
 type FakeDockerVersioner struct {
 	Version string
 	Err     error


### PR DESCRIPTION
Following up the discussion on https://github.com/docker/machine/pull/1475, here's a version of `docker-machine ls` with a `verbose` flag.

The `DOCKER` and `ERROR` columns would be hidden by default and shown with this new flag.

@nathanleclaire, @thaJeztah, @hairyhenderson wdyt?