### PR TITLE
Disable ControlPath on SSH connections

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -55,7 +55,7 @@ var (
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails
 		"-o", "ConnectTimeout=10", // timeout after 10 seconds
 		"-o", "ControlMaster=no", // disable ssh multiplexing
-		"-o", "ControlPath=no",
+		"-o", "ControlPath=none",
 	}
 	defaultClientType = External
 )


### PR DESCRIPTION
This is a fix PR for https://github.com/docker/machine/pull/2614

It turns out that `ControlMaster was` already set to `no` and that `ControlPath` was set to `no` instead of `none` (as found in man ssh_config)

Signed-off-by: Marc Trudel <mtrudel@wizcorp.jp>

Signed-off-by: David Gageot <david@gageot.net>