### PR TITLE
Detect shell from grand parent process name if not directly called from a windows shell

### DIFF
--- a/libmachine/shell/shell_windows_test.go
+++ b/libmachine/shell/shell_windows_test.go
@@ -13,13 +13,29 @@ func TestDetect(t *testing.T) {
 
 	shell, err := Detect()
 
-	assert.Equal(t, "cmd", shell)
+	assert.Equal(t, "powershell", shell)
 	assert.NoError(t, err)
 }
 
-func TestStartedBy(t *testing.T) {
-	shell, err := startedBy()
+func TestGetNameAndItsPpidOfCurrent(t *testing.T) {
+	shell, shellppid, err := getNameAndItsPpid(os.Getpid())
+
+	assert.Equal(t, "shell.test.exe", shell)
+	assert.Equal(t, os.Getppid(), shellppid)
+	assert.NoError(t, err)
+}
+
+func TestGetNameAndItsPpidOfParent(t *testing.T) {
+	shell, _, err := getNameAndItsPpid(os.Getppid())
 
 	assert.Equal(t, "go.exe", shell)
+	assert.NoError(t, err)
+}
+
+func TestGetNameAndItsPpidOfGrandParent(t *testing.T) {
+	shell, shellppid, err := getNameAndItsPpid(os.Getppid())
+	shell, shellppid, err = getNameAndItsPpid(shellppid)
+
+	assert.Equal(t, "powershell.exe", shell)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
After creating the `docker-machine` chocolatey package V0.5.6 I found out that I missed a case detecting the windows powershell. Chocolatey does install the exe files into a package folder and then creates a shim to put it into PATH without adding new directories to the PATH variable.

Therefore the call stack of a `docker-machine env dev` command from a PowerShell looks like this: powershell -> docker-machine shim -> docker-machine

<img width="911" alt="docker-machine-env-with-choco-shim" src="https://cloud.githubusercontent.com/assets/207759/12280705/532a0ccc-b990-11e5-9b7d-1488638ae407.png">

The docker-machine.exe (pid 8992) retrieves the name of its parent and this still is docker-machine (pid 6076), the shim from chocolatey. It should look further up to find the powershell (pid 2028).

This is a proposal to fix this issue inside the docker-machine binary itself. I know this is an edge case with Chocolatey.

I have discussed this within the chocolatey Gitter channel and putting the exe directly into the chocolatey's bin directory is not preferred. 

Adding another directory to the user's PATH variable is also not optimal as this doesn't work within the same shell when a user installs docker-machine with just `choco install docker-machine`. A new shell must be opened to use it. 

So my approach is this PR which works fine for a powershell.exe and cmd.exe shell. Still works fine with git-bash, cygwin as they always set the SHELL environment.

WDYT?
