### PR TITLE
Set swarm manage to advertise on 3376

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -41,13 +41,14 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 	advertiseInfo := fmt.Sprintf("%s:%s", ip, dockerPort)
 
 	if swarmOptions.Master {
+		advertiseMasterInfo := fmt.Sprintf("%s:%s", ip, "3376")
 		cmd := fmt.Sprintf("manage --tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H %s --strategy %s --advertise %s",
 			authOptions.CaCertRemotePath,
 			authOptions.ServerCertRemotePath,
 			authOptions.ServerKeyRemotePath,
 			swarmOptions.Host,
 			swarmOptions.Strategy,
-			advertiseInfo,
+			advertiseMasterInfo,
 		)
 
 		cmdMaster := strings.Fields(cmd)


### PR DESCRIPTION
## Overview

Currently when you setup a new swarm master, it's advertising on `2376` instead of `3376`. When advertising on `2376` it causes issues with replication as replicas are forwarding to the standard docker port instead of swarm.

Fixes https://github.com/docker/swarm/issues/1576