### PR TITLE
Add code to ensure RPC server cleanup in happy path

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -22,6 +22,8 @@ func cmdActive(c CommandLine, api libmachine.API) error {
 		return fmt.Errorf("Error getting active host: %s", err)
 	}
 
+	defer libmachine.CloseHosts(api, hosts)
+
 	items := getHostListItems(hosts, hostsInError)
 
 	for _, item := range items {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -78,6 +78,8 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 		return consolidateErrs(errs)
 	}
 
+	defer libmachine.CloseHosts(api, hosts)
+
 	if len(hosts) == 0 {
 		return ErrNoMachineSpecified
 	}

--- a/commands/config.go
+++ b/commands/config.go
@@ -22,6 +22,7 @@ func cmdConfig(c CommandLine, api libmachine.API) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	dockerHost, authOptions, err := check.DefaultConnChecker.Check(host, c.Bool("swarm"))
 	if err != nil {

--- a/commands/create.go
+++ b/commands/create.go
@@ -228,6 +228,10 @@ func cmdCreateInner(c CommandLine, api libmachine.API) error {
 
 	log.Infof("To see how to connect Docker to this machine, run: %s", fmt.Sprintf("%s env %s", os.Args[0], name))
 
+	if err := api.Close(h); err != nil {
+		return fmt.Errorf("Error closing plugin connection to driver: %s", err)
+	}
+
 	return nil
 }
 
@@ -321,10 +325,8 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 		driver = serialDriver.Driver
 	}
 
