### PR TITLE
introduce dind (Docker in Docker) option to `config` command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -151,6 +151,10 @@ var Commands = []cli.Command{
 				Name:  "swarm",
 				Usage: "Display the Swarm config instead of the Docker daemon",
 			},
+			cli.BoolFlag{
+				Name:  "dind",
+				Usage: "Generate CLI arguments to forward the config to a Docker in Docker client",
+			},
 		},
 	},
 	{

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,7 +14,65 @@ Show the Docker client configuration for a machine.
 
     $ docker-machine config dev
     --tlsverify
-    --tlscacert="/Users/ehazlett/.docker/machines/dev/ca.pem"
-    --tlscert="/Users/ehazlett/.docker/machines/dev/cert.pem"
-    --tlskey="/Users/ehazlett/.docker/machines/dev/key.pem"
-    -H tcp://192.168.99.103:2376
+    --tlscacert="/home/bjaglin/.docker/machine/certs/ca.pem"
+    --tlscert="/home/bjaglin/.docker/machine/certs/cert.pem"
+    --tlskey="/home/bjaglin/.docker/machine/certs/key.pem"
+    -H=tcp://192.168.99.100:2376
+
+You can pass the arguments right after the `docker` command via command
+substitution on Unix shells:
+
+    $ docker $(docker-machine config dev) info
+    Containers: 58
+    Images: 545
+    Server Version: 1.9.1
+    Storage Driver: overlay
+     Backing Filesystem: extfs
+    Execution Driver: native-0.2
+    Logging Driver: json-file
+    Kernel Version: 4.2.0-19-generic
+    Operating System: Ubuntu 15.10
+    CPUs: 4
+    Total Memory: 11.64 GiB
+    Name: t440s
+    ID: 4CO2:NGIJ:KC6L:MBYG:BXNH:DRJK:GM5J:LQHT:H6QD:7RA2:FX2O:NRXF
+    WARNING: No swap limit support
+
+
+## Docker in Docker
+
+If you use want to forward the configuration to a Docker client running within
+a container, you can start this container, use the `--dind` flag:
+
+    $ docker-machine config --dind b2d
+    --volume="/home/bjaglin/.docker/machine/machines/b2d:/etc/docker/cert:ro"
+    --env="DOCKER_CERT_PATH=/etc/docker/cert"
+    --env="DOCKER_TLS_VERIFY=1"
+    --env="DOCKER_HOST=tcp://192.168.99.100:2376"
+
+Note that the configuration should passed as arguments to the `docker run`
+command and not to the `docker` client itself, as the container being started
+will be run on the local engine (or a remote one if `DOCKER_HOST` has been set
+earlier).
+
+    $ docker run $(docker-machine config --dind b2d) docker:1.9.0 docker version
+    Client:
+     Version:      1.9.0
+     API version:  1.21
+     Go version:   go1.4.3
+     Git commit:   76d6bc9
+     Built:        Tue Nov  3 19:20:09 UTC 2015
+     OS/Arch:      linux/amd64
+    
+    Server:
+     Version:      1.9.1
+     API version:  1.21
+     Go version:   go1.4.3
+     Git commit:   a34a1d5
+     Built:        Fri Nov 20 17:56:04 UTC 2015
+     OS/Arch:      linux/amd64
+
+This is an advanced use-case, useful when using containers relying on a Docker
+client available within the container, typically for orchestration. The Docker
+client within the container might be part of the image, or bind-mounted (which
+requires the binary to be statically linked).

--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -38,6 +38,12 @@ use_shared_machine
   [ "$status" -eq 0  ]
 }
 
+@test "$DRIVER: run busybox container through a Docker in Docker client" {
+  run docker $(machine config $NAME) run $(machine config --dind $NAME) busybox echo hello world
+  echo ${output}
+  [ "$status" -eq 0  ]
+}
+
 @test "$DRIVER: url" {
   run machine url $NAME
   echo ${output}


### PR DESCRIPTION
I am using [Crane](https://github.com/michaelsauter/crane) within a container to orchestrate a remote engine. If I setup my local client to use the remote engine, the orchestration container is spawned remotely, so I can't bind-mount any configuration into it. The `--dind` flag introduced in that PR allows me to run a local orchestrator onto which I can bind-mount, yet still pointing at my remote target.

I first thought about extending the `env` command, but I ended up putting in `config`, although neither of them feels 100% right...

I have not tested the functionality from a Windows client, but as far as I can tell (which is not much because command substitution is very limited, so even the existing `config` might be tricky), all is taken care in terms of spaces and specificities of the Windows filesystem mounts.