### PR TITLE
Fixes issue #2342 - Issue provisioning swarm master with --replication through Docker Machine

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -99,7 +99,7 @@ manage \
 --tlscert={{.AuthOptions.ServerCertRemotePath}} \
 --tlskey={{.AuthOptions.ServerKeyRemotePath}} \
 -H {{.SwarmOptions.Host}} \
---strategy {{.SwarmOptions.Strategy}} {{range .SwarmOptions.ArbitraryFlags}} --{{.}}{{end}} {{.SwarmOptions.Discovery}}
+--strategy {{.SwarmOptions.Strategy}} --advertise {{.IP}}:{{.DockerPort}} {{range .SwarmOptions.ArbitraryFlags}} --{{.}}{{end}} {{.SwarmOptions.Discovery}}
 `
 
 	swarmWorkerCmdTemplate := `sudo docker run -d \


### PR DESCRIPTION
added advertise flag to swarm manager template.
Uses the --swarm-addr parameter to set the advertise address for the manager
same as the swarm agent
