### PR TITLE
Check for nil before deferencing pointer in SG config

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -866,13 +866,15 @@ func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) []*
 	hasDockerPort := false
 	hasSwarmPort := false
 	for _, p := range group.IpPermissions {
-		switch *p.FromPort {
-		case 22:
-			hasSshPort = true
-		case int64(dockerPort):
-			hasDockerPort = true
-		case int64(swarmPort):
-			hasSwarmPort = true
+		if p.FromPort != nil {
+			switch *p.FromPort {
+			case 22:
+				hasSshPort = true
+			case int64(dockerPort):
+				hasDockerPort = true
+			case int64(swarmPort):
+				hasSwarmPort = true
+			}
 		}
 	}
 


### PR DESCRIPTION
You can see in debug output here https://ci.appveyor.com/project/eris-ltd/eris-cli/build/1.0.441-winTest that the `p.FromPort` seems to be dereferencing a pointer which is `nil`.  I'm not sure what state the SG could be in where `FromPort` is not specified but at any rate it seems to be prudent to check if it's `nil` first.

I'd like to add a unit test for this once https://github.com/docker/machine/pull/2828 (beginning of testable client interface) is in.

cc @docker/machine-maintainers 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>