### PR TITLE
Fixes #2595 remove fails when config.json is not found

### DIFF
--- a/commands/rm_test.go
+++ b/commands/rm_test.go
@@ -53,3 +53,87 @@ func TestCmdRm(t *testing.T) {
 	assert.False(t, libmachinetest.Exists(api, "machineToRemove2"))
 	assert.True(t, libmachinetest.Exists(api, "machine"))
 }
+
+func TestCmdRmforcefully(t *testing.T) {
+	commandLine := &commandstest.FakeCommandLine{
+		CliArgs: []string{"machineToRemove1", "machineToRemove2"},
+		LocalFlags: &commandstest.FakeFlagger{
+			Data: map[string]interface{}{
+				"force": true,
+			},
+		},
+	}
+	api := &libmachinetest.FakeAPI{
+		Hosts: []*host.Host{
+			{
+				Name:   "machineToRemove1",
+				Driver: &fakedriver.Driver{},
+			},
+			{
+				Name:   "machineToRemove2",
+				Driver: &fakedriver.Driver{},
+			},
+		},
+	}
+
+	err := cmdRm(commandLine, api)
+	assert.NoError(t, err)
+
+	assert.False(t, libmachinetest.Exists(api, "machineToRemove1"))
+	assert.False(t, libmachinetest.Exists(api, "machineToRemove2"))
+}
+
+func TestCmdRmforceDoesAutoConfirm(t *testing.T) {
+	commandLine := &commandstest.FakeCommandLine{
+		CliArgs: []string{"machineToRemove1", "machineToRemove2"},
+		LocalFlags: &commandstest.FakeFlagger{
+			Data: map[string]interface{}{
+				"y":     false,
+				"force": true,
+			},
+		},
+	}
+	api := &libmachinetest.FakeAPI{
+		Hosts: []*host.Host{
+			{
+				Name:   "machineToRemove1",
+				Driver: &fakedriver.Driver{},
+			},
+			{
+				Name:   "machineToRemove2",
+				Driver: &fakedriver.Driver{},
+			},
+		},
+	}
+
+	err := cmdRm(commandLine, api)
+	assert.NoError(t, err)
+
+	assert.False(t, libmachinetest.Exists(api, "machineToRemove1"))
+	assert.False(t, libmachinetest.Exists(api, "machineToRemove2"))
+}
+
+func TestCmdRmforceConfirmUnset(t *testing.T) {
+	commandLine := &commandstest.FakeCommandLine{
+		CliArgs: []string{"machineToRemove1"},
+		LocalFlags: &commandstest.FakeFlagger{
+			Data: map[string]interface{}{
+				"y":     false,
+				"force": false,
+			},
+		},
+	}
+	api := &libmachinetest.FakeAPI{
+		Hosts: []*host.Host{
+			{
+				Name:   "machineToRemove1",
+				Driver: &fakedriver.Driver{},
+			},
+		},
+	}
+
+	err := cmdRm(commandLine, api)
+	assert.EqualError(t, err, "EOF")
+
+	assert.True(t, libmachinetest.Exists(api, "machineToRemove1"))
+}


### PR DESCRIPTION
This issue occurs when `api.Load()` fails while loading
the `config.json` file, in case the config file is not present.
Refactored the code to handled `-y` and `-f` as documented.

Signed-off-by: Anil Belur <askb23@gmail.com>