### PR TITLE
Add emacs support to env command

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -130,6 +130,10 @@ func shellCfgSet(c CommandLine, api libmachine.API) (*ShellConfig, error) {
 		shellCfg.Prefix = "SET "
 		shellCfg.Suffix = "\n"
 		shellCfg.Delimiter = "="
+	case "emacs":
+		shellCfg.Prefix = "(setenv \""
+		shellCfg.Suffix = "\")\n"
+		shellCfg.Delimiter = "\" \""
 	default:
 		shellCfg.Prefix = "export "
 		shellCfg.Suffix = "\"\n"
@@ -170,6 +174,10 @@ func shellCfgUnset(c CommandLine, api libmachine.API) (*ShellConfig, error) {
 		shellCfg.Prefix = "SET "
 		shellCfg.Suffix = "\n"
 		shellCfg.Delimiter = "="
+	case "emacs":
+		shellCfg.Prefix = "(setenv \""
+		shellCfg.Suffix = ")\n"
+		shellCfg.Delimiter = "\" nil"
 	default:
 		shellCfg.Prefix = "unset "
 		shellCfg.Suffix = "\n"
@@ -229,6 +237,9 @@ func (g *EnvUsageHintGenerator) GenerateUsageHint(userShell string, args []strin
 	case "cmd":
 		cmd = fmt.Sprintf("\tFOR /f \"tokens=*\" %%i IN ('%s') DO %%i", commandLine)
 		comment = "REM"
+	case "emacs":
+		cmd = fmt.Sprintf("(with-temp-buffer (shell-command \"%s\" (current-buffer)) (eval-buffer))", commandLine)
+		comment = ";;"
 	default:
 		cmd = fmt.Sprintf("eval \"$(%s)\"", commandLine)
 	}

--- a/test/integration/core/env_shell.bats
+++ b/test/integration/core/env_shell.bats
@@ -51,6 +51,15 @@ load ${BASE_TEST_DIR}/helpers.bash
   [[ ${lines[4]} == "set -gx NO_PROXY \"$(machine ip $NAME)\";" ]]
 }
 
+@test "$DRIVER: test emacs notation" {
+  run machine env --shell emacs --no-proxy $NAME
+  [[ ${lines[0]} == "(setenv \"DOCKER_TLS_VERIFY\" \"1\")" ]]
+  [[ ${lines[1]} == "(setenv \"DOCKER_HOST\" \"$(machine url $NAME)\")" ]]
+  [[ ${lines[2]} == "(setenv \"DOCKER_CERT_PATH\" \"$MACHINE_STORAGE_PATH/machines/$NAME\")" ]]
+  [[ ${lines[3]} == "(setenv \"DOCKER_MACHINE_NAME\" \"$NAME\")" ]]
+  [[ ${lines[4]} == "(setenv \"NO_PROXY\" \"$(machine ip $NAME)\")" ]]
+}
+
 @test "$DRIVER: test no proxy with NO_PROXY already set" {
   export NO_PROXY=localhost
   run machine env --no-proxy $NAME
@@ -103,4 +112,12 @@ load ${BASE_TEST_DIR}/helpers.bash
   [[ ${lines[1]} == "SET DOCKER_HOST=" ]]
   [[ ${lines[2]} == "SET DOCKER_CERT_PATH=" ]]
   [[ ${lines[3]} == "SET DOCKER_MACHINE_NAME=" ]]
+}
+
+@test "$DRIVER: unset with emacs shell" {
+  run machine env --shell emacs -u
+  [[ ${lines[0]} == "(setenv \"DOCKER_TLS_VERIFY\" nil)" ]]
+  [[ ${lines[1]} == "(setenv \"DOCKER_HOST\" nil)" ]]
+  [[ ${lines[2]} == "(setenv \"DOCKER_CERT_PATH\" nil)" ]]
+  [[ ${lines[3]} == "(setenv \"DOCKER_MACHINE_NAME\" nil)" ]]
 }


### PR DESCRIPTION
This is useful for setting docker client env vars within Emacs, when using docker.el for example: https://github.com/dougm/docker.el/blob/machine/docker-machine.el#L36-L50