### PR TITLE
Increase heartbeat interval and timeout

### DIFF
--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	heartbeatTimeout = 500 * time.Millisecond
+	heartbeatTimeout = 10 * time.Second
 )
 
 func RegisterDriver(d drivers.Driver) {

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	heartbeatInterval = 200 * time.Millisecond
+	heartbeatInterval = 5 * time.Second
 )
 
 type RPCClientDriver struct {
@@ -138,13 +138,12 @@ func NewRPCClientDriver(driverName string, rawDriver []byte) (*RPCClientDriver, 
 			select {
 			case <-c.heartbeatDoneCh:
 				return
-			default:
+			case <-time.After(heartbeatInterval):
 				if err := c.Client.Call(HeartbeatMethod, struct{}{}, nil); err != nil {
 					log.Warnf("Error attempting heartbeat call to plugin server: %s", err)
 					c.Close()
 					return
 				}
-				time.Sleep(heartbeatInterval)
 			}
 		}
 	}(c)


### PR DESCRIPTION
@abronan suggested the current timeout is very aggressive and I'm inclined to agree.  This may help us with some of the issues we're seeing with RPC since it eases up a bit on the server.  If it seems to be too long, we can revert.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>