### PR TITLE
Fix multiple VirtualBox bugs on Windows

### DIFF
--- a/drivers/virtualbox/network.go
+++ b/drivers/virtualbox/network.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"strconv"
+	"strings"
+	"time"
+
+	"github.com/docker/machine/libmachine/log"
 )
 
 const (
 	buggyNetmask = "0f000000"
+	dhcpPrefix   = "HostInterfaceNetworking-"
 )
 
 var (
-	reHostonlyInterfaceCreated        = regexp.MustCompile(`Interface '(.+)' was successfully created`)
-	errNewHostOnlyInterfaceNotVisible = errors.New("The host-only interface we just created is not visible. This is a well known bug of VirtualBox. You might want to uninstall it and reinstall at least version 5.0.12 that is is supposed to fix this issue")
+	reHostOnlyAdapterCreated        = regexp.MustCompile(`Interface '(.+)' was successfully created`)
+	errNewHostOnlyAdapterNotVisible = errors.New("The host-only adapter we just created is not visible. This is a well known VirtualBox bug. You might want to uninstall it and reinstall at least version 5.0.12 that is is supposed to fix this issue")
 )
 
 // Host-only network.
@@ -23,7 +27,6 @@ type hostOnlyNetwork struct {
 	GUID        string
 	DHCP        bool
 	IPv4        net.IPNet
-	IPv6        net.IPNet
 	HwAddr      net.HardwareAddr
 	Medium      string
 	Status      string
@@ -32,17 +35,8 @@ type hostOnlyNetwork struct {
 
 // Save changes the configuration of the host-only network.
 func (n *hostOnlyNetwork) Save(vbox VBoxManager) error {
-	if n.IPv4.IP != nil && n.IPv4.Mask != nil {
-		if err := vbox.vbm("hostonlyif", "ipconfig", n.Name, "--ip", n.IPv4.IP.String(), "--netmask", net.IP(n.IPv4.Mask).String()); err != nil {
-			return err
-		}
-	}
-
-	if n.IPv6.IP != nil && n.IPv6.Mask != nil {
-		prefixLen, _ := n.IPv6.Mask.Size()
-		if err := vbox.vbm("hostonlyif", "ipconfig", n.Name, "--ipv6", n.IPv6.IP.String(), "--netmasklengthv6", fmt.Sprintf("%d", prefixLen)); err != nil {
-			return err
-		}
+	if err := n.SaveIPv4(vbox); err != nil {
+		return err
 	}
 
 	if n.DHCP {
@@ -52,23 +46,34 @@ func (n *hostOnlyNetwork) Save(vbox VBoxManager) error {
 	return nil
 }
 
-// createHostonlyNet creates a new host-only network.
-func createHostonlyNet(vbox VBoxManager) (*hostOnlyNetwork, error) {
+// SaveIPv4 changes the ipv4 configuration of the host-only network.
+func (n *hostOnlyNetwork) SaveIPv4(vbox VBoxManager) error {
+	if n.IPv4.IP != nil && n.IPv4.Mask != nil {
+		if err := vbox.vbm("hostonlyif", "ipconfig", n.Name, "--ip", n.IPv4.IP.String(), "--netmask", net.IP(n.IPv4.Mask).String()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createHostonlyAdapter creates a new host-only network.
+func createHostonlyAdapter(vbox VBoxManager) (*hostOnlyNetwork, error) {
 	out, err := vbox.vbmOut("hostonlyif", "create")
 	if err != nil {
 		return nil, err
 	}
 
-	res := reHostonlyInterfaceCreated.FindStringSubmatch(string(out))
+	res := reHostOnlyAdapterCreated.FindStringSubmatch(string(out))
 	if res == nil {
-		return nil, errors.New("failed to create hostonly interface")
+		return nil, errors.New("Failed to create host-only adapter")
 	}
 
 	return &hostOnlyNetwork{Name: res[1]}, nil
 }
 
-// listHostOnlyNetworks gets all host-only networks in a  map keyed by HostonlyNet.NetworkName.
-func listHostOnlyNetworks(vbox VBoxManager) (map[string]*hostOnlyNetwork, error) {
+// listHostOnlyAdapters gets all host-only adapters in a  map keyed by NetworkName.
+func listHostOnlyAdapters(vbox VBoxManager) (map[string]*hostOnlyNetwork, error) {
 	out, err := vbox.vbmOut("list", "hostonlyifs")
 	if err != nil {
 		return nil, err
@@ -90,14 +95,6 @@ func listHostOnlyNetworks(vbox VBoxManager) (map[string]*hostOnlyNetwork, error)
 			n.IPv4.IP = net.ParseIP(val)
 		case "NetworkMask":
 			n.IPv4.Mask = parseIPv4Mask(val)
-		case "IPV6Address":
-			n.IPv6.IP = net.ParseIP(val)
-		case "IPV6NetworkMaskPrefixLength":
-			l, err := strconv.ParseUint(val, 10, 8)
-			if err != nil {
-				return err
-			}
-			n.IPv6.Mask = net.CIDRMask(int(l), net.IPv6len*8)
 		case "HardwareAddress":
 			mac, err := net.ParseMAC(val)
 			if err != nil {
@@ -112,13 +109,13 @@ func listHostOnlyNetworks(vbox VBoxManager) (map[string]*hostOnlyNetwork, error)
 			n.NetworkName = val
 
 			if _, present := byName[n.NetworkName]; present {
-				return fmt.Errorf("VirtualBox is configured with multiple host-only interfaces with the same name %q. Please remove one.", n.NetworkName)
+				return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same name %q. Please remove one.", n.NetworkName)
 			}
 			byName[n.NetworkName] = n
 
 			if len(n.IPv4.IP) != 0 {
 				if _, present := byIP[n.IPv4.IP.String()]; present {
-					return fmt.Errorf("VirtualBox is configured with multiple host-only interfaces with the same IP %q. Please remove one.", n.IPv4.IP)
+					return fmt.Errorf("VirtualBox is configured with multiple host-only adapters with the same IP %q. Please remove one.", n.IPv4.IP)
 				}
 				byIP[n.IPv4.IP.String()] = n
 			}
@@ -135,65 +132,87 @@ func listHostOnlyNetworks(vbox VBoxManager) (map[string]*hostOnlyNetwork, error)
 	return byName, nil
 }
 
-func getHostOnlyNetwork(nets map[string]*hostOnlyNetwork, hostIP net.IP, netmask net.IPMask) *hostOnlyNetwork {
+func getHostOnlyAdapter(nets map[string]*hostOnlyNetwork, hostIP net.IP, netmask net.IPMask) *hostOnlyNetwork {
 	for _, n := range nets {
 		// Second part of this conditional handles a race where
 		// VirtualBox returns us the incorrect netmask value for the
-		// newly created interface.
+		// newly created adapter.
 		if hostIP.Equal(n.IPv4.IP) &&
 			(netmask.String() == n.IPv4.Mask.String() || n.IPv4.Mask.String() == buggyNetmask) {
+			log.Debugf("Found: %s", n.Name)
 			return n
 		}
 	}
 
+	log.Debug("Not found")
 	return nil
 }
 
-func getOrCreateHostOnlyNetwork(hostIP net.IP, netmask net.IPMask, dhcpIP net.IP, dhcpLowerIP net.IP, dhcpUpperIP net.IP, vbox VBoxManager) (*hostOnlyNetwork, error) {
-	nets, err := listHostOnlyNetworks(vbox)
+func getOrCreateHostOnlyNetwork(hostIP net.IP, netmask net.IPMask, vbox VBoxManager) (*hostOnlyNetwork, error) {
+	nets, err := listHostOnlyAdapters(vbox)
 	if err != nil {
 		return nil, err
 	}
 
-	hostOnlyNet := getHostOnlyNetwork(nets, hostIP, netmask)
-	if hostOnlyNet != nil {
-		return hostOnlyNet, nil
+	hostOnlyAdapter := getHostOnlyAdapter(nets, hostIP, netmask)
+	if hostOnlyAdapter != nil {
+		return hostOnlyAdapter, nil
 	}
 
-	// No existing host-only interface found. Create a new one.
-	hostOnlyNet, err = createHostonlyNet(vbox)
+	// No existing host-only adapter found. Create a new one.
+	hostOnlyAdapter, err = createHostonlyAdapter(vbox)
+	if err != nil {
+		// Sometimes the host-only adapter fails to create. See https://www.virtualbox.org/ticket/14040
+		// BUT, it is created in fact! So let's wait until it appears last in the list
+		log.Warnf("Creating a new host-only adapter produced an error: %s", err)
+		log.Warn("This is a known VirtualBox bug. Let's try to recover anyway...")
+
+		hostOnlyAdapter, err = waitForNewHostOnlyNetwork(nets, vbox)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Warnf("Found a new host-only adapter: %q", hostOnlyAdapter.Name)
+	}
+
+	hostOnlyAdapter.IPv4.IP = hostIP
+	hostOnlyAdapter.IPv4.Mask = netmask
+	if err := hostOnlyAdapter.Save(vbox); err != nil {
+		return nil, err
+	}
+
+	// Check that the adapter still exists.
+	// Sometimes, Vbox says it created it but then it cannot be found...
+	nets, err = listHostOnlyAdapters(vbox)
 	if err != nil {
 		return nil, err
 	}
 
-	hostOnlyNet.IPv4.IP = hostIP
-	hostOnlyNet.IPv4.Mask = netmask
-	if err := hostOnlyNet.Save(vbox); err != nil {
-		return nil, err
+	found := getHostOnlyAdapter(nets, hostIP, netmask)
+	if found == nil {
+		return nil, errNewHostOnlyAdapterNotVisible
 	}
 
-	dhcp := dhcpServer{}
-	dhcp.IPv4.IP = dhcpIP
-	dhcp.IPv4.Mask = netmask
-	dhcp.LowerIP = dhcpLowerIP
-	dhcp.UpperIP = dhcpUpperIP
-	dhcp.Enabled = true
-	if err := addHostonlyDHCP(hostOnlyNet.Name, dhcp, vbox); err != nil {
-		return nil, err
+	return hostOnlyAdapter, nil
+}
+
+func waitForNewHostOnlyNetwork(oldNets map[string]*hostOnlyNetwork, vbox VBoxManager) (*hostOnlyNetwork, error) {
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+
+		newNets, err := listHostOnlyAdapters(vbox)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, latestNet := range newNets {
+			if _, present := oldNets[name]; !present {
+				return latestNet, nil
+			}
+		}
 	}
 
-	// Check that the interface really exists.
-	// Sometimes, Vbox says it created the interface but then it cannot be found...
-	nets, err = listHostOnlyNetworks(vbox)
-	if err != nil {
-		return nil, err
-	}
-	hostOnlyNet = getHostOnlyNetwork(nets, hostIP, netmask)
-	if hostOnlyNet == nil {
-		return nil, errNewHostOnlyInterfaceNotVisible
-	}
-
-	return hostOnlyNet, nil
+	return nil, errors.New("Failed to find a new host-only adapter")
 }
 
 // DHCP server info.
@@ -205,22 +224,57 @@ type dhcpServer struct {
 	Enabled     bool
 }
 
-func addDHCPServer(kind, name string, d dhcpServer, vbox VBoxManager) error {
-	command := "modify"
-
-	// On some platforms (OSX), creating a hostonlyinterface adds a default dhcpserver
-	// While on others (Windows?) it does not.
-	dhcps, err := getDHCPServers(vbox)
+// removeOrphanDHCPServers removed the DHCP servers linked to no host-only adapter
+func removeOrphanDHCPServers(vbox VBoxManager) error {
+	dhcps, err := listDHCPServers(vbox)
 	if err != nil {
 		return err
 	}
 
-	if _, ok := dhcps[name]; !ok {
-		command = "add"
+	if len(dhcps) == 0 {
+		return nil
+	}
+
+	nets, err := listHostOnlyAdapters(vbox)
+	if err != nil {
+		return err
+	}
+
+	for name := range dhcps {
+		if strings.HasPrefix(name, dhcpPrefix) {
+			if _, present := nets[name]; !present {
+				if err := vbox.vbm("dhcpserver", "remove", "--netname", name); err != nil {
+					log.Warnf("Unable to remove orphan dhcp server %q: %s", name, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// addHostOnlyDHCPServer adds a DHCP server to a host-only network.
+func addHostOnlyDHCPServer(ifname string, d dhcpServer, vbox VBoxManager) error {
+	name := dhcpPrefix + ifname
+
+	dhcps, err := listDHCPServers(vbox)
+	if err != nil {
+		return err
+	}
+
+	// On some platforms (OSX), creating a host-only adapter adds a default dhcpserver,
+	// while on others (Windows?) it does not.
+	command := "add"
+	if dhcp, ok := dhcps[name]; ok {
+		command = "modify"
+		if (dhcp.IPv4.IP.Equal(d.IPv4.IP)) && (dhcp.IPv4.Mask.String() == d.IPv4.Mask.String()) && (dhcp.LowerIP.Equal(d.LowerIP)) && (dhcp.UpperIP.Equal(d.UpperIP)) && dhcp.Enabled {
+			// dhcp is up to date
+			return nil
+		}
 	}
 
 	args := []string{"dhcpserver", command,
-		kind, name,
+		"--netname", name,
 		"--ip", d.IPv4.IP.String(),
 		"--netmask", net.IP(d.IPv4.Mask).String(),
 		"--lowerip", d.LowerIP.String(),
@@ -235,13 +289,8 @@ func addDHCPServer(kind, name string, d dhcpServer, vbox VBoxManager) error {
 	return vbox.vbm(args...)
 }
 
-// addHostonlyDHCP adds a DHCP server to a host-only network.
-func addHostonlyDHCP(ifname string, d dhcpServer, vbox VBoxManager) error {
-	return addDHCPServer("--netname", "HostInterfaceNetworking-"+ifname, d, vbox)
-}
-
-// getDHCPServers gets all DHCP server settings in a map keyed by DHCP.NetworkName.
-func getDHCPServers(vbox VBoxManager) (map[string]*dhcpServer, error) {
+// listDHCPServers lists all DHCP server settings in a map keyed by DHCP.NetworkName.
+func listDHCPServers(vbox VBoxManager) (map[string]*dhcpServer, error) {
 	out, err := vbox.vbmOut("list", "dhcpservers")
 	if err != nil {
 		return nil, err

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -6,6 +6,8 @@ import (
 
 	"io"
 
+	"time"
+
 	"github.com/docker/machine/drivers/errdriver"
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/cert"
@@ -132,6 +134,9 @@ func (api *Client) Create(h *host.Host) error {
 	log.Info("Creating machine...")
 
 	if err := api.performCreate(h); err != nil {
+		// Wait for all the logs to reach the client
+		time.Sleep(2 * time.Second)
+
 		vBoxLog := ""
 		if h.DriverName == "virtualbox" {
 			vBoxLog = filepath.Join(api.GetMachinesDir(), h.Name, h.Name, "Logs", "VBox.log")


### PR DESCRIPTION
Fixes a bug when an host-only adapter cannot be used
Fixes a bug when the host-only adapter uses a wrong IP and then multiple machines get the same IP
Fixes the error message when the VM cannot be started
