### PR TITLE
log.fatal is evil

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -204,11 +204,12 @@ func runDriver(driverName string) {
 }
 
 func cmdNotFound(c *cli.Context, command string) {
-	log.Fatalf(
+	log.Errorf(
 		"%s: '%s' is not a %s command. See '%s --help'.",
 		c.App.Name,
 		command,
 		c.App.Name,
 		os.Args[0],
 	)
+	os.Exit(1)
 }

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -312,8 +312,8 @@ func matchesName(host *host.Host, names []string) bool {
 	for _, n := range names {
 		r, err := regexp.Compile(n)
 		if err != nil {
-			// TODO: remove that call to Fatal
-			log.Fatal(err)
+			log.Error(err)
+			os.Exit(1) // TODO: Can we get rid of this call, and exit 'properly' ?
 		}
 		if r.MatchString(host.Driver.GetMachineName()) {
 			return true

--- a/libmachine/examples/vbox_create.go
+++ b/libmachine/examples/vbox_create.go
@@ -25,29 +25,34 @@ func main() {
 
 	data, err := json.Marshal(driver)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return
 	}
 
 	h, err := client.NewHost("virtualbox", data)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return
 	}
 
 	h.HostOptions.EngineOptions.StorageDriver = "overlay"
 
 	if err := client.Create(h); err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return
 	}
 
 	out, err := h.RunSSHCommand("df -h")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return
 	}
 
 	fmt.Printf("Results of your disk space query:\n%s\n", out)
 
 	fmt.Println("Powering down machine now...")
 	if err := h.Stop(); err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return
 	}
 }

--- a/libmachine/log/fmt_machine_logger.go
+++ b/libmachine/log/fmt_machine_logger.go
@@ -69,18 +69,6 @@ func (ml *FmtMachineLogger) Infof(fmtString string, args ...interface{}) {
 	fmt.Fprintf(ml.outWriter, fmtString+"\n", args...)
 }
 
-func (ml *FmtMachineLogger) Fatal(args ...interface{}) {
-	ml.history.Record(args...)
-	fmt.Fprintln(ml.errWriter, args...)
-	os.Exit(1)
-}
-
-func (ml *FmtMachineLogger) Fatalf(fmtString string, args ...interface{}) {
-	ml.history.Recordf(fmtString, args...)
-	fmt.Fprintf(ml.errWriter, fmtString+"\n", args...)
-	os.Exit(1)
-}
-
 func (ml *FmtMachineLogger) Warn(args ...interface{}) {
 	ml.history.Record(args...)
 	fmt.Fprintln(ml.outWriter, args...)

--- a/libmachine/log/log.go
+++ b/libmachine/log/log.go
@@ -49,14 +49,6 @@ func Infof(fmtString string, args ...interface{}) {
 	logger.Infof(fmtString, args...)
 }
 
-func Fatal(args ...interface{}) {
-	logger.Fatal(args...)
-}
-
-func Fatalf(fmtString string, args ...interface{}) {
-	logger.Fatalf(fmtString, args...)
-}
-
 func Warn(args ...interface{}) {
 	logger.Warn(args...)
 }

--- a/libmachine/log/machine_logger.go
+++ b/libmachine/log/machine_logger.go
@@ -17,9 +17,6 @@ type MachineLogger interface {
 	Info(args ...interface{})
 	Infof(fmtString string, args ...interface{})
 
-	Fatal(args ...interface{})
-	Fatalf(fmtString string, args ...interface{})
-
 	Warn(args ...interface{})
 	Warnf(fmtString string, args ...interface{})
 


### PR DESCRIPTION
`log.Fatal` contains an implicit `os.Exit(1)`.
This is error prone, we've been recently caught red handed on this see https://github.com/dgageot/machine/commit/f96595d7d0515490c6b39ff3f22126eb495e7dd6#diff-b54b33b58b9d76939b70cd4d2f48f251L116

As we have no more than 2 calls, i did remove them all.