### PR TITLE
Configures swarm-master with failover support

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -42,7 +42,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 
 	if swarmOptions.Master {
 		advertiseMasterInfo := fmt.Sprintf("%s:%s", ip, "3376")
-		cmd := fmt.Sprintf("manage --tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H %s --strategy %s --advertise %s",
+		cmd := fmt.Sprintf("manage --tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H %s --strategy %s --replication  --advertise %s",
 			authOptions.CaCertRemotePath,
 			authOptions.ServerCertRemotePath,
 			authOptions.ServerKeyRemotePath,


### PR DESCRIPTION
If more then one swarm-master is created with same discovery backend,
Rest of swarm-master will be configured as replica of primary master

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>