### PR TITLE
Explicitly set umask before invoking vmrun in vmwarefusion

### DIFF
--- a/drivers/vmwarefusion/vmrun.go
+++ b/drivers/vmwarefusion/vmrun.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/docker/machine/libmachine/log"
 )
@@ -36,6 +37,9 @@ func setVmwareCmd(cmd string) string {
 }
 
 func vmrun(args ...string) (string, string, error) {
+	// vmrun with nogui on VMware Fusion through at least 8.0.1 doesn't work right
+	// if the umask is set to not allow world-readable permissions
+	_ = syscall.Umask(022)
 	cmd := exec.Command(vmrunbin, args...)
 	if os.Getenv("MACHINE_DEBUG") != "" {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
For some reason, invoking vmrun with the nogui option doesn't work right if umask is set to not allow world-readable permissions by default.  This seems to be true at least in VMware Fusion 7.0.x through 8.0.1 when running on OS X 10.10 (Yosemite) and possibly other versions (although at the moment it doesn't seem to be an issue in El Capitan with Fusion 8.0.2).  

As a workaround, this changes the driver to explicitly set the umask to 022 before invoking vmrun.

This might resolve issue #1671 for some people.