### PR TITLE
add timeout override to ls command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -37,6 +37,8 @@ type CommandLine interface {
 
 	Bool(name string) bool
 
+	Int(name string) int
+
 	String(name string) string
 
 	StringSlice(name string) []string
@@ -215,6 +217,11 @@ var Commands = []cli.Command{
 				Name:  "filter",
 				Usage: "Filter output based on conditions provided",
 				Value: &cli.StringSlice{},
+			},
+			cli.IntFlag{
+				Name:  "timeout, t",
+				Usage: fmt.Sprintf("Timeout in seconds, default to %ds", DefaultTimeoutDuration),
+				Value: DefaultTimeoutDuration,
 			},
 		},
 		Name:   "ls",

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -21,8 +21,10 @@ import (
 	"github.com/skarademir/naturalsort"
 )
 
+const DefaultTimeoutDuration = 10
+
 var (
-	stateTimeoutDuration = 10 * time.Second
+	stateTimeoutDuration = DefaultTimeoutDuration * time.Second
 )
 
 // FilterOptions -
@@ -47,6 +49,9 @@ type HostListItem struct {
 }
 
 func cmdLs(c CommandLine, api libmachine.API) error {
+	stateTimeoutDuration = time.Duration(c.Int("timeout")) * time.Second
+	log.Debugf("ls timeout set to %d seconds", stateTimeoutDuration/time.Second)
+
 	quiet := c.Bool("quiet")
 	filters, err := parseFilters(c.StringSlice("filter"))
 	if err != nil {

--- a/docs/reference/ls.md
+++ b/docs/reference/ls.md
@@ -16,8 +16,21 @@ parent="smn_machine_subcmds"
 
     Options:
 
-       --quiet, -q					Enable quiet mode
+       --quiet, -q					                Enable quiet mode
        --filter [--filter option --filter option]	Filter output based on conditions provided
+       --timeout, -t				                Timeout in seconds, default to 10s
+
+## Timeout
+
+The `ls` command tries to reach each host in parallel. If a given host does not answer in less than 10 seconds, the `ls` command
+will state that this host is in `timeout`. In some circumstances (poor connection, high load or while troubleshooting) you may want to
+increase or decrease this value. You can use the `-t` flag for this purpose with a numerical value in seconds.
+
+### Example
+
+    $ docker-machine ls -t 12
+    NAME      ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER   ERRORS
+    default   -        virtualbox   Running   tcp://192.168.99.100:2376           v1.9.0
 
 ## Filtering
 


### PR DESCRIPTION
This add a `--timeout` flag for the `ls` command. 
The default stays the same at 10 seconds but can be overriden to suit a specific need.