### PR TITLE
Fix truncated plugin binary logs

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -32,12 +32,11 @@ const (
 
 type PluginStreamer interface {
 	// Return a channel for receiving the output of the stream line by
-	// line, and a channel for stopping the stream when we are finished
-	// reading from it.
+	// line.
 	//
 	// It happens to be the case that we do this all inside of the main
 	// plugin struct today, but that may not be the case forever.
-	AttachStream(*bufio.Scanner) (<-chan string, chan<- bool)
+	AttachStream(*bufio.Scanner) <-chan string
 }
 
 type PluginServer interface {
@@ -155,40 +154,23 @@ func (lbe *Executor) Close() error {
 		return fmt.Errorf("Error waiting for binary close: %s", err)
 	}
 
-	if err := lbe.pluginStdout.Close(); err != nil {
-		return fmt.Errorf("Error closing plugin stdout: %s", err)
-	}
-
-	if err := lbe.pluginStderr.Close(); err != nil {
-		return fmt.Errorf("Error closing plugin stderr: %s", err)
-	}
-
 	return nil
 }
 
-func stream(scanner *bufio.Scanner, streamOutCh chan<- string, stopCh <-chan bool) {
-	for {
-		select {
-		case <-stopCh:
-			close(streamOutCh)
-			return
-		default:
-			if scanner.Scan() {
-				line := scanner.Text()
-				if err := scanner.Err(); err != nil {
-					log.Warnf("Scanning stream: %s", err)
-				}
-				streamOutCh <- strings.Trim(line, "\n")
-			}
+func stream(scanner *bufio.Scanner, streamOutCh chan<- string) {
+	for scanner.Scan() {
+		line := scanner.Text()
+		if err := scanner.Err(); err != nil {
+			log.Warnf("Scanning stream: %s", err)
 		}
+		streamOutCh <- strings.Trim(line, "\n")
 	}
 }
 
-func (lbp *Plugin) AttachStream(scanner *bufio.Scanner) (<-chan string, chan<- bool) {
+func (lbp *Plugin) AttachStream(scanner *bufio.Scanner) <-chan string {
 	streamOutCh := make(chan string)
-	stopCh := make(chan bool)
-	go stream(scanner, streamOutCh, stopCh)
-	return streamOutCh, stopCh
+	go stream(scanner, streamOutCh)
+	return streamOutCh
 }
 
 func (lbp *Plugin) execServer() error {
@@ -207,8 +189,8 @@ func (lbp *Plugin) execServer() error {
 
 	lbp.addrCh <- strings.TrimSpace(addr)
 
-	stdOutCh, stopStdoutCh := lbp.AttachStream(outScanner)
-	stdErrCh, stopStderrCh := lbp.AttachStream(errScanner)
+	stdOutCh := lbp.AttachStream(outScanner)
+	stdErrCh := lbp.AttachStream(errScanner)
 
 	for {
 		select {
@@ -216,9 +198,7 @@ func (lbp *Plugin) execServer() error {
 			log.Infof(pluginOut, lbp.MachineName, out)
 		case err := <-stdErrCh:
 			log.Debugf(pluginErr, lbp.MachineName, err)
-		case _ = <-lbp.stopCh:
-			stopStdoutCh <- true
-			stopStderrCh <- true
+		case <-lbp.stopCh:
 			if err := lbp.Executor.Close(); err != nil {
 				return fmt.Errorf("Error closing local plugin binary: %s", err)
 			}

--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -173,12 +173,13 @@ func stream(scanner *bufio.Scanner, streamOutCh chan<- string, stopCh <-chan boo
 			close(streamOutCh)
 			return
 		default:
-			scanner.Scan()
-			line := scanner.Text()
-			if err := scanner.Err(); err != nil {
-				log.Warnf("Scanning stream: %s", err)
+			if scanner.Scan() {
+				line := scanner.Text()
+				if err := scanner.Err(); err != nil {
+					log.Warnf("Scanning stream: %s", err)
+				}
+				streamOutCh <- strings.Trim(line, "\n")
 			}
-			streamOutCh <- strings.Trim(line, "\n")
 		}
 	}
 }

--- a/libmachine/drivers/plugin/localbinary/plugin_test.go
+++ b/libmachine/drivers/plugin/localbinary/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/docker/machine/libmachine/log"
+	"github.com/stretchr/testify/assert"
 )
 
 type FakeExecutor struct {
@@ -56,15 +57,16 @@ func TestLocalBinaryPluginAddressTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping timeout test")
 	}
-	lbp := &Plugin{}
-	lbp.addrCh = make(chan string, 1)
-	go func() {
-		_, err := lbp.Address()
-		if err == nil {
-			t.Fatalf("Expected to get a timeout error, instead got %s", err)
-		}
-	}()
-	time.Sleep(defaultTimeout + 1)
+
+	lbp := &Plugin{
+		addrCh:  make(chan string, 1),
+		timeout: 1 * time.Second,
+	}
+
+	addr, err := lbp.Address()
+
+	assert.Empty(t, addr)
+	assert.EqualError(t, err, "Failed to dial the plugin server in 1s")
 }
 
 func TestLocalBinaryPluginClose(t *testing.T) {

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -30,6 +30,7 @@ Please use this plugin through the main 'docker-machine' binary.
 	}
 
 	log.SetDebug(true)
+	os.Setenv("MACHINE_DEBUG", "1")
 
 	rpcd := rpcdriver.NewRPCServerDriver(d)
 	rpc.RegisterName(rpcdriver.RPCServiceNameV0, rpcd)
@@ -50,10 +51,12 @@ Please use this plugin through the main 'docker-machine' binary.
 	for {
 		select {
 		case <-rpcd.CloseCh:
+			log.Debug("Closing plugin on server side")
 			os.Exit(0)
 		case <-rpcd.HeartbeatCh:
 			continue
 		case <-time.After(heartbeatTimeout):
+			// TODO: Add heartbeat retry logic
 			os.Exit(1)
 		}
 	}

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -88,13 +88,14 @@ func NewInternalClient(rpcclient *rpc.Client) *InternalClient {
 
 func CloseDrivers() {
 	openedDriversLock.Lock()
+	defer openedDriversLock.Unlock()
 
 	for _, openedDriver := range openedDrivers {
-		openedDriver.close()
+		if err := openedDriver.close(); err != nil {
+			log.Warnf("Error closing a plugin driver: %s", err)
+		}
 	}
 	openedDrivers = []*RPCClientDriver{}
-
-	openedDriversLock.Unlock()
 }
 
 func NewRPCClientDriver(driverName string, rawDriver []byte) (*RPCClientDriver, error) {

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -158,8 +158,6 @@ func NewRPCClientDriver(driverName string, rawDriver []byte) (*RPCClientDriver, 
 			case <-time.After(heartbeatInterval):
 				if err := c.Client.Call(HeartbeatMethod, struct{}{}, nil); err != nil {
 					log.Warnf("Error attempting heartbeat call to plugin server: %s", err)
-					c.close()
-					return
 				}
 			}
 		}

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -189,12 +189,6 @@ func (c *RPCClientDriver) close() error {
 	c.heartbeatDoneCh <- true
 	close(c.heartbeatDoneCh)
 
-	log.Debug("Making call to close connection to plugin binary")
-
-	if err := c.plugin.Close(); err != nil {
-		return err
-	}
-
 	log.Debug("Making call to close driver server")
 
 	if err := c.Client.Call(CloseMethod, struct{}{}, nil); err != nil {
@@ -202,6 +196,12 @@ func (c *RPCClientDriver) close() error {
 	}
 
 	log.Debug("Successfully made call to close driver server")
+
+	log.Debug("Making call to close connection to plugin binary")
+
+	if err := c.plugin.Close(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -66,8 +66,6 @@ const (
 	RestartMethod            = `.Restart`
 	KillMethod               = `.Kill`
 	UpgradeMethod            = `.Upgrade`
-	LocalArtifactPathMethod  = `.LocalArtifactPath`
-	GlobalArtifactPathMethod = `.GlobalArtifactPath`
 )
 
 func (ic *InternalClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
@@ -344,25 +342,6 @@ func (c *RPCClientDriver) Restart() error {
 
 func (c *RPCClientDriver) Kill() error {
 	return c.Client.Call(KillMethod, struct{}{}, nil)
-}
-
-func (c *RPCClientDriver) LocalArtifactPath(file string) string {
-	var path string
-
-	if err := c.Client.Call(LocalArtifactPathMethod, file, &path); err != nil {
-		log.Warnf("Error attempting call to get LocalArtifactPath: %s", err)
-	}
-
-	return path
-}
-
-func (c *RPCClientDriver) GlobalArtifactPath() string {
-	globalArtifactPath, err := c.rpcStringCall(GlobalArtifactPathMethod)
-	if err != nil {
-		log.Warnf("Error attempting call to get GlobalArtifactPath: %s", err)
-	}
-
-	return globalArtifactPath
 }
 
 func (c *RPCClientDriver) Upgrade() error {


### PR DESCRIPTION
This is a fixed version of https://github.com/docker/machine/pull/2637

+ It fixes the race condition in unit tests
+ It adds a couple of small fixes to the plugin mechanism