### PR TITLE
Enhance shell detection in `env` command

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -248,16 +248,14 @@ func (g *EnvUsageHintGenerator) GenerateUsageHint(userShell string, args []strin
 }
 
 func detectShell() (string, error) {
-	// attempt to get the SHELL env var
-	shell := filepath.Base(os.Getenv("SHELL"))
+	shell := os.Getenv("SHELL")
 
-	log.Debugf("shell: %s", shell)
 	if shell == "" {
-		// check for windows env and not bash (i.e. msysgit, etc)
 		if runtime.GOOS == "windows" {
-			log.Info("On Windows, please specify either 'cmd' or 'powershell' with the --shell flag.\n\n")
+			fmt.Printf("You can further specify your shell with either 'cmd' or 'powershell' with the --shell flag.\n\n")
+			return "cmd", nil // this could be either powershell or cmd, defaulting to cmd
 		}
-
+		fmt.Printf("The default lines below are for a sh/bash shell, you can specify the shell you're using, with the --shell flag.\n\n")
 		return "", ErrUnknownShell
 	}
 
@@ -265,5 +263,5 @@ func detectShell() (string, error) {
 		return "fish", nil
 	}
 
-	return shell, nil
+	return filepath.Base(shell), nil
 }

--- a/commands/env.go
+++ b/commands/env.go
@@ -261,5 +261,9 @@ func detectShell() (string, error) {
 		return "", ErrUnknownShell
 	}
 
+	if os.Getenv("__fish_bin_dir") != "" {
+		return "fish", nil
+	}
+
 	return shell, nil
 }

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -547,3 +547,22 @@ func TestShellCfgUnset(t *testing.T) {
 		os.Setenv(test.noProxyVar, "")
 	}
 }
+
+func TestDetectBash(t *testing.T) {
+	original_shell := os.Getenv("SHELL")
+	os.Setenv("SHELL", "/bin/bash")
+	defer os.Setenv("SHELL", original_shell)
+	shell, _ := detectShell()
+	assert.Equal(t, "bash", shell)
+}
+
+func TestDetectFish(t *testing.T) {
+	original_shell := os.Getenv("SHELL")
+	os.Setenv("SHELL", "/bin/bash")
+	defer os.Setenv("SHELL", original_shell)
+	original_fishdir := os.Getenv("__fish_bin_dir")
+	os.Setenv("__fish_bin_dir", "/usr/local/Cellar/fish/2.2.0/bin")
+	defer os.Setenv("__fish_bin_dir", original_fishdir)
+	shell, _ := detectShell()
+	assert.Equal(t, "fish", shell)
+}

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"fmt"
+
 	"github.com/docker/machine/commands/commandstest"
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/drivers/fakedriver"
@@ -549,20 +551,32 @@ func TestShellCfgUnset(t *testing.T) {
 }
 
 func TestDetectBash(t *testing.T) {
-	original_shell := os.Getenv("SHELL")
+	originalShell := os.Getenv("SHELL")
 	os.Setenv("SHELL", "/bin/bash")
-	defer os.Setenv("SHELL", original_shell)
-	shell, _ := detectShell()
+	defer os.Setenv("SHELL", originalShell)
+	shell, err := detectShell()
+	assert.Nil(t, err)
 	assert.Equal(t, "bash", shell)
 }
 
 func TestDetectFish(t *testing.T) {
-	original_shell := os.Getenv("SHELL")
+	originalShell := os.Getenv("SHELL")
 	os.Setenv("SHELL", "/bin/bash")
-	defer os.Setenv("SHELL", original_shell)
-	original_fishdir := os.Getenv("__fish_bin_dir")
+	defer os.Setenv("SHELL", originalShell)
+	originalFishdir := os.Getenv("__fish_bin_dir")
 	os.Setenv("__fish_bin_dir", "/usr/local/Cellar/fish/2.2.0/bin")
-	defer os.Setenv("__fish_bin_dir", original_fishdir)
-	shell, _ := detectShell()
+	defer os.Setenv("__fish_bin_dir", originalFishdir)
+	shell, err := detectShell()
+	assert.Nil(t, err)
 	assert.Equal(t, "fish", shell)
+}
+
+func TestUnknowShell(t *testing.T) {
+	originalShell := os.Getenv("SHELL")
+	os.Setenv("SHELL", "")
+	defer os.Setenv("SHELL", originalShell)
+	shell, err := detectShell()
+	fmt.Println(shell)
+	assert.Equal(t, err, ErrUnknownShell)
+	assert.Equal(t, "", shell)
 }

--- a/commands/env_windows_test.go
+++ b/commands/env_windows_test.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetect(t *testing.T) {
+	originalShell := os.Getenv("SHELL")
+	os.Setenv("SHELL", "")
+	defer os.Setenv("SHELL", originalShell)
+	shell, err := detectShell()
+	assert.Nil(t, err)
+	assert.Equal(t, "cmd", shell)
+}


### PR DESCRIPTION
This fix : 
- un-hide the message displayed to the user on windows stating to use the `--shell` flag
- On windows, default to cmd if we detect we are not running in cywin/mingw etc...
- Properly detect fish shell
- Unit test for everyone.

This fixes #1441, #732