### PR TITLE
Return exit code 3 on pre-create errors

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/machine/libmachine/crashreport"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnerror"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/ssh"
@@ -122,7 +123,11 @@ func runCommand(command func(commandLine CommandLine, api libmachine.API) error)
 				crashReporter.Send(crashErr)
 			}
 
-			osExit(1)
+			if _, ok := err.(mcnerror.ErrDuringPreCreate); ok {
+				osExit(3)
+			} else {
+				osExit(1)
+			}
 		}
 	}
 }

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnerror"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/provision"
@@ -124,7 +125,7 @@ func (api *Client) Create(h *host.Host) error {
 	log.Info("Running pre-create checks...")
 
 	if err := h.Driver.PreCreateCheck(); err != nil {
-		return fmt.Errorf("Error with pre-create check: %s", err)
+		return mcnerror.ErrDuringPreCreate{err}
 	}
 
 	if err := api.Save(h); err != nil {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -24,3 +24,11 @@ type ErrHostAlreadyExists struct {
 func (e ErrHostAlreadyExists) Error() string {
 	return fmt.Sprintf("Host already exists: %q", e.Name)
 }
+
+type ErrDuringPreCreate struct {
+	Cause error
+}
+
+func (e ErrDuringPreCreate) Error() string {
+	return fmt.Sprintf("Error with pre-create check: %q", e.Cause)
+}


### PR DESCRIPTION
This will return exit code 1 for every errors, except pre-create check errors, which will return 3.

Kitematic/Toolbox can now filter those errors out.