### PR TITLE
Allow concurrently saving data to file (fixes #2612)

### DIFF
--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -49,10 +49,6 @@ func (s Filestore) saveToFile(data []byte, file string) error {
 		return err
 	}
 
-	if err = os.Remove(file); err != nil {
-		return err
-	}
-
 	if err = os.Rename(tmpfi.Name(), file); err != nil {
 		return err
 	}


### PR DESCRIPTION
The explicit os.Remove is not necessary because os.Rename will already
overwrite the target path (except perhaps on plan9, but docker-machine
doesn't support that anyway - see also https://github.com/golang/go/issues/13673).

This 'fixes' race conditions when 2 processes are saving the same file
concurrently. Of course if those 2 processes attempt to write different
data this might still lead to surprising results, but in practice 'last
writer wins' seems like a sane default strategy.

Signed-off-by: Arnout Engelen <arnout@bzzt.net>