### PR TITLE
FIX #2411 On a btrfs system, don't default to aufs

### DIFF
--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -94,9 +94,11 @@ func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOp
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "overlay"
+	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)
+	if err != nil {
+		return err
 	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
 
 	// HACK: since Arch does not come with sudo by default we install
 	log.Debug("Installing sudo")

--- a/libmachine/provision/arch_test.go
+++ b/libmachine/provision/arch_test.go
@@ -1,0 +1,20 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func TestArchDefaultStorageDriver(t *testing.T) {
+	p := NewArchProvisioner(&fakedriver.Driver{}).(*ArchProvisioner)
+	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "overlay" {
+		t.Fatal("Default storage driver should be overlay")
+	}
+}

--- a/libmachine/provision/arch_test.go
+++ b/libmachine/provision/arch_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestArchDefaultStorageDriver(t *testing.T) {
 	p := NewArchProvisioner(&fakedriver.Driver{}).(*ArchProvisioner)
-	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
 	if p.EngineOptions.StorageDriver != "overlay" {
 		t.Fatal("Default storage driver should be overlay")

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -106,9 +106,11 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "aufs"
+	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	if err != nil {
+		return err
 	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
 
 	// HACK: since debian does not come with sudo by default we install
 	log.Debug("installing sudo")

--- a/libmachine/provision/debian_test.go
+++ b/libmachine/provision/debian_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDebianDefaultStorageDriver(t *testing.T) {
 	p := NewDebianProvisioner(&fakedriver.Driver{}).(*DebianProvisioner)
-	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
 	if p.EngineOptions.StorageDriver != "aufs" {
 		t.Fatal("Default storage driver should be aufs")

--- a/libmachine/provision/debian_test.go
+++ b/libmachine/provision/debian_test.go
@@ -1,0 +1,20 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func TestDebianDefaultStorageDriver(t *testing.T) {
+	p := NewDebianProvisioner(&fakedriver.Driver{}).(*DebianProvisioner)
+	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "aufs" {
+		t.Fatal("Default storage driver should be aufs")
+	}
+}

--- a/libmachine/provision/provisiontest/sshcommander.go
+++ b/libmachine/provision/provisiontest/sshcommander.go
@@ -1,0 +1,22 @@
+//Package provisiontest provides utilities for testing provisioners
+package provisiontest
+
+import (
+	"errors"
+	"strings"
+)
+
+//FakeSSHCommander is an implementation of provision.SSHCommander to provide predictable responses set by testing code
+//Extend it when needed
+type FakeSSHCommander struct {
+	//Result of the ssh command to look up the FilesystemType
+	FilesystemType string
+}
+
+//SSHCommand is an implementation of provision.SSHCommander.SSHCommand to provide predictable responses set by testing code
+func (sshCmder FakeSSHCommander) SSHCommand(args string) (string, error) {
+	if !strings.HasPrefix(args, "stat -f") {
+		return "", errors.New("Not implemented by FakeSSHCommander")
+	}
+	return sshCmder.FilesystemType + "\n", nil
+}

--- a/libmachine/provision/provisiontest/sshcommander.go
+++ b/libmachine/provision/provisiontest/sshcommander.go
@@ -1,22 +1,39 @@
 //Package provisiontest provides utilities for testing provisioners
 package provisiontest
 
-import (
-	"errors"
-	"strings"
-)
+import "errors"
 
-//FakeSSHCommander is an implementation of provision.SSHCommander to provide predictable responses set by testing code
-//Extend it when needed
-type FakeSSHCommander struct {
+//FakeSSHCommanderOptions is intended to create a FakeSSHCommander without actually knowing the underlying sshcommands by passing it to NewSSHCommander
+type FakeSSHCommanderOptions struct {
 	//Result of the ssh command to look up the FilesystemType
 	FilesystemType string
 }
 
-//SSHCommand is an implementation of provision.SSHCommander.SSHCommand to provide predictable responses set by testing code
-func (sshCmder FakeSSHCommander) SSHCommand(args string) (string, error) {
-	if !strings.HasPrefix(args, "stat -f") {
-		return "", errors.New("Not implemented by FakeSSHCommander")
+//FakeSSHCommander is an implementation of provision.SSHCommander to provide predictable responses set by testing code
+//Extend it when needed
+type FakeSSHCommander struct {
+	Responses map[string]string
+}
+
+//NewFakeSSHCommander creates a FakeSSHCommander without actually knowing the underlying sshcommands
+func NewFakeSSHCommander(options FakeSSHCommanderOptions) *FakeSSHCommander {
+	if options.FilesystemType == "" {
+		options.FilesystemType = "ext4"
 	}
-	return sshCmder.FilesystemType + "\n", nil
+	sshCmder := &FakeSSHCommander{
+		Responses: map[string]string{
+			"stat -f -c %T /var/lib": options.FilesystemType + "\n",
+		},
+	}
+
+	return sshCmder
+}
+
+//SSHCommand is an implementation of provision.SSHCommander.SSHCommand to provide predictable responses set by testing code
+func (sshCmder *FakeSSHCommander) SSHCommand(args string) (string, error) {
+	response, commandRegistered := sshCmder.Responses[args]
+	if !commandRegistered {
+		return "", errors.New("Command not registered in FakeSSHCommander")
+	}
+	return response, nil
 }

--- a/libmachine/provision/provisiontest/sshcommander_test.go
+++ b/libmachine/provision/provisiontest/sshcommander_test.go
@@ -1,11 +1,28 @@
 package provisiontest
 
-import "testing"
+import (
+	"testing"
 
-func TestStatSSHCommand(t *testing.T) {
-	sshCmder := FakeSSHCommander{FilesystemType: "btrfs"}
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateFakeSSHCommander(t *testing.T) {
+	sshCmder := NewFakeSSHCommander(FakeSSHCommanderOptions{FilesystemType: "btrfs"})
 	output, err := sshCmder.SSHCommand("stat -f -c %T /var/lib")
 	if err != nil || output != "btrfs\n" {
 		t.Fatal("FakeSSHCommander should have returned btrfs and no error but returned '", output, "' and error", err)
 	}
+}
+
+func TestStatSSHCommand(t *testing.T) {
+	sshCmder := FakeSSHCommander{
+		Responses: map[string]string{"sshcommand": "sshcommandresponse"},
+	}
+
+	output, err := sshCmder.SSHCommand("sshcommand")
+	assert.NoError(t, err)
+	assert.Equal(t, "sshcommandresponse", output)
+
+	output, err = sshCmder.SSHCommand("errorcommand")
+	assert.Error(t, err)
 }

--- a/libmachine/provision/provisiontest/sshcommander_test.go
+++ b/libmachine/provision/provisiontest/sshcommander_test.go
@@ -1,0 +1,11 @@
+package provisiontest
+
+import "testing"
+
+func TestStatSSHCommand(t *testing.T) {
+	sshCmder := FakeSSHCommander{FilesystemType: "btrfs"}
+	output, err := sshCmder.SSHCommand("stat -f -c %T /var/lib")
+	if err != nil || output != "btrfs\n" {
+		t.Fatal("FakeSSHCommander should have returned btrfs and no error but returned '", output, "' and error", err)
+	}
+}

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -159,9 +159,11 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for redhat
-	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "devicemapper"
+	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	if err != nil {
+		return err
 	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
 
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -35,7 +35,7 @@ func TestRedHatGenerateYumRepoList(t *testing.T) {
 
 func TestRedHatDefaultStorageDriver(t *testing.T) {
 	p := NewRedHatProvisioner("", &fakedriver.Driver{})
-	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
 	if p.EngineOptions.StorageDriver != "devicemapper" {
 		t.Fatal("Default storage driver should be devicemapper")

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -3,6 +3,12 @@ package provision
 import (
 	"regexp"
 	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
 )
 
 func TestRedHatGenerateYumRepoList(t *testing.T) {
@@ -24,5 +30,14 @@ func TestRedHatGenerateYumRepoList(t *testing.T) {
 
 	if !m {
 		t.Fatalf("expected match for centos/7")
+	}
+}
+
+func TestRedHatDefaultStorageDriver(t *testing.T) {
+	p := NewRedHatProvisioner("", &fakedriver.Driver{})
+	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "devicemapper" {
+		t.Fatal("Default storage driver should be devicemapper")
 	}
 }

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -122,9 +122,11 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "aufs"
+	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	if err != nil {
+		return err
 	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
 
 	log.Debug("setting hostname")
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {

--- a/libmachine/provision/ubuntu_systemd_test.go
+++ b/libmachine/provision/ubuntu_systemd_test.go
@@ -2,6 +2,12 @@ package provision
 
 import (
 	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
 )
 
 func TestUbuntuSystemdCompatibleWithHost(t *testing.T) {
@@ -26,4 +32,13 @@ func TestUbuntuSystemdCompatibleWithHost(t *testing.T) {
 		t.Fatalf("expected to NOT be compatible with ubuntu 14.04")
 	}
 
+}
+
+func TestUbuntuSystemdDefaultStorageDriver(t *testing.T) {
+	p := NewUbuntuSystemdProvisioner(&fakedriver.Driver{}).(*UbuntuSystemdProvisioner)
+	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "aufs" {
+		t.Fatal("Default storage driver should be aufs")
+	}
 }

--- a/libmachine/provision/ubuntu_systemd_test.go
+++ b/libmachine/provision/ubuntu_systemd_test.go
@@ -36,7 +36,7 @@ func TestUbuntuSystemdCompatibleWithHost(t *testing.T) {
 
 func TestUbuntuSystemdDefaultStorageDriver(t *testing.T) {
 	p := NewUbuntuSystemdProvisioner(&fakedriver.Driver{}).(*UbuntuSystemdProvisioner)
-	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
 	if p.EngineOptions.StorageDriver != "aufs" {
 		t.Fatal("Default storage driver should be aufs")

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -141,9 +141,11 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "aufs"
+	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	if err != nil {
+		return err
 	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
 
 	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
 		return err

--- a/libmachine/provision/ubuntu_upstart_test.go
+++ b/libmachine/provision/ubuntu_upstart_test.go
@@ -2,6 +2,12 @@ package provision
 
 import (
 	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
 )
 
 func TestUbuntuCompatibleWithHost(t *testing.T) {
@@ -26,4 +32,13 @@ func TestUbuntuCompatibleWithHost(t *testing.T) {
 		t.Fatalf("expected to NOT be compatible with ubuntu 15.04")
 	}
 
+}
+
+func TestUbuntuDefaultStorageDriver(t *testing.T) {
+	p := NewUbuntuProvisioner(&fakedriver.Driver{}).(*UbuntuProvisioner)
+	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "aufs" {
+		t.Fatal("Default storage driver should be aufs")
+	}
 }

--- a/libmachine/provision/ubuntu_upstart_test.go
+++ b/libmachine/provision/ubuntu_upstart_test.go
@@ -36,7 +36,7 @@ func TestUbuntuCompatibleWithHost(t *testing.T) {
 
 func TestUbuntuDefaultStorageDriver(t *testing.T) {
 	p := NewUbuntuProvisioner(&fakedriver.Driver{}).(*UbuntuProvisioner)
-	p.SSHCommander = provisiontest.FakeSSHCommander{FilesystemType: "ext4"}
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
 	if p.EngineOptions.StorageDriver != "aufs" {
 		t.Fatal("Default storage driver should be aufs")


### PR DESCRIPTION
FIX #2411 On an Ubuntu system, don't default to aufs on a btrfs filesystem

Signed-off-by: Rob Van Mieghem <rob@vanmieghemcloud.com>