### PR TITLE
Better error when swarm is not started

### DIFF
--- a/commands/ls.go
+++ b/commands/ls.go
@@ -305,7 +305,10 @@ func attemptGetHostState(h *host.Host, stateQueryChan chan<- HostListItem) {
 	if err == nil && url != "" {
 		// PERFORMANCE: Reuse the url instead of asking the host again.
 		// This reduces the number of calls to the drivers
-		dockerHost := &mcndockerclient.RemoteDocker{url, h.AuthOptions()}
+		dockerHost := &mcndockerclient.RemoteDocker{
+			HostURL:    url,
+			AuthOption: h.AuthOptions(),
+		}
 		dockerVersion, err = mcndockerclient.DockerVersion(dockerHost)
 
 		if err != nil {

--- a/libmachine/check/check.go
+++ b/libmachine/check/check.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/cert"
 	"github.com/docker/machine/libmachine/host"
-	"github.com/docker/machine/libmachine/state"
 )
 
 var (
@@ -39,23 +38,12 @@ type ConnChecker interface {
 type MachineConnChecker struct{}
 
 func (mcc *MachineConnChecker) Check(h *host.Host, swarm bool) (string, *auth.Options, error) {
-	hostState, err := h.Driver.GetState()
-	if err != nil {
-		// TODO: This is a common operation and should have a commonly
-		// defined error.
-		return "", &auth.Options{}, fmt.Errorf("Error trying to get host state: %s", err)
-	}
-	if hostState != state.Running {
-		return "", &auth.Options{}, fmt.Errorf("%s is not running. Please start it in order to use the connection settings", h.Name)
-	}
-
 	dockerHost, err := h.Driver.GetURL()
 	if err != nil {
 		return "", &auth.Options{}, fmt.Errorf("Error getting driver URL: %s", err)
 	}
 
 	if swarm {
-		var err error
 		dockerHost, err = parseSwarm(dockerHost, h)
 		if err != nil {
 			return "", &auth.Options{}, fmt.Errorf("Error parsing swarm: %s", err)

--- a/libmachine/check/check.go
+++ b/libmachine/check/check.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 var (
 	DefaultConnChecker ConnChecker
+	ErrSwarmNotStarted = errors.New("Connection to Swarm cannot be checked but the certs are valid. Maybe swarm is not started")
 )
 
 func init() {
@@ -40,17 +42,18 @@ type MachineConnChecker struct{}
 func (mcc *MachineConnChecker) Check(h *host.Host, swarm bool) (string, *auth.Options, error) {
 	dockerHost, err := h.Driver.GetURL()
 	if err != nil {
-		return "", &auth.Options{}, fmt.Errorf("Error getting driver URL: %s", err)
+		return "", &auth.Options{}, err
 	}
 
+	dockerURL := dockerHost
 	if swarm {
-		dockerHost, err = parseSwarm(dockerHost, h)
+		dockerURL, err = parseSwarm(dockerHost, h)
 		if err != nil {
-			return "", &auth.Options{}, fmt.Errorf("Error parsing swarm: %s", err)
+			return "", &auth.Options{}, err
 		}
 	}
 
-	u, err := url.Parse(dockerHost)
+	u, err := url.Parse(dockerURL)
 	if err != nil {
 		return "", &auth.Options{}, fmt.Errorf("Error parsing URL: %s", err)
 	}
@@ -58,10 +61,19 @@ func (mcc *MachineConnChecker) Check(h *host.Host, swarm bool) (string, *auth.Op
 	authOptions := h.HostOptions.AuthOptions
 
 	if err := checkCert(u.Host, authOptions); err != nil {
+		if swarm {
+			// Connection to the swarm port cannot be checked. Maybe it's just the swarm containers that are down
+			// TODO: check the containers and restart them
+			// Let's check the non-swarm connection to give a better error message to the user.
+			if _, _, err := mcc.Check(h, false); err == nil {
+				return "", &auth.Options{}, ErrSwarmNotStarted
+			}
+		}
+
 		return "", &auth.Options{}, fmt.Errorf("Error checking and/or regenerating the certs: %s", err)
 	}
 
-	return dockerHost, authOptions, nil
+	return dockerURL, authOptions, nil
 }
 
 func checkCert(hostURL string, authOptions *auth.Options) error {
@@ -81,7 +93,7 @@ func parseSwarm(hostURL string, h *host.Host) (string, error) {
 	swarmOptions := h.HostOptions.SwarmOptions
 
 	if !swarmOptions.Master {
-		return "", fmt.Errorf("Error: %s is not a swarm master.  The --swarm flag is intended for use with swarm masters", h.Name)
+		return "", fmt.Errorf("%q is not a swarm master. The --swarm flag is intended for use with swarm masters", h.Name)
 	}
 
 	u, err := url.Parse(swarmOptions.Host)

--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -35,7 +35,10 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 	dockerPort := "2376"
 	dockerDir := p.GetDockerOptionsDir()
 	dockerHost := fmt.Sprintf("tcp://%s:%s", ip, dockerPort)
-	dockerClient := mcndockerclient.RemoteDocker{dockerHost, &authOptions}
+	dockerClient := mcndockerclient.RemoteDocker{
+		HostURL:    dockerHost,
+		AuthOption: &authOptions,
+	}
 	advertiseInfo := fmt.Sprintf("%s:%s", ip, dockerPort)
 
 	if swarmOptions.Master {


### PR DESCRIPTION
When trying to check connection to a swarm cluster, we get an "invalid certs" errors if the problem comes from swarm containers being down. 
This PR gives a better error message if swarm connection is down but connection to the docker socket is up.