### PR TITLE
Standardize --driver-memory-size flag including ENV vars

### DIFF
--- a/docs/drivers/hyper-v.md
+++ b/docs/drivers/hyper-v.md
@@ -27,7 +27,7 @@ Options:
 -   `--hyperv-boot2docker-url`: The URL of the boot2docker ISO.
 -   `--hyperv-virtual-switch`: Name of the virtual switch to use.
 -   `--hyperv-disk-size`: Size of disk for the host in MB.
--   `--hyperv-memory`: Size of memory for the host in MB.
+-   `--hyperv-memory-size`: Size of memory for the host in MB.
 -   `--hyperv-cpu-count`: Number of CPUs for the host.
 
 Environment variables and default values:
@@ -37,5 +37,5 @@ Environment variables and default values:
 | `--hyperv-boot2docker-url` | `HYPERV_BOOT2DOCKER_URL` | _Latest boot2docker url_ |
 | `--hyperv-virtual-switch`  | `HYPERV_VIRTUAL_SWITCH`  | _first found_            |
 | `--hyperv-disk-size`       | `HYPERV_DISK_SIZE`       | `20000`                  |
-| `--hyperv-memory`          | `HYPERV_MEMORY`          | `1024`                   |
+| `--hyperv-memory-size`     | `HYPERV_MEMORY`          | `1024`                   |
 | `--hyperv-cpu-count`       | `HYPERV_CPU_COUNT`       | `1`                      |

--- a/docs/drivers/soft-layer.md
+++ b/docs/drivers/soft-layer.md
@@ -17,7 +17,7 @@ You need to generate an API key in the softlayer control panel.
 
 Options:
 
--   `--softlayer-memory`: Memory for host in MB.
+-   `--softlayer-memory-size`: Memory for host in MB.
 -   `--softlayer-disk-size`: A value of `0` will set the SoftLayer default.
 -   `--softlayer-user`: **required** Username for your SoftLayer account, api key needs to match this user.
 -   `--softlayer-api-key`: **required** API key for your user account.
@@ -39,7 +39,7 @@ Environment variables and default values:
 
 | CLI option                     | Environment variable        | Default                     |
 | ------------------------------ | --------------------------- | --------------------------- |
-| `--softlayer-memory`           | `SOFTLAYER_MEMORY`          | `1024`                      |
+| `--softlayer-memory-size`      | `SOFTLAYER_MEMORY`          | `1024`                      |
 | `--softlayer-disk-size`        | `SOFTLAYER_DISK_SIZE`       | `0`                         |
 | **`--softlayer-user`**         | `SOFTLAYER_USER`            | -                           |
 | **`--softlayer-api-key`**      | `SOFTLAYER_API_KEY`         | -                           |

--- a/docs/drivers/virtualbox.md
+++ b/docs/drivers/virtualbox.md
@@ -25,7 +25,7 @@ command:
 
 Options:
 
--   `--virtualbox-memory`: Size of memory for the host in MB.
+-   `--virtualbox-memory-size`: Size of memory for the host in MB.
 -   `--virtualbox-cpu-count`: Number of CPUs to use to create the VM. Defaults to single CPU.
 -   `--virtualbox-disk-size`: Size of disk for the host in MB.
 -   `--virtualbox-host-dns-resolver`: Use the host DNS resolver. (Boolean value, defaults to false)
@@ -68,7 +68,7 @@ Environment variables and default values:
 
 | CLI option                           | Environment variable               | Default                  |
 | ------------------------------------ | ---------------------------------- | ------------------------ |
