### PR TITLE
Add option to create amazon ec2 instances with the EbsOptimized setting.

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -54,6 +54,7 @@ This example assumes the VPC ID was found in the `a` availability zone. Use the`
 -   `--amazonec2-use-private-address`: Use the private IP address for docker-machine, but still create a public IP address.
 -   `--amazonec2-private-address-only`: Use the private IP address only.
 -   `--amazonec2-monitoring`: Enable CloudWatch Monitoring.
+-   `--amazonec2-use-ebs-optimized-instance`: Create an EBS Optimized Instance, instance type must support it.
 
 By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10 LTS.
 
@@ -73,29 +74,31 @@ By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10 LTS.
 
 Environment variables and default values:
 
-| CLI option                          | Environment variable    | Default          |
-| ----------------------------------- | ----------------------- | ---------------- |
-| **`--amazonec2-access-key`**        | `AWS_ACCESS_KEY_ID`     | -                |
-| **`--amazonec2-secret-key`**        | `AWS_SECRET_ACCESS_KEY` | -                |
-| `--amazonec2-session-token`         | `AWS_SESSION_TOKEN`     | -                |
-| `--amazonec2-ami`                   | `AWS_AMI`               | `ami-5f709f34`   |
-| `--amazonec2-region`                | `AWS_DEFAULT_REGION`    | `us-east-1`      |
-| **`--amazonec2-vpc-id`**            | `AWS_VPC_ID`            | -                |
-| `--amazonec2-zone`                  | `AWS_ZONE`              | `a`              |
-| `--amazonec2-subnet-id`             | `AWS_SUBNET_ID`         | -                |
-| `--amazonec2-security-group`        | `AWS_SECURITY_GROUP`    | `docker-machine` |
-| `--amazonec2-tags`                  | `AWS_TAGS`              | -                |
-| `--amazonec2-instance-type`         | `AWS_INSTANCE_TYPE`     | `t2.micro`       |
-| `--amazonec2-device-name`           | `AWS_DEVICE_NAME`       | `/dev/sda1`      |
-| `--amazonec2-root-size`             | `AWS_ROOT_SIZE`         | `16`             |
-| `--amazonec2-volume-type`           | `AWS_VOLUME_TYPE`       | `gp2`            |
-| `--amazonec2-iam-instance-profile`  | `AWS_INSTANCE_PROFILE`  | -                |
-| `--amazonec2-ssh-user`              | `AWS_SSH_USER`          | `ubuntu`         |
-| `--amazonec2-request-spot-instance` | -                       | `false`          |
-| `--amazonec2-spot-price`            | -                       | `0.50`           |
-| `--amazonec2-use-private-address`   | -                       | `false`          |
-| `--amazonec2-private-address-only`  | -                       | `false`          |
-| `--amazonec2-monitoring`            | -                       | `false`          |
+| CLI option                               | Environment variable    | Default          |
+| ---------------------------------------- | ----------------------- | ---------------- |
+| **`--amazonec2-access-key`**             | `AWS_ACCESS_KEY_ID`     | -                |
+| **`--amazonec2-secret-key`**             | `AWS_SECRET_ACCESS_KEY` | -                |
+| `--amazonec2-session-token`              | `AWS_SESSION_TOKEN`     | -                |
+| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-5f709f34`   |
+| `--amazonec2-region`                     | `AWS_DEFAULT_REGION`    | `us-east-1`      |
+| **`--amazonec2-vpc-id`**                 | `AWS_VPC_ID`            | -                |
+| `--amazonec2-zone`                       | `AWS_ZONE`              | `a`              |
+| `--amazonec2-subnet-id`                  | `AWS_SUBNET_ID`         | -                |
+| `--amazonec2-security-group`             | `AWS_SECURITY_GROUP`    | `docker-machine` |
+| `--amazonec2-tags`                       | `AWS_TAGS`              | -                |
+| `--amazonec2-instance-type`              | `AWS_INSTANCE_TYPE`     | `t2.micro`       |
+| `--amazonec2-device-name`                | `AWS_DEVICE_NAME`       | `/dev/sda1`      |
+| `--amazonec2-root-size`                  | `AWS_ROOT_SIZE`         | `16`             |
+| `--amazonec2-volume-type`                | `AWS_VOLUME_TYPE`       | `gp2`            |
+| `--amazonec2-iam-instance-profile`       | `AWS_INSTANCE_PROFILE`  | -                |
+| `--amazonec2-ssh-user`                   | `AWS_SSH_USER`          | `ubuntu`         |
+| `--amazonec2-request-spot-instance`      | -                       | `false`          |
+| `--amazonec2-spot-price`                 | -                       | `0.50`           |
+| `--amazonec2-use-private-address`        | -                       | `false`          |
+| `--amazonec2-private-address-only`       | -                       | `false`          |
+| `--amazonec2-monitoring`                 | -                       | `false`          |
+| `--amazonec2-use-ebs-optimized-instance` | -                       | `false`          |
+
 
 ## Security Group
 
