### PR TITLE
close handle on destination after copying boot2docker.iso into vm folder

### DIFF
--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -55,6 +55,8 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 
+	defer out.Close()
+
 	if _, err = io.Copy(out, in); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixed a problem using the hyper-v driver for me. To me it seems that after copying the boot2docker.iso into the local VM folder, the destination file still has a handle open on it which caused the hyper-v driver to throw the error shown below.
It now works nicely for me.

Word of caution: Just starting with Go and Docker and creating my first pull request, you get the dubious honor of my first attempt to meddle ;-)
So I'm not sure this fix (or the form of a pull-request, for that matter) is appropriate. Please bear with me and point me in the right direction.

The following error was thrown using docker-machine on Windows Server 2016 TP4:
(First attempt was fine, the ones after that showed the following error)


D:\data\namolabs\automation\DockerMachine>docker-machine.exe --debug --storage-path "e:\vms\dockermachine" create --driver hyperv --hyperv-virtual-switch "InternalLan" --hyperv-disk-size 30000 --hyperv-memory 2048 docker21
Docker Machine Version:  0.5.4, build 6643d0e
Found binary path at .\docker-machine.exe
Launching plugin server for driver hyperv
Plugin server listening at address 127.0.0.1:59694
() Calling .GetVersion
Using API Version  1
..
...
...
(docker21) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile Connect-VMNetworkAdapter -VMName docker21 -SwitchName 'InternalLan'
(docker21) DBG | [stdout =====>] :
(docker21) Starting  VM...
(docker21) DBG | [stderr =====>] :
(docker21) DBG | [executing ==>] : C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile Start-VM -Name docker21
(docker21) DBG | [stdout =====>] :
(docker21) DBG | [stderr =====>] : Start-VM : 'docker21' failed to start.
(docker21) DBG | Microsoft Emulated IDE Controller (Instance ID 83F8638B-8DCA-4152-9EDA-2CA8B33039B4): Failed to Power on with Error 'The process cannot access the file because it is being used by another process.'.
(docker21) DBG | Failed to open attachment 'e:\vms\dockermachine\machines\docker21\boot2docker.iso'. Error: 'The process cannot access the file because it is being used by another process.'.
(docker21) DBG | 'docker21' failed to start. (Virtual machine ID F1FFFD80-FD88-42FD-9875-D4E1720DF6BC)
(docker21) DBG | 'docker21' Microsoft Emulated IDE Controller (Instance ID 83F8638B-8DCA-4152-9EDA-2CA8B33039B4): Failed to Power on with Error 'The process cannot access the file because it is being used by another
(docker21) DBG | process.' (0x80070020). (Virtual machine ID F1FFFD80-FD88-42FD-9875-D4E1720DF6BC)
(docker21) DBG | 'docker21': Failed to open attachment 'e:\vms\dockermachine\machines\docker21\boot2docker.iso'. Error: 'The process cannot access the file because it is being used by another process.' (0x80070020).
(docker21) DBG | (Virtual machine ID F1FFFD80-FD88-42FD-9875-D4E1720DF6BC)
(docker21) DBG | At line:1 char:1
(docker21) DBG | + Start-VM -Name docker21
(docker21) DBG | + ~~~~~~~~~~~~~~~~~~~~~~~
(docker21) DBG |     + CategoryInfo          : ResourceBusy: (:) [Start-VM], VirtualizationException
(docker21) DBG |     + FullyQualifiedErrorId : ObjectInUse,Microsoft.HyperV.PowerShell.Commands.StartVM
(docker21) DBG |
(docker21) DBG |
notifying bugsnag: [Error in driver during machine creation: exit status 1]
Error creating machine: Error in driver during machine creation: exit status 1