-| `--virtualbox-memory`                | `VIRTUALBOX_MEMORY_SIZE`           | `1024`                   |
+| `--virtualbox-memory-size`           | `VIRTUALBOX_MEMORY_SIZE`           | `1024`                   |
 | `--virtualbox-cpu-count`             | `VIRTUALBOX_CPU_COUNT`             | `1`                      |
 | `--virtualbox-disk-size`             | `VIRTUALBOX_DISK_SIZE`             | `20000`                  |
 | `--virtualbox-host-dns-resolver`     | `VIRTUALBOX_HOST_DNS_RESOLVER`     | `false`                  |

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -103,7 +103,7 @@ invoking the `create` help text.
        --virtualbox-hostonly-nicpromisc "deny"                                                              Specify the Host Only Network Adapter Promiscuous Mode [$VIRTUALBOX_HOSTONLY_NIC_PROMISC]
        --virtualbox-hostonly-nictype "82540EM"                                                              Specify the Host Only Network Adapter Type [$VIRTUALBOX_HOSTONLY_NIC_TYPE]
        --virtualbox-import-boot2docker-vm                                                                   The name of a Boot2Docker VM to import
-       --virtualbox-memory "1024"                                                                           Size of memory for host in MB [$VIRTUALBOX_MEMORY_SIZE]
+       --virtualbox-memory-size "1024"                                                                      Size of memory for host in MB [$VIRTUALBOX_MEMORY_SIZE]
        --virtualbox-no-share                                                                                Disable the mount of your home directory
 
 You may notice that some flags specify environment variables that they are

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -69,6 +69,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "HYPERV_MEMORY",
 		},
 		mcnflag.IntFlag{
+			Name:   "hyperv-memory-size",
+			Usage:  "Memory size for host in MB.",
+			Value:  defaultMemory,
+			EnvVar: "HYPERV_MEMORY_SIZE",
+		},
+		mcnflag.IntFlag{
 			Name:   "hyperv-cpu-count",
 			Usage:  "number of CPUs for the machine",
 			Value:  defaultCPU,
@@ -81,7 +87,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Boot2DockerURL = flags.String("hyperv-boot2docker-url")
 	d.VSwitch = flags.String("hyperv-virtual-switch")
 	d.DiskSize = flags.Int("hyperv-disk-size")
-	d.MemSize = flags.Int("hyperv-memory")
+	if flags.Int("hyperv-memory-size") != defaultMemory {
+		d.MemSize = flags.Int("hyperv-memory-size")
+	} else {
+		d.MemSize = flags.Int("hyperv-memory")
+	}
 	d.CPU = flags.Int("hyperv-cpu-count")
 	d.SwarmMaster = flags.Bool("swarm-master")
 	d.SwarmHost = flags.String("swarm-host")

--- a/drivers/hyperv/hyperv_test.go
+++ b/drivers/hyperv/hyperv_test.go
@@ -60,3 +60,33 @@ func TestSetConfigFromCustomFlags(t *testing.T) {
 	assert.Equal(t, 4, driver.CPU)
 	assert.Equal(t, "docker", driver.GetSSHUsername())
 }
+
+func TestSetConfigFromCustomFlagsMemorySize(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"hyperv-boot2docker-url": "B2D_URL",
+			"hyperv-virtual-switch":  "TheSwitch",
+			"hyperv-disk-size":       100000,
+			"hyperv-memory-size":     4096,
+			"hyperv-cpu-count":       4,
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+
+	sshPort, err := driver.GetSSHPort()
+	assert.Equal(t, 22, sshPort)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "B2D_URL", driver.Boot2DockerURL)
+	assert.Equal(t, "TheSwitch", driver.VSwitch)
+	assert.Equal(t, 100000, driver.DiskSize)
+	assert.Equal(t, 4096, driver.MemSize)
+	assert.Equal(t, 4, driver.CPU)
+	assert.Equal(t, "docker", driver.GetSSHUsername())
+}

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -91,6 +91,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  defaultMemory,
 		},
 		mcnflag.IntFlag{
+			EnvVar: "SOFTLAYER_MEMORY_SIZE",
+			Name:   "softlayer-memory-size",
+			Usage:  "Memory in MB for machine",
+			Value:  defaultMemory,
+		},
+		mcnflag.IntFlag{
 			EnvVar: "SOFTLAYER_DISK_SIZE",
 			Name:   "softlayer-disk-size",
 			Usage:  "Disk size for machine, a value of 0 uses the default size on softlayer",
@@ -227,12 +233,17 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		return err
 	}
 
