### PR TITLE
Fix truncated plugin binary logs

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -78,6 +78,7 @@ type Plugin struct {
 type Executor struct {
 	pluginStdout, pluginStderr io.ReadCloser
 	DriverName                 string
+	cmd                        *exec.Cmd
 	binaryPath                 string
 }
 
@@ -123,14 +124,14 @@ func (lbe *Executor) Start() (*bufio.Scanner, *bufio.Scanner, error) {
 
 	log.Debugf("Launching plugin server for driver %s", lbe.DriverName)
 
-	cmd := exec.Command(lbe.binaryPath)
+	lbe.cmd = exec.Command(lbe.binaryPath)
 
-	lbe.pluginStdout, err = cmd.StdoutPipe()
+	lbe.pluginStdout, err = lbe.cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error getting cmd stdout pipe: %s", err)
 	}
 
-	lbe.pluginStderr, err = cmd.StderrPipe()
+	lbe.pluginStderr, err = lbe.cmd.StderrPipe()
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error getting cmd stderr pipe: %s", err)
 	}
@@ -141,7 +142,7 @@ func (lbe *Executor) Start() (*bufio.Scanner, *bufio.Scanner, error) {
 	os.Setenv(PluginEnvKey, PluginEnvVal)
 	os.Setenv(PluginEnvDriverName, lbe.DriverName)
 
-	if err := cmd.Start(); err != nil {
+	if err := lbe.cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("Error starting plugin binary: %s", err)
 	}
 
@@ -149,34 +150,34 @@ func (lbe *Executor) Start() (*bufio.Scanner, *bufio.Scanner, error) {
 }
 
 func (lbe *Executor) Close() error {
+	if err := lbe.cmd.Wait(); err != nil {
+		return fmt.Errorf("Error waiting for binary close: %s", err)
+	}
+
 	if err := lbe.pluginStdout.Close(); err != nil {
-		return err
+		return fmt.Errorf("Error closing plugin stdout: %s", err)
 	}
 
 	if err := lbe.pluginStderr.Close(); err != nil {
-		return err
+		return fmt.Errorf("Error closing plugin stderr: %s", err)
 	}
 
 	return nil
 }
 
 func stream(scanner *bufio.Scanner, streamOutCh chan<- string, stopCh <-chan bool) {
-	lines := make(chan string)
-	go func() {
-		for scanner.Scan() {
-			lines <- scanner.Text()
-		}
-	}()
 	for {
 		select {
 		case <-stopCh:
 			close(streamOutCh)
 			return
-		case line := <-lines:
-			streamOutCh <- strings.Trim(line, "\n")
+		default:
+			scanner.Scan()
+			line := scanner.Text()
 			if err := scanner.Err(); err != nil {
 				log.Warnf("Scanning stream: %s", err)
 			}
+			streamOutCh <- strings.Trim(line, "\n")
 		}
 	}
 }

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -30,6 +30,7 @@ Please use this plugin through the main 'docker-machine' binary.
 	}
 
 	log.SetDebug(true)
+	os.Setenv("MACHINE_DEBUG", "1")
 
 	rpcd := rpcdriver.NewRPCServerDriver(d)
 	rpc.RegisterName(rpcdriver.RPCServiceNameV0, rpcd)
@@ -50,10 +51,12 @@ Please use this plugin through the main 'docker-machine' binary.
 	for {
 		select {
 		case <-rpcd.CloseCh:
+			log.Debug("Closing plugin on server side")
 			os.Exit(0)
 		case <-rpcd.HeartbeatCh:
 			continue
 		case <-time.After(heartbeatTimeout):
+			// TODO: Add heartbeat retry logic
 			os.Exit(1)
 		}
 	}

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -173,12 +173,6 @@ func (c *RPCClientDriver) Close() error {
 	c.heartbeatDoneCh <- true
 	close(c.heartbeatDoneCh)
 
-	log.Debug("Making call to close connection to plugin binary")
-
-	if err := c.plugin.Close(); err != nil {
-		return err
-	}
-
 	log.Debug("Making call to close driver server")
 
 	if err := c.Client.Call(CloseMethod, struct{}{}, nil); err != nil {
@@ -186,6 +180,12 @@ func (c *RPCClientDriver) Close() error {
 	}
 
 	log.Debug("Successfully made call to close driver server")
+
+	log.Debug("Making call to close connection to plugin binary")
+
+	if err := c.plugin.Close(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Closes https://github.com/docker/machine/issues/2622
Closes https://github.com/docker/machine/issues/2217

Simplifies some logic in the "plugin binary" client side code, and critically adds a `cmd.Wait()`, a few revisions to ensure things happening in the proper order, and a message to verify that we can see the successful exit of the plugin in the logs.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>