### PR TITLE
fix swarm provision issue #2715: invalid restart policy

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -62,7 +62,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 		hostBind := fmt.Sprintf("%s:%s", dockerDir, dockerDir)
 		masterHostConfig := dockerclient.HostConfig{
 			RestartPolicy: dockerclient.RestartPolicy{
-				Name:              "Always",
+				Name:              "always",
 				MaximumRetryCount: 0,
 			},
 			Binds:        []string{hostBind},
@@ -89,7 +89,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 
 	workerHostConfig := dockerclient.HostConfig{
 		RestartPolicy: dockerclient.RestartPolicy{
-			Name:              "Always",
+			Name:              "always",
 			MaximumRetryCount: 0,
 		},
 		NetworkMode: "host",


### PR DESCRIPTION
Tested in my local cluster, restarts once again occurring as expected.