### PR TITLE
Add context, driver name & command to crash report

### DIFF
--- a/libmachine/crashreport/crash_report.go
+++ b/libmachine/crashreport/crash_report.go
@@ -40,7 +40,7 @@ func Configure(key string) {
 }
 
 // Send through http the crash report to bugsnag need a call to Configure(apiKey) before
-func Send(error error) error {
+func Send(err error, context string, driverName string, command string) error {
 	if noReportFileExist() {
 		err := errors.New("Not sending report since the optout file exist.")
 		log.Debug(err)
@@ -79,7 +79,7 @@ func Send(error error) error {
 		buffer.WriteString(message + "\n")
 	}
 	metaData.Add("history", "trace", buffer.String())
-	return bugsnag.Notify(error, metaData)
+	return bugsnag.Notify(err, metaData, bugsnag.SeverityError, bugsnag.Context{String: context}, bugsnag.ErrorClass{Name: fmt.Sprintf("%s/%s", driverName, command)})
 }
 
 func noReportFileExist() bool {

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -135,13 +135,13 @@ func (h *Host) Upgrade() error {
 
 	provisioner, err := provision.DetectProvisioner(h.Driver)
 	if err != nil {
-		crashreport.Send(err)
+		crashreport.Send(err, "provision.DetectProvisioner", h.Driver.DriverName(), "Upgrade")
 		return err
 	}
 
 	log.Info("Upgrading docker...")
 	if err := provisioner.Package("docker", pkgaction.Upgrade); err != nil {
-		crashreport.Send(err)
+		crashreport.Send(err, "provisioner.Package", h.Driver.DriverName(), "Upgrade")
 		return err
 	}
 

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -98,7 +98,7 @@ func (api *Client) Create(h *host.Host) error {
 	log.Info("Creating machine...")
 
 	if err := api.performCreate(h); err != nil {
-		crashreport.Send(err)
+		crashreport.Send(err, "api.performCreate", h.DriverName, "Create")
 		return err
 	}
 


### PR DESCRIPTION
This add Context, Driver name & command to bugsnag crash reporting.

Hopefully this should help in triaging errors.