### PR TITLE
Disable ControlMaster and ControlPath on SSH connections

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -50,6 +50,8 @@ var (
 	baseSSHArgs = []string{
 		"-o", "PasswordAuthentication=no",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails


### PR DESCRIPTION
Ref: https://github.com/docker/machine/issues/1591#issuecomment-126169020

I personally wouldn't merge this yet: this is meant to fix a very specific issue in a very specific place; I don't think we should have to trade-off a responsive create for a slower (or at least forcibly slower) ssh command.

However, I do believe those two flags should be added wherever we try to boot a machine and need to configure it. 

Suggestions welcome.