@@ -107,3 +110,4 @@ Note that a security group will be created and associated to the host. This secu
 
 If you specify a security group yourself using the `--amazonec2-security-group` flag, the above ports will be checked and opened and the security group modified.
 If you want more ports to be opened, like application specific ports, use the aws console and modify the configuration manually.
+

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -52,34 +52,35 @@ var (
 
 type Driver struct {
 	*drivers.BaseDriver
-	Id                  string
-	AccessKey           string
-	SecretKey           string
-	SessionToken        string
-	Region              string
-	AMI                 string
-	SSHKeyID            int
-	KeyName             string
-	InstanceId          string
-	InstanceType        string
-	PrivateIPAddress    string
-	SecurityGroupId     string
-	SecurityGroupName   string
-	Tags                string
-	ReservationId       string
-	DeviceName          string
-	RootSize            int64
-	VolumeType          string
-	IamInstanceProfile  string
-	VpcId               string
-	SubnetId            string
-	Zone                string
-	keyPath             string
-	RequestSpotInstance bool
-	SpotPrice           string
-	PrivateIPOnly       bool
-	UsePrivateIP        bool
-	Monitoring          bool
+	Id                      string
+	AccessKey               string
+	SecretKey               string
+	SessionToken            string
+	Region                  string
+	AMI                     string
+	SSHKeyID                int
+	KeyName                 string
+	InstanceId              string
+	InstanceType            string
+	PrivateIPAddress        string
+	SecurityGroupId         string
+	SecurityGroupName       string
+	Tags                    string
+	ReservationId           string
+	DeviceName              string
+	RootSize                int64
+	VolumeType              string
+	IamInstanceProfile      string
+	VpcId                   string
+	SubnetId                string
+	Zone                    string
+	keyPath                 string
+	RequestSpotInstance     bool
+	SpotPrice               string
+	PrivateIPOnly           bool
+	UsePrivateIP            bool
+	UseEbsOptimizedInstance bool
+	Monitoring              bool
 }
 
 func (d *Driver) GetCreateFlags() []mcnflag.Flag {
@@ -193,6 +194,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  "amazonec2-monitoring",
 			Usage: "Set this flag to enable CloudWatch monitoring",
 		},
+		mcnflag.BoolFlag{
+			Name:  "amazonec2-use-ebs-optimized-instance",
+			Usage: "Create an EBS optimized instance",
+		},
 	}
 }
 
@@ -249,6 +254,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.PrivateIPOnly = flags.Bool("amazonec2-private-address-only")
 	d.UsePrivateIP = flags.Bool("amazonec2-use-private-address")
 	d.Monitoring = flags.Bool("amazonec2-monitoring")
+	d.UseEbsOptimizedInstance = flags.Bool("amazonec2-use-ebs-optimized-instance")
 	d.SetSwarmConfigFromFlags(flags)
 
 	if d.AccessKey == "" {
@@ -429,6 +435,7 @@ func (d *Driver) Create() error {
 				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 					Name: &d.IamInstanceProfile,
 				},
+				EbsOptimized:        &d.UseEbsOptimizedInstance,
 				BlockDeviceMappings: []*ec2.BlockDeviceMapping{bdm},
 			},
 			InstanceCount: aws.Int64(1),
@@ -494,6 +501,7 @@ func (d *Driver) Create() error {
 			IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 				Name: &d.IamInstanceProfile,
 			},
+			EbsOptimized:        &d.UseEbsOptimizedInstance,
 			BlockDeviceMappings: []*ec2.BlockDeviceMapping{bdm},
 		})
 

--- a/test/integration/amazonec2/create-ebsinstance.bats
+++ b/test/integration/amazonec2/create-ebsinstance.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load ${BASE_TEST_DIR}/helpers.bash
+
+force_env DRIVER amazonec2
+
+#Use Instance Type that supports EBS Optimize 
+export AWS_INSTANCE_TYPE=m4.large
+
+only_if_env AWS_DEFAULT_REGION
+
+only_if_env AWS_ACCESS_KEY_ID
+
+only_if_env AWS_SECRET_ACCESS_KEY
+
+only_if_env AWS_SUBNET_ID
+
+
+@test "$DRIVER: Should Create an EBS Optimized Instance" {
+  
+  machine create -d amazonec2 --amazonec2-use-ebs-optimized-instance $NAME
+
+  run docker $(machine config $NAME) run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION blendle/aws-cli ec2 describe-instances --filters Name=tag:Name,Values=$NAME Name=instance-state-name,Values=running --query 'Reservations[0].Instances[0].EbsOptimized' --output text	
+
+    [[ ${lines[*]:-1} =~ "True" ]]
+
+ }
+
+
+
+ 
+ 


### PR DESCRIPTION
fixes #1904 Non EbsOptimized instances will be created by default but adding the flag
UseEbsOptimizedInstance will create and EBSOptimized Instance if the instance type supports it.

Signed-off-by: Jeffrey Ellin <jeff@ellin.com>