### PR TITLE
Remove the path to docker-machine in help/version on windows

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
+
+	"path/filepath"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/machine/commands"
@@ -92,7 +93,7 @@ func main() {
 	cli.AppHelpTemplate = AppHelpTemplate
 	cli.CommandHelpTemplate = CommandHelpTemplate
 	app := cli.NewApp()
-	app.Name = path.Base(os.Args[0])
+	app.Name = filepath.Base(os.Args[0])
 	app.Author = "Docker Machine Contributors"
 	app.Email = "https://github.com/docker/machine"
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>