### PR TITLE
Simplify makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: bash
 services: docker
 env:
   matrix:
-    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="make dco fmt lint vet test-long coverage-send"
+    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="make validate coverage-send"
     - TARGET_OS=darwin TARGET_ARCH=amd64 TARGETS="cross"
     - TARGET_OS=windows TARGET_ARCH=amd64 TARGETS="cross"
 script: USE_CONTAINER=true make "$TARGETS"

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -57,6 +57,6 @@ install:
 
 clean: coverage-clean build-clean
 test: dco fmt test-short lint vet
-validate: dco fmt vet lint test-short test-long
+validate: dco fmt lint vet test-long
 
 .PHONY: .all_build .all_coverage .all_release .all_test .all_validate test build validate clean

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -9,6 +9,3 @@ test-long:
 test-integration: build
 	$(eval TESTSUITE=$(filter-out $@,$(MAKECMDGOALS)))
 	test/integration/run-bats.sh $(TESTSUITE)
-
-%:
-	@:

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -8,15 +8,12 @@ current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 dco:
 	@echo `bash $(current_dir)/../script/validate-dco`
 
-# Fmt
 fmt:
 	@test -z "$$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 
-# Vet
-vet: build
+vet:
 	@test -z "$$(go vet $(PKGS) 2>&1 | tee /dev/stderr)"
 
-# Lint
 lint:
 	$(if $(GOLINT), , \
 		$(error Please install golint: go get -u github.com/golang/lint/golint))


### PR DESCRIPTION
- Remove some duplication / redundant comments
- vet doesn't need to build (Does it?)

Now `make test` will not build at the end.

Signed-off-by: David Gageot <david@gageot.net>