### PR TITLE
GCE delete instance during rm

### DIFF
--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -360,14 +360,9 @@ func (d *Driver) Remove() error {
 		return err
 	}
 
-	s, err := d.GetState()
-	if err != nil {
+	if err := c.deleteInstance(); err != nil {
 		return err
 	}
-	if s == state.Running {
-		if err := c.deleteInstance(); err != nil {
-			return err
-		}
-	}
+
 	return c.deleteDisk()
 }


### PR DESCRIPTION
Fixed #2766

by issue #2766  and bb45f83 stop command no more delete instance. but during the rm command process, `deleteInstance` function only called when instance running. so `rm` failed after `stop` command.

I changed always call deleteInstance regadless instance status.