+	memorySize := flags.Int("softlayer-memory-size")
+	if memorySize == defaultMemory {
+		memorySize = flags.Int("softlayer-memory")
+	}
+
 	d.deviceConfig = &deviceConfig{
 		Hostname:      flags.String("softlayer-hostname"),
 		DiskSize:      flags.Int("softlayer-disk-size"),
 		Cpu:           flags.Int("softlayer-cpu"),
 		Domain:        flags.String("softlayer-domain"),
-		Memory:        flags.Int("softlayer-memory"),
+		Memory:        memorySize,
 		PrivateNet:    flags.Bool("softlayer-private-net-only"),
 		LocalDisk:     flags.Bool("softlayer-local-disk"),
 		HourlyBilling: flags.Bool("softlayer-hourly-billing"),

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -86,6 +86,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "VIRTUALBOX_MEMORY_SIZE",
 		},
 		mcnflag.IntFlag{
+			Name:   "virtualbox-memory-size",
+			Usage:  "Size of memory for host in MB",
+			Value:  defaultMemory,
+			EnvVar: "VIRTUALBOX_MEMORY_SIZE",
+		},
+		mcnflag.IntFlag{
 			Name:   "virtualbox-cpu-count",
 			Usage:  "number of CPUs for the machine (-1 to use the number of CPUs available)",
 			Value:  defaultCPU,
@@ -180,7 +186,11 @@ func (d *Driver) GetURL() (string, error) {
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.CPU = flags.Int("virtualbox-cpu-count")
-	d.Memory = flags.Int("virtualbox-memory")
+	if flags.Int("virtualbox-memory-size") != defaultMemory {
+		d.Memory = flags.Int("virtualbox-memory-size")
+	} else {
+		d.Memory = flags.Int("virtualbox-memory")
+	}
 	d.DiskSize = flags.Int("virtualbox-disk-size")
 	d.Boot2DockerURL = flags.String("virtualbox-boot2docker-url")
 	d.SwarmMaster = flags.Bool("swarm-master")

--- a/script/release.sh
+++ b/script/release.sh
@@ -27,7 +27,7 @@ function checkError {
 
 function createMachine {
   docker-machine rm -f release 2> /dev/null
-  docker-machine create -d virtualbox --virtualbox-cpu-count=2 --virtualbox-memory=2048 release
+  docker-machine create -d virtualbox --virtualbox-cpu-count=2 --virtualbox-memory-size=2048 release
 }
 
 VERSION=$1

--- a/test/integration/virtualbox/custom-mem-disk.bats
+++ b/test/integration/virtualbox/custom-mem-disk.bats
@@ -32,7 +32,7 @@ function findCPUCount() {
 }
 
 @test "$DRIVER: create with custom disk, cpu count and memory size flags" {
-  run machine create -d $DRIVER --virtualbox-cpu-count $CUSTOM_CPUCOUNT --virtualbox-disk-size $CUSTOM_DISKSIZE --virtualbox-memory $CUSTOM_MEMSIZE $NAME
+  run machine create -d $DRIVER --virtualbox-cpu-count $CUSTOM_CPUCOUNT --virtualbox-disk-size $CUSTOM_DISKSIZE --virtualbox-memory-size $CUSTOM_MEMSIZE $NAME
   [ "$status" -eq 0  ]
 }
 


### PR DESCRIPTION
- Some drivers use --driver-memory but have the ENV variable as
  DRIVER_MEMORY_SIZE. This request makes all drivers use the
  --driver-memory-size flag, but still allows for non-conforming
  drivers to use the --driver-memory flag until deprecated.
  In the case where --driver-memory-size matches the defaultMemory,
  use the --driver-memory flag. If neither flag is used, the
  memory is still set to defaultMemory.