### PR TITLE
Fix shared folder mount on restart

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -415,8 +415,15 @@ func (d *Driver) Stop() error {
 }
 
 func (d *Driver) Restart() error {
-	_, _, err := vmrun("reset", d.vmxPath(), "nogui")
-	return err
+	// Stop VM gracefully
+	if err := d.Stop(); err != nil {
+		return err
+	}
+	// Start it again and mount shared folder
+	if err := d.Start(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (d *Driver) Kill() error {


### PR DESCRIPTION
Currently the `vmwarefusion` driver does not mount shared folders when restarting the VM.

Mentioned in boot2docker/boot2docker#1105