### PR TITLE
Run docker-machine from the PATH for core drivers

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -88,6 +88,8 @@ func main() {
 		return
 	}
 
+	localbinary.CurrentBinaryIsDockerMachine = true
+
 	setDebugOutputLevel()
 	cli.AppHelpTemplate = AppHelpTemplate
 	cli.CommandHelpTemplate = CommandHelpTemplate


### PR DESCRIPTION
When external code uses `docker-machine` as a library, it should spawn core-drivers from the `docker-machine` binary that is in the PATH, not the current binary (`os.Args[0]`) which will not contain any driver.

Without this, no external code can use libmachine.

Signed-off-by: David Gageot <david@gageot.net>