### PR TITLE
Close drivers on exit

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/cert"
 	"github.com/docker/machine/libmachine/crashreport"
+	"github.com/docker/machine/libmachine/drivers/rpc"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnutils"
@@ -115,6 +116,8 @@ func fatalOnError(command func(commandLine CommandLine, api libmachine.API) erro
 		mcndirs.BaseDir = api.Filestore.Path
 		mcnutils.GithubAPIToken = api.GithubAPIToken
 		ssh.SetDefaultClient(api.SSHClientType)
+
+		defer rpcdriver.CloseDrivers()
 
 		if err := command(&contextCommandLine{context}, api); err != nil {
 			log.Fatal(err)

--- a/commands/create.go
+++ b/commands/create.go
@@ -321,12 +321,6 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 		driver = serialDriver.Driver
 	}
 
-	if rpcd, ok := driver.(*rpcdriver.RPCClientDriver); ok {
-		if err := rpcd.Close(); err != nil {
-			return err
-		}
-	}
-
 	return c.Application().Run(os.Args)
 }
 


### PR DESCRIPTION
This is a simpler version of https://github.com/docker/machine/pull/2635
It makes sure we don't have to call close everywhere we load a host.

Signed-off-by: David Gageot <david@gageot.net>