### PR TITLE
Support creating a machine from an existing google VM

### DIFF
--- a/docs/drivers/gce.md
+++ b/docs/drivers/gce.md
@@ -38,7 +38,7 @@ To create a machine instance, specify `--driver google`, the project id and the 
 
 ### Options
 
--   `--google-project`: **required** The id of your project to use when launching the instance.
+    -   `--google-project`: **required** The id of your project to use when launching the instance.
     -   `--google-zone`: The zone to launch the instance.
     -   `--google-machine-type`: The type of instance.
     -   `--google-machine-image`: The absolute URL to a base VM image to instantiate.
@@ -50,6 +50,7 @@ To create a machine instance, specify `--driver google`, the project id and the 
     -   `--google-preemptible`: Instance preemptibility.
     -   `--google-tags`: Instance tags (comma-separated).
     -   `--google-use-internal-ip`: When this option is used during create it will make docker-machine use internal rather than public NATed IPs. The flag is persistent in the sense that a machine created with it retains the IP. It's useful for managing docker machines from another machine on the same network e.g. while deploying swarm.
+    -   `--google-use-existing`: Don't create a new VM, use an existing one. This is useful when you'd like to provision Docker on a VM you created yourself, maybe because it uses create options not supported by this driver. 
 
 The GCE driver will use the `ubuntu-1510-wily-v20151114` instance image unless otherwise specified. To obtain a
 list of image URLs run:
@@ -72,3 +73,4 @@ Environment variables and default values:
 | `--google-preemptible`     | `GOOGLE_PREEMPTIBLE`     | -                                    |
 | `--google-tags`            | `GOOGLE_TAGS`            | -                                    |
 | `--google-use-internal-ip` | `GOOGLE_USE_INTERNAL_IP` | -                                    |
+| `--google-use-existing`    | `GOOGLE_USE_EXISTING`    | -                                    |

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -26,6 +26,7 @@ type Driver struct {
 	DiskSize      int
 	Project       string
 	Tags          string
+	UseExisting   bool
 }
 
 const (
@@ -110,6 +111,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Use internal GCE Instance IP rather than public one",
 			EnvVar: "GOOGLE_USE_INTERNAL_IP",
 		},
+		mcnflag.BoolFlag{
+			Name:   "google-use-existing",
+			Usage:  "Don't create a new VM, use an existing one",
+			EnvVar: "GOOGLE_USE_EXISTING",
+		},
 	}
 }
 
@@ -156,15 +162,18 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	d.Zone = flags.String("google-zone")
-	d.MachineType = flags.String("google-machine-type")
-	d.MachineImage = flags.String("google-machine-image")
-	d.DiskSize = flags.Int("google-disk-size")
-	d.DiskType = flags.String("google-disk-type")
-	d.Address = flags.String("google-address")
-	d.Preemptible = flags.Bool("google-preemptible")
-	d.UseInternalIP = flags.Bool("google-use-internal-ip")
-	d.Scopes = flags.String("google-scopes")
-	d.Tags = flags.String("google-tags")
+	d.UseExisting = flags.Bool("google-use-existing")
+	if !d.UseExisting {
+		d.MachineType = flags.String("google-machine-type")
+		d.MachineImage = flags.String("google-machine-image")
+		d.DiskSize = flags.Int("google-disk-size")
+		d.DiskType = flags.String("google-disk-type")
+		d.Address = flags.String("google-address")
+		d.Preemptible = flags.Bool("google-preemptible")
+		d.UseInternalIP = flags.Bool("google-use-internal-ip")
+		d.Scopes = flags.String("google-scopes")
+		d.Tags = flags.String("google-tags")
+	}
 	d.SSHUser = flags.String("google-username")
 	d.SSHPort = 22
 	d.SetSwarmConfigFromFlags(flags)
@@ -191,8 +200,15 @@ func (d *Driver) PreCreateCheck() error {
 	// doesn't exist, so just check instance for nil.
 	log.Infof("Check if the instance already exists")
 
-	if instance, _ := c.instance(); instance != nil {
-		return fmt.Errorf("Instance %v already exists.", d.MachineName)
+	instance, _ := c.instance()
+	if d.UseExisting {
+		if instance == nil {
+			return fmt.Errorf("Unable to find instance %q in zone %q.", d.MachineName, d.Zone)
+		}
+	} else {
+		if instance != nil {
+			return fmt.Errorf("Instance %q already exists in zone %q.", d.MachineName, d.Zone)
+		}
 	}
 
 	return nil
@@ -213,6 +229,13 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+	if err := c.openFirewallPorts(); err != nil {
+		return err
+	}
+
+	if d.UseExisting {
+		return c.configureInstance(d)
+	}
 	return c.createInstance(d)
 }
 


### PR DESCRIPTION
This is very useful if you want to create a VM with options that are not supported by `docker-machine create`. In the future, all drivers could implement this and it would lower the urge on supporting every single option of each cloud provider.

Signed-off-by: David Gageot <david@gageot.net>