### PR TITLE
Align version output with other docker tools

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -12,5 +12,5 @@ var (
 
 // FullVersion formats the version to be printed
 func FullVersion() string {
-	return fmt.Sprintf("%s ( %s )", Version, GitCommit)
+	return fmt.Sprintf("%s, build %s", Version, GitCommit)
 }


### PR DESCRIPTION
```
$ docker-compose -v
docker-compose version 1.5.2, build 7240ff3

$ docker -v
Docker version 1.9.1, build a34a1d5
```