-	if rpcd, ok := driver.(*rpcdriver.RPCClientDriver); ok {
-		if err := rpcd.Close(); err != nil {
-			return err
-		}
+	if err := libmachine.CloseIfRPCDriver(driver); err != nil {
+		return err
 	}
 
 	return c.Application().Run(os.Args)

--- a/commands/env.go
+++ b/commands/env.go
@@ -76,6 +76,7 @@ func shellCfgSet(c CommandLine, api libmachine.API) (*ShellConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer api.Close(host)
 
 	dockerHost, _, err := check.DefaultConnChecker.Check(host, c.Bool("swarm"))
 	if err != nil {

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -98,12 +98,13 @@ func TestShellCfgSet(t *testing.T) {
 	var tests = []struct {
 		description      string
 		commandLine      CommandLine
-		api              libmachine.API
+		api              *libmachinetest.FakeAPI
 		connChecker      check.ConnChecker
 		noProxyVar       string
 		noProxyValue     string
 		expectedShellCfg *ShellConfig
 		expectedErr      error
+		closedHosts      []string
 	}{
 		{
 			description: "no host name specified",
@@ -148,6 +149,7 @@ func TestShellCfgSet(t *testing.T) {
 				MachineName:     "quux",
 			},
 			expectedErr: nil,
+			closedHosts: []string{"quux"},
 		},
 		{
 			description: "fish shell set happy path",
@@ -184,6 +186,7 @@ func TestShellCfgSet(t *testing.T) {
 				MachineName:     "quux",
 			},
 			expectedErr: nil,
+			closedHosts: []string{"quux"},
 		},
 		{
 			description: "powershell set happy path",
@@ -220,6 +223,7 @@ func TestShellCfgSet(t *testing.T) {
 				MachineName:     "quux",
 			},
 			expectedErr: nil,
+			closedHosts: []string{"quux"},
 		},
 		{
 			description: "emacs set happy path",
@@ -256,6 +260,7 @@ func TestShellCfgSet(t *testing.T) {
 				MachineName:     "quux",
 			},
 			expectedErr: nil,
+			closedHosts: []string{"quux"},
 		},
 		{
 			description: "cmd.exe happy path",
@@ -292,6 +297,7 @@ func TestShellCfgSet(t *testing.T) {
 				MachineName:     "quux",
 			},
 			expectedErr: nil,
+			closedHosts: []string{"quux"},
 		},
 		{
 			description: "bash shell set happy path with --no-proxy flag; no existing environment variable set",
@@ -336,6 +342,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyVar:   "NO_PROXY",
 			noProxyValue: "",
 			expectedErr:  nil,
+			closedHosts:  []string{"quux"},
 		},
 		{
 			description: "bash shell set happy path with --no-proxy flag; existing environment variable _is_ set",
@@ -380,6 +387,7 @@ func TestShellCfgSet(t *testing.T) {
 			noProxyVar:   "no_proxy",
 			noProxyValue: "192.168.59.1",
 			expectedErr:  nil,
+			closedHosts:  []string{"quux"},
 		},
 	}
 
@@ -394,6 +402,7 @@ func TestShellCfgSet(t *testing.T) {
 		shellCfg, err := shellCfgSet(test.commandLine, test.api)
 		assert.Equal(t, test.expectedShellCfg, shellCfg)
 		assert.Equal(t, test.expectedErr, err)
+		test.api.AssertClosed(t, test.closedHosts)
 
 		os.Unsetenv(test.noProxyVar)
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -30,6 +30,7 @@ func cmdInspect(c CommandLine, api libmachine.API) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	tmplString := c.String("format")
 	if tmplString != "" {

--- a/commands/ip_test.go
+++ b/commands/ip_test.go
@@ -36,6 +36,8 @@ func TestCmdIP(t *testing.T) {
 		},
 	}
 
+	defer api.AssertClosed(t, []string{"machine"})
+
 	stdoutGetter := commandstest.NewStdoutGetter()
 	defer stdoutGetter.Stop()
 

--- a/commands/kill_test.go
+++ b/commands/kill_test.go
@@ -47,6 +47,8 @@ func TestCmdKill(t *testing.T) {
 		},
 	}
 
+	defer api.AssertClosed(t, []string{"machineToKill1", "machineToKill2"})
+
 	err := cmdKill(commandLine, api)
 	assert.NoError(t, err)
 

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -63,6 +63,8 @@ func cmdLs(c CommandLine, api libmachine.API) error {
 		return err
 	}
 
+	defer libmachine.CloseHosts(api, hostList)
+
 	hostList = filterHosts(hostList, filters)
 
 	// Just print out the names if we're being quiet

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -21,6 +21,7 @@ func cmdRm(c CommandLine, api libmachine.API) error {
 		if err != nil {
 			return fmt.Errorf("Error removing host %q: %s", hostName, err)
 		}
+		defer api.Close(h)
 
 		if !confirm && !force {
 			userinput, err := confirmInput(fmt.Sprintf("Do you really want to remove %q?", hostName))

--- a/commands/rm_test.go
+++ b/commands/rm_test.go
@@ -46,6 +46,8 @@ func TestCmdRm(t *testing.T) {
 		},
 	}
 
+	defer api.AssertClosed(t, []string{"machineToRemove1", "machineToRemove2"})
+
 	err := cmdRm(commandLine, api)
 	assert.NoError(t, err)
 

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -24,6 +24,7 @@ func cmdSSH(c CommandLine, api libmachine.API) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	currentState, err := host.Driver.GetState()
 	if err != nil {

--- a/commands/status.go
+++ b/commands/status.go
@@ -14,6 +14,7 @@ func cmdStatus(c CommandLine, api libmachine.API) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	currentState, err := host.Driver.GetState()
 	if err != nil {

--- a/commands/stop_test.go
+++ b/commands/stop_test.go
@@ -47,6 +47,8 @@ func TestCmdStop(t *testing.T) {
 		},
 	}
 
+	defer api.AssertClosed(t, []string{"machineToStop1", "machineToStop2"})
+
 	err := cmdStop(commandLine, api)
 	assert.NoError(t, err)
 

--- a/commands/url.go
+++ b/commands/url.go
@@ -15,6 +15,7 @@ func cmdURL(c CommandLine, api libmachine.API) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	url, err := host.URL()
 	if err != nil {

--- a/commands/url_test.go
+++ b/commands/url_test.go
@@ -47,6 +47,8 @@ func TestCmdURL(t *testing.T) {
 		},
 	}
 
+	defer api.AssertClosed(t, []string{"machine"})
+
 	stdoutGetter := commandstest.NewStdoutGetter()
 	defer stdoutGetter.Stop()
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -27,6 +27,7 @@ func printVersion(c CommandLine, api libmachine.API, out io.Writer) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close(host)
 
 	version, err := host.DockerVersion()
 	if err != nil {


### PR DESCRIPTION
I noticed in going over some of the RPC work that we rarely activate the cleanup of the plugin servers ourselves in commands.  This is, of course, not good (we should always cleanup after ourselves and let the heartbeat timeout take care of the rest if there is a panic / non-normal exit on client side).

This PR adds code to do so.  Combined with another PR I have in the pipe to fix truncated logs, it will help aid in diagnosing problems with plugins and with the RPC itself.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>