### PR TITLE
Fix bash docker-machine wrapper

### DIFF
--- a/contrib/completion/bash/docker-machine-wrapper.bash
+++ b/contrib/completion/bash/docker-machine-wrapper.bash
@@ -47,7 +47,7 @@ EOF
         esac
     else
         # Just call the actual docker-machine app
-        $(which docker-machine) "$@"
+        command docker-machine "$@"
     fi
 }
 


### PR DESCRIPTION
Fix an issue with the bash __docker-machine-wrapper function where commands other than `use` would result in an error when attempting to delegate to docker-machine.

Resolves an issue in the bash wrapper where attempting to run any `docker-machine` command other than `use` would result in an error: 
`docker-machine: 'is' is not a docker-machine command. See 'docker-machine --help'.`

Reproduction:
```
$ docker-machine --help
docker-machine: 'is' is not a docker-machine command. See 'docker-machine --help'.

$ docker-machine use
Usage: docker-machine use [OPTIONS] [arg...]

Evaluate the commands to set up the environment for the Docker client

Description:
   Argument is a machine name.

Options:

   --swarm	Display the Swarm config instead of the Docker daemon
   --unset, -u	Unset variables instead of setting them
```


After fix:
```
$ docker-machine --help
Usage: docker-machine [OPTIONS] COMMAND [arg...]

Create and manage machines running Docker.

Version: 0.5.1 (HEAD)

Author:
  Docker Machine Contributors - <https://github.com/docker/machine>

Options:
  --debug, -D						Enable debug mode
  -s, --storage-path "/Users/davids/.docker/machine"	Configures storage path [$MACHINE_STORAGE_PATH]
  --tls-ca-cert 					CA to verify remotes against [$MACHINE_TLS_CA_CERT]
  --tls-ca-key 						Private key to generate certificates [$MACHINE_TLS_CA_KEY]
  --tls-client-cert 					Client cert to use for TLS [$MACHINE_TLS_CLIENT_CERT]
  --tls-client-key 					Private key used in client TLS auth [$MACHINE_TLS_CLIENT_KEY]
  --github-api-token 					Token to use for requests to the Github API [$MACHINE_GITHUB_API_TOKEN]
  --native-ssh						Use the native (Go-based) SSH implementation. [$MACHINE_NATIVE_SSH]
  --help, -h						show help
  --version, -v						print the version

Commands:
  active	Print which machine is active
  config	Print the connection config for machine
  create	Create a machine.

Run 'docker-machine create --driver name' to include the create flags for that driver in the help text.
  env			Display the commands to set up the environment for the Docker client
  inspect		Inspect information about a machine
  ip			Get the IP address of a machine
  kill			Kill a machine
  ls			List machines
  regenerate-certs	Regenerate TLS Certificates for a machine
  restart		Restart a machine
  rm			Remove a machine
  ssh			Log into or run a command on a machine with SSH.
  scp			Copy files between machines
  start			Start a machine
  status		Get the status of a machine
  stop			Stop a machine
  upgrade		Upgrade a machine to the latest version of Docker
  url			Get the URL of a machine
  help			Shows a list of commands or help for one command

Run 'docker-machine COMMAND --help' for more information on a command.

$ docker-machine use
Usage: docker-machine use [OPTIONS] [arg...]

Evaluate the commands to set up the environment for the Docker client

Description:
   Argument is a machine name.

Options:

   --swarmDisplay the Swarm config instead of the Docker daemon
   --unset, -uUnset variables instead of setting them
```