### PR TITLE
Add --openstack-keypair-name and --openstack-private-key-file

### DIFF
--- a/docs/drivers/openstack.md
+++ b/docs/drivers/openstack.md
@@ -28,10 +28,12 @@ Options:
 -   `--openstack-floatingip-pool`: The IP pool that will be used to get a public IP can assign it to the machine. If there is an
     IP address already allocated but not assigned to any machine, this IP will be chosen and assigned to the machine. If
     there is no IP address already allocated a new IP will be allocated and assigned to the machine.
+-   `--openstack-keypair-name`: Specify the existing Nova keypair to use.
 -   `--openstack-insecure`: Explicitly allow openstack driver to perform "insecure" SSL (https) requests. The server's certificate will not be verified against any certificate authorities. This option should be used with caution.
 -   `--openstack-ip-version`: If the instance has both IPv4 and IPv6 address, you can select IP version. If not provided `4` will be used.
 -   `--openstack-net-name` or `--openstack-net-id`: Identify the private network the machine will be connected on. If your OpenStack project project contains only one private network it will be use automatically.
 -   `--openstack-password`: User password. It can be omitted if the standard environment variable `OS_PASSWORD` is set.
+-   `--openstack-private-key-file`: Used with `--openstack-keypair-name`, associates the private key to the keypair.
 -   `--openstack-region`: The region to work on. Can be omitted if there is only one region on the OpenStack.
 -   `--openstack-sec-groups`: If security groups are available on your OpenStack you can specify a comma separated list
     to use for the machine (e.g. `secgrp001,secgrp002`).
@@ -57,9 +59,11 @@ Environment variables and default values:
 | `--openstack-image-name`        | `OS_IMAGE_NAME`        | -           |
 | `--openstack-insecure`          | `OS_INSECURE`          | `false`     |
 | `--openstack-ip-version`        | `OS_IP_VERSION`        | `4`         |
+| `--openstack-keypair-name`      | `OS_KEYPAIR_NAME`      | -           |
 | `--openstack-net-id`            | `OS_NETWORK_ID`        | -           |
 | `--openstack-net-name`          | `OS_NETWORK_NAME`      | -           |
 | `--openstack-password`          | `OS_PASSWORD`          | -           |
+| `--openstack-private-key-file`  | `OS_PRIVATE_KEY_FILE`  | -           |
 | `--openstack-region`            | `OS_REGION_NAME`       | -           |
 | `--openstack-sec-groups`        | `OS_SECURITY_GROUPS`   | -           |
 | `--openstack-ssh-port`          | `OS_SSH_PORT`          | `22`        |

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	DeleteInstance(d *Driver) error
 	WaitForInstanceStatus(d *Driver, status string) error
 	GetInstanceIPAddresses(d *Driver) ([]IPAddress, error)
+	GetPublicKey(keyPairName string) ([]byte, error)
 	CreateKeyPair(d *Driver, name string, publicKey string) error
 	DeleteKeyPair(d *Driver, name string) error
 	GetNetworkID(d *Driver) (string, error)
@@ -298,6 +299,14 @@ func (c *GenericClient) GetTenantID(d *Driver) (string, error) {
 	})
 
 	return tenantId, err
+}
+
+func (c *GenericClient) GetPublicKey(keyPairName string) ([]byte, error) {
+	kp, err := keypairs.Get(c.Compute, keyPairName).Extract()
+	if err != nil {
+		return nil, err
+	}
+	return []byte(kp.PublicKey), nil
 }
 
 func (c *GenericClient) CreateKeyPair(d *Driver, name string, publicKey string) error {


### PR DESCRIPTION
Import and reuse existing keypairs.
This is due to some providers limitations (number of allowed keys).

It adds two flags:
`--openstack-keypair-name`: Keypair existing in Nova
`--openstack-private-key-file`: Private key associated to the Keypair

It makes both options mandatory together.

If a keypair is specified, then the public key is downloaded, and with the private key, it becomes the new keypair in use by the machine. If no keypair is specified, the driver default behaviour is to create and upload a keypair to Nova.

Refers to issue: https://github.com/docker/machine/issues/1738

Signed-off-by: Fabrizio Soppelsa <fsoppelsa@mirantis.com>

---

```
?   	github.com/docker/machine	[no test files]
ok  	github.com/docker/machine/commands	0.007s
?   	github.com/docker/machine/commands/commandstest	[no test files]
ok  	github.com/docker/machine/commands/mcndirs	0.002s
ok  	github.com/docker/machine/drivers/amazonec2	5.301s
?   	github.com/docker/machine/drivers/amazonec2/amz	[no test files]
?   	github.com/docker/machine/drivers/azure	[no test files]
ok  	github.com/docker/machine/drivers/digitalocean	0.002s
?   	github.com/docker/machine/drivers/errdriver	[no test files]
ok  	github.com/docker/machine/drivers/exoscale	0.004s
?   	github.com/docker/machine/drivers/fakedriver	[no test files]
ok  	github.com/docker/machine/drivers/generic	0.003s
ok  	github.com/docker/machine/drivers/google	0.003s
ok  	github.com/docker/machine/drivers/hyperv	0.003s
?   	github.com/docker/machine/drivers/none	[no test files]
ok  	github.com/docker/machine/drivers/openstack	0.003s
ok  	github.com/docker/machine/drivers/rackspace	0.004s
ok  	github.com/docker/machine/drivers/softlayer	0.004s
ok  	github.com/docker/machine/drivers/virtualbox	0.004s
?   	github.com/docker/machine/drivers/vmwarefusion	[no test files]
ok  	github.com/docker/machine/drivers/vmwarevcloudair	0.003s
ok  	github.com/docker/machine/drivers/vmwarevsphere	0.003s
?   	github.com/docker/machine/drivers/vmwarevsphere/errors	[no test files]
?   	github.com/docker/machine/libmachine	[no test files]
?   	github.com/docker/machine/libmachine/auth	[no test files]
ok  	github.com/docker/machine/libmachine/cert	0.664s
ok  	github.com/docker/machine/libmachine/check	0.003s
?   	github.com/docker/machine/libmachine/crashreport	[no test files]
ok  	github.com/docker/machine/libmachine/drivers	0.003s
?   	github.com/docker/machine/libmachine/drivers/plugin	[no test files]
ok  	github.com/docker/machine/libmachine/drivers/plugin/localbinary	0.002s
?   	github.com/docker/machine/libmachine/drivers/rpc	[no test files]
?   	github.com/docker/machine/libmachine/engine	[no test files]
?   	github.com/docker/machine/libmachine/examples	[no test files]
ok  	github.com/docker/machine/libmachine/host	0.003s
?   	github.com/docker/machine/libmachine/hosttest	[no test files]
?   	github.com/docker/machine/libmachine/libmachinetest	[no test files]
ok  	github.com/docker/machine/libmachine/log	0.003s
?   	github.com/docker/machine/libmachine/mcndockerclient	[no test files]
?   	github.com/docker/machine/libmachine/mcnerror	[no test files]
?   	github.com/docker/machine/libmachine/mcnflag	[no test files]
ok  	github.com/docker/machine/libmachine/mcnutils	0.004s
ok  	github.com/docker/machine/libmachine/persist	0.005s
?   	github.com/docker/machine/libmachine/persist/persisttest	[no test files]
?   	github.com/docker/machine/libmachine/provider	[no test files]
ok  	github.com/docker/machine/libmachine/provision	0.004s
ok  	github.com/docker/machine/libmachine/provision/pkgaction	0.002s
ok  	github.com/docker/machine/libmachine/provision/serviceaction	0.002s
ok  	github.com/docker/machine/libmachine/ssh	0.429s
ok  	github.com/docker/machine/libmachine/state	0.002s
?   	github.com/docker/machine/libmachine/swarm	[no test files]
?   	github.com/docker/machine/libmachine/version	[no test files]
?   	github.com/docker/machine/version	[no test files]
```