### PR TITLE
Fix "installing bash completion" instructions

### DIFF
--- a/docs/install-machine.md
+++ b/docs/install-machine.md
@@ -62,7 +62,7 @@ as:
     active machine
 
 To install the scripts, copy or link them into your `/etc/bash_completion.d` or
-`/usr/local/etc/bash_completion.d` file. To enable the `docker-machine` shell
+`/usr/local/etc/bash_completion.d` directory. To enable the `docker-machine` shell
 prompt, add `$(__docker-machine-ps1)` to your `PS1` setting in `~/.bashrc`.
 
     PS1='[\u@\h \W$(__docker-machine-ps1)]\$ '


### PR DESCRIPTION
The scripts are copied/linked into a _directory_, not a file. The two directories are the default locations for bash completion extensions.