### PR TITLE
Use bundled bugsnag APIKey

### DIFF
--- a/libmachine/crashreport/crash_report.go
+++ b/libmachine/crashreport/crash_report.go
@@ -19,38 +19,30 @@ import (
 	"github.com/docker/machine/version"
 )
 
-// We bundle a bugnsag key, but we disable its usage for now
-// this ease testing just set useDefaultKey to true
-// and yet we bundle the code without activating it by default.
-var useDefaultKey = false
-
-const defaultAPIKey = "a9697f9a010c33ee218a65e5b1f3b0c1"
+const (
+	defaultAPIKey  = "a9697f9a010c33ee218a65e5b1f3b0c1"
+	noreportAPIKey = "no-report"
+)
 
 var apiKey string
 
 // Configure the apikey for bugnag
 func Configure(key string) {
+	apiKey = defaultAPIKey
 	if key != "" {
 		apiKey = key
-		return
-	}
-	if useDefaultKey {
-		apiKey = defaultAPIKey
 	}
 }
 
 // Send through http the crash report to bugsnag need a call to Configure(apiKey) before
 func Send(err error, context string, driverName string, command string) error {
-	if noReportFileExist() {
-		err := errors.New("Not sending report since the optout file exist.")
-		log.Debug(err)
-		return err
+	if noReportFileExist() || apiKey == noreportAPIKey {
+		log.Debug("Opting out of crash reporting.")
+		return nil
 	}
 
 	if apiKey == "" {
-		err := errors.New("Not sending report since no api key has been set.")
-		log.Debug(err)
-		return err
+		return errors.New("Not sending report since no api key has been set.")
 	}
 
 	bugsnag.Configure(bugsnag.Configuration{

--- a/test/integration/run-bats.sh
+++ b/test/integration/run-bats.sh
@@ -93,6 +93,7 @@ export MACHINE_BIN_NAME=docker-machine
 export BATS_LOG="$MACHINE_ROOT/bats.log"
 export B2D_LOCATION=~/.docker/machine/cache/boot2docker.iso
 export SHARED_NAME="bats-$DRIVER-test-shared-$(date +%s)"
+export MACHINE_BUGSNAG_API_TOKEN=no-report
 
 # This function gets used in the integration tests, so export it.
 export -f machine


### PR DESCRIPTION
As per @docker/machine-maintainers decision, we now use the default embedded bugsnag key for the upcoming 0.5.3 release