### PR TITLE
Allow Debug messages from ec2 driver to include request / response

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -655,8 +655,11 @@ func (d *Driver) Remove() error {
 
 func (d *Driver) getClient() *ec2.EC2 {
 	config := aws.NewConfig()
+	alogger := AwsLogger()
 	config = config.WithRegion(d.Region)
 	config = config.WithCredentials(credentials.NewStaticCredentials(d.AccessKey, d.SecretKey, d.SessionToken))
+	config = config.WithLogger(alogger)
+	config = config.WithLogLevel(aws.LogDebugWithHTTPBody)
 	return ec2.New(session.New(config))
 }
 

--- a/drivers/amazonec2/logger.go
+++ b/drivers/amazonec2/logger.go
@@ -1,0 +1,21 @@
+package amazonec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"log"
+	"os"
+)
+
+type awslogger struct {
+	logger *log.Logger
+}
+
+func AwsLogger() aws.Logger {
+	return &awslogger{
+		logger: log.New(os.Stderr, "", log.LstdFlags),
+	}
+}
+
+func (l awslogger) Log(args ...interface{}) {
+	l.logger.Println(args...)
+}


### PR DESCRIPTION
Allow Debug messages from ec2 driver to include request / response data sent to aws.

This Closes #2794 

Signed-off-by: Jeffrey Ellin <jeff@ellin.com>