### PR TITLE
fix(Makefile): Prevent makefile from using containers when $USE_CONTAINERS=false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ifneq (,$(findstring test-integration,$(MAKECMDGOALS)))
 	include Makefile.inc
 	include mk/main.mk
-else ifeq ($(USE_CONTAINER),)
+else ifneq ($(USE_CONTAINER), true)
 	include Makefile.inc
 	include mk/main.mk
 else


### PR DESCRIPTION
If one sets $USE_CONTAINERS to false, perhaps if one has attempted to use containers beforehand and failed miserably, the makefile will still use containers. 
```
Kaustavs-MacBook-Pro:machine kaustavhaldar$ echo $USE_CONTAINER
true
Kaustavs-MacBook-Pro:machine kaustavhaldar$ export USE_CONTAINER=false
Kaustavs-MacBook-Pro:machine kaustavhaldar$ echo $USE_CONTAINER
false
Kaustavs-MacBook-Pro:machine kaustavhaldar$ make build
Get http:///var/run/docker.sock/v1.20/containers/json?all=1: dial unix /var/run/docker.sock: no such file or directory.
* Are you trying to connect to a TLS-enabled daemon without TLS?
* Is your docker daemon up and running?
Post http:///var/run/docker.sock/v1.20/build?cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=docker-machine-build&ulimits=null: dial unix /var/run/docker.sock: no such file or directory.
* Are you trying to connect to a TLS-enabled daemon without TLS?
* Is your docker daemon up and running?
make: *** [build] Error 1
```
This fixes that. 