### PR TITLE
Rackspace: Only derive tenant ID if tenant name is supplied.

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -566,7 +566,7 @@ func (d *Driver) resolveIds() error {
 		})
 	}
 
-	if d.TenantId == "" {
+	if d.TenantName != "" && d.TenantId == "" {
 		if err := d.initIdentity(); err != nil {
 			return err
 		}


### PR DESCRIPTION
The Rackspace driver authenticates with username and API key rather than tenant name or ID. Modify the base OpenStack driver to only attempt to derive a tenant ID if a tenant name has been supplied, which will always be true for `-d openstack`, but never for `-d rackspace`.

Addresses #2781.