### PR TITLE
Add ability to imply 'default' VM in commands

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -14,11 +14,12 @@ func cmdConfig(c CommandLine, api libmachine.API) error {
 	// being run (it is intended to be run in a subshell)
 	log.SetOutWriter(os.Stderr)
 
-	if len(c.Args()) != 1 {
-		return ErrExpectedOneMachine
+	target, err := targetHost(c, api)
+	if err != nil {
+		return err
 	}
 
-	host, err := api.Load(c.Args().First())
+	host, err := api.Load(target)
 	if err != nil {
 		return err
 	}

--- a/commands/env.go
+++ b/commands/env.go
@@ -20,7 +20,6 @@ const (
 )
 
 var (
-	errImproperEnvArgs      = errors.New("Error: Expected one machine name")
 	errImproperUnsetEnvArgs = errors.New("Error: Expected no machine name when the -u flag is present")
 	defaultUsageHinter      UsageHintGenerator
 )
@@ -68,11 +67,16 @@ func cmdEnv(c CommandLine, api libmachine.API) error {
 }
 
 func shellCfgSet(c CommandLine, api libmachine.API) (*ShellConfig, error) {
-	if len(c.Args()) != 1 {
-		return nil, errImproperEnvArgs
+	if len(c.Args()) > 1 {
+		return nil, ErrExpectedOneMachine
 	}
 
-	host, err := api.Load(c.Args().First())
+	target, err := targetHost(c, api)
+	if err != nil {
+		return nil, err
+	}
+
+	host, err := api.Load(target)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -21,12 +21,17 @@ var funcMap = template.FuncMap{
 }
 
 func cmdInspect(c CommandLine, api libmachine.API) error {
-	if len(c.Args()) == 0 {
+	if len(c.Args()) > 1 {
 		c.ShowHelp()
 		return ErrExpectedOneMachine
 	}
 
-	host, err := api.Load(c.Args().First())
+	target, err := targetHost(c, api)
+	if err != nil {
+		return err
+	}
+
+	host, err := api.Load(target)
 	if err != nil {
 		return err
 	}

--- a/commands/kill_test.go
+++ b/commands/kill_test.go
@@ -17,7 +17,7 @@ func TestCmdKillMissingMachineName(t *testing.T) {
 
 	err := cmdKill(commandLine, api)
 
-	assert.EqualError(t, err, "Error: Expected to get one or more machine names as arguments")
+	assert.Equal(t, ErrNoDefault, err)
 }
 
 func TestCmdKill(t *testing.T) {

--- a/commands/rm_test.go
+++ b/commands/rm_test.go
@@ -18,7 +18,7 @@ func TestCmdRmMissingMachineName(t *testing.T) {
 
 	err := cmdRm(commandLine, api)
 
-	assert.EqualError(t, err, "Error: Expected to get one or more machine names as arguments")
+	assert.Equal(t, ErrNoMachineSpecified, err)
 	assert.True(t, commandLine.HelpShown)
 }
 

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -23,12 +23,12 @@ func cmdSSH(c CommandLine, api libmachine.API) error {
 		return nil
 	}
 
-	name := firstArg
-	if name == "" {
-		return ErrExpectedOneMachine
+	target, err := targetHost(c, api)
+	if err != nil {
+		return err
 	}
 
-	host, err := api.Load(name)
+	host, err := api.Load(target)
 	if err != nil {
 		return err
 	}

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -53,10 +53,10 @@ func TestCmdSSH(t *testing.T) {
 		},
 		{
 			commandLine: &commandstest.FakeCommandLine{
-				CliArgs: []string{""},
+				CliArgs: []string{},
 			},
 			api:         &libmachinetest.FakeAPI{},
-			expectedErr: ErrExpectedOneMachine,
+			expectedErr: ErrNoDefault,
 		},
 		{
 			commandLine: &commandstest.FakeCommandLine{

--- a/commands/status.go
+++ b/commands/status.go
@@ -6,11 +6,16 @@ import (
 )
 
 func cmdStatus(c CommandLine, api libmachine.API) error {
-	if len(c.Args()) != 1 {
+	if len(c.Args()) > 1 {
 		return ErrExpectedOneMachine
 	}
 
-	host, err := api.Load(c.Args().First())
+	target, err := targetHost(c, api)
+	if err != nil {
+		return err
+	}
+
+	host, err := api.Load(target)
 	if err != nil {
 		return err
 	}

--- a/commands/stop_test.go
+++ b/commands/stop_test.go
@@ -5,52 +5,99 @@ import (
 
 	"github.com/docker/machine/commands/commandstest"
 	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/libmachinetest"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCmdStopMissingMachineName(t *testing.T) {
-	commandLine := &commandstest.FakeCommandLine{}
-	api := &libmachinetest.FakeAPI{}
-
-	err := cmdStop(commandLine, api)
-
-	assert.EqualError(t, err, "Error: Expected to get one or more machine names as arguments")
-}
-
 func TestCmdStop(t *testing.T) {
-	commandLine := &commandstest.FakeCommandLine{
-		CliArgs: []string{"machineToStop1", "machineToStop2"},
-	}
-	api := &libmachinetest.FakeAPI{
-		Hosts: []*host.Host{
-			{
-				Name: "machineToStop1",
-				Driver: &fakedriver.Driver{
-					MockState: state.Running,
+	testCases := []struct {
+		commandLine    CommandLine
+		api            libmachine.API
+		expectedErr    error
+		expectedStates map[string]state.State
+	}{
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name: "default",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+					},
 				},
 			},
-			{
-				Name: "machineToStop2",
-				Driver: &fakedriver.Driver{
-					MockState: state.Running,
+			expectedErr: nil,
+			expectedStates: map[string]state.State{
+				"default": state.Stopped,
+			},
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name: "foobar",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+					},
 				},
 			},
-			{
-				Name: "machine",
-				Driver: &fakedriver.Driver{
-					MockState: state.Running,
+			expectedErr: ErrNoDefault,
+			expectedStates: map[string]state.State{
+				"foobar": state.Running,
+			},
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"machineToStop1", "machineToStop2"},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name: "machineToStop1",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+					},
+					{
+						Name: "machineToStop2",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+					},
+					{
+						Name: "machine",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+					},
 				},
+			},
+			expectedErr: nil,
+			expectedStates: map[string]state.State{
+				"machineToStop1": state.Stopped,
+				"machineToStop2": state.Stopped,
+				"machine":        state.Running,
 			},
 		},
 	}
 
-	err := cmdStop(commandLine, api)
-	assert.NoError(t, err)
+	for _, tc := range testCases {
+		err := cmdStop(tc.commandLine, tc.api)
+		assert.Equal(t, tc.expectedErr, err)
 
-	assert.Equal(t, state.Stopped, libmachinetest.State(api, "machineToStop1"))
-	assert.Equal(t, state.Stopped, libmachinetest.State(api, "machineToStop2"))
-	assert.Equal(t, state.Running, libmachinetest.State(api, "machine"))
+		for hostName, expectedState := range tc.expectedStates {
+			assert.Equal(t, expectedState, libmachinetest.State(tc.api, hostName))
+		}
+	}
 }

--- a/commands/url.go
+++ b/commands/url.go
@@ -7,11 +7,16 @@ import (
 )
 
 func cmdURL(c CommandLine, api libmachine.API) error {
-	if len(c.Args()) != 1 {
+	if len(c.Args()) > 1 {
 		return ErrExpectedOneMachine
 	}
 
-	host, err := api.Load(c.Args().First())
+	target, err := targetHost(c, api)
+	if err != nil {
+		return err
+	}
+
+	host, err := api.Load(target)
 	if err != nil {
 		return err
 	}

--- a/commands/url_test.go
+++ b/commands/url_test.go
@@ -17,7 +17,7 @@ func TestCmdURLMissingMachineName(t *testing.T) {
 
 	err := cmdURL(commandLine, api)
 
-	assert.EqualError(t, err, "Error: Expected one machine name as an argument")
+	assert.Equal(t, ErrNoDefault, err)
 }
 
 func TestCmdURLTooManyNames(t *testing.T) {

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -62,7 +62,7 @@ Next, as noted in the output of the `docker-machine create` command, we have to
 tell Docker to talk to that machine. You can do this with the `docker-machine
 env` command. For example,
 
-    $ eval "$(docker-machine env dev)"
+    $ eval "$(docker-machine env default)"
     $ docker ps
 
 > **Note**: If you are using `fish`, or a Windows shell such as
@@ -74,15 +74,15 @@ This will set environment variables that the Docker client will read which
 specify the TLS settings. Note that you will need to do that every time you
 open a new tab or restart your machine.
 
-To see what will be set, run `docker-machine env dev`.
+To see what will be set, we can run `docker-machine env default`.
 
-    $ docker-machine env dev
+    $ docker-machine env default
     export DOCKER_TLS_VERIFY="1"
     export DOCKER_HOST="tcp://172.16.62.130:2376"
-    export DOCKER_CERT_PATH="/Users/<your username>/.docker/machine/machines/dev"
-    export DOCKER_MACHINE_NAME="dev"
+    export DOCKER_CERT_PATH="/Users/<yourusername>/.docker/machine/machines/default"
+    export DOCKER_MACHINE_NAME="default"
     # Run this command to configure your shell:
-    # eval "$(docker-machine env dev)"
+    # eval "$(docker-machine env default)"
 
 You can now run Docker commands on this host:
 
@@ -98,7 +98,7 @@ You can now run Docker commands on this host:
 Any exposed ports are available on the Docker host’s IP address, which you can
 get using the `docker-machine ip` command:
 
-    $ docker-machine ip dev
+    $ docker-machine ip default
     192.168.99.100
 
 For instance, you can try running a webserver ([nginx](https://www.nginx.com/)
@@ -109,7 +109,7 @@ in a container with the following command:
 When the image is finished pulling, you can hit the server at port 8000 on the
 IP address given to you by `docker-machine ip`. For instance:
 
-    $ curl $(docker-machine ip dev):8000
+    $ curl $(docker-machine ip default):8000
     <!DOCTYPE html>
     <html>
     <head>
@@ -142,7 +142,47 @@ output of `docker-machine ls`.
 
 If you are finished using a host for the time being, you can stop it with
 `docker-machine stop` and later start it again with `docker-machine start`.
-Make sure to specify the machine name as an argument:
 
-    $ docker-machine stop dev
-    $ docker-machine start dev
+    $ docker-machine stop default
+    $ docker-machine start default
+
+## Operating on machines without specifying the name
+
+Some commands will assume that the specified operation should be run on a
+machine named `default` (if it exists) if no machine name is passed to them as
+an argument.  Because using a local VM named `default` is such a common pattern,
+this allows you to save some typing on Machine commands that may be frequently
+invoked.
+
+For instance:
+
+    $ docker-machine stop
+    Stopping "default"....
+    Machine "default" was stopped.
+
+    $ docker-machine start
+    Starting "default"...
+    (default) Waiting for an IP...
+    Machine "default" was started.
+    Started machines may have new IP addresses.  You may need to re-run the `docker-machine env` command.
+
+    $ eval $(docker-machine env)
+
+    $ docker-machine ip
+    192.168.99.100
+
+Commands that will follow this style are:
+
+- `docker-machine stop`
+- `docker-machine start`
+- `docker-machine regenerate-certs`
+- `docker-machine restart`
+- `docker-machine kill`
+- `docker-machine upgrade`
+- `docker-machine config`
+- `docker-machine env`
+- `docker-machine inspect`
+- `docker-machine url`
+
+For machines other than `default`, and commands other than those listed above,
+you must always specify the name explicitly as an argument.

--- a/test/integration/cli/inspect.bats
+++ b/test/integration/cli/inspect.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "inspect: show error in case of no args" {
   run machine inspect
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Error: No machine name(s) specified and no \"default\" machine exists."* ]]
 }

--- a/test/integration/cli/status.bats
+++ b/test/integration/cli/status.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "status: show error in case of no args" {
   run machine status
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Error: No machine name(s) specified and no \"default\" machine exists."* ]]
 }

--- a/test/integration/cli/url.bats
+++ b/test/integration/cli/url.bats
@@ -5,5 +5,5 @@ load ${BASE_TEST_DIR}/helpers.bash
 @test "url: show error in case of no args" {
   run machine url
   [ "$status" -eq 1 ]
-  [[ ${output} == *"Expected one machine name as an argument"* ]]
+  [[ ${output} == *"Error: No machine name(s) specified and no \"default\" machine exists."* ]]
 }


### PR DESCRIPTION
This is one feature that people sorely missed from boot2docker and we now have the test infrastructure to make sure it's properly tested, so I'm excited to put this PR in.

This PR adds a "short form" to commands whereby if no name is specified, `default` is assumed to be the intended target.

Closes https://github.com/docker/machine/issues/1783

e.g.:

```console
$ docker-machine stop
Stopping "default"....
Machine "default" was stopped.

$ docker-machine start
Starting "default"...
(default) Waiting for an IP...
Machine "default" was started.
Started machines may have new IP addresses.  You may need to re-run the `docker-machine env` command.

$ docker-machine ip
192.168.99.100
```

cc @docker/machine-maintainers @londoncalling 

Possibly a few integration test failures that I'll fix due to the changed error message.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>