### PR TITLE
Fix bugsnag

### DIFF
--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/docker/machine/libmachine/auth"
-	"github.com/docker/machine/libmachine/crashreport"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/log"
@@ -163,22 +162,12 @@ func (h *Host) Upgrade() error {
 
 	provisioner, err := provision.DetectProvisioner(h.Driver)
 	if err != nil {
-		return crashreport.CrashError{
-			Cause:      err,
-			Command:    "Upgrade",
-			Context:    "provision.DetectProvisioner",
-			DriverName: h.Driver.DriverName(),
-		}
+		return err
 	}
 
 	log.Info("Upgrading docker...")
 	if err := provisioner.Package("docker", pkgaction.Upgrade); err != nil {
-		return crashreport.CrashError{
-			Cause:      err,
-			Command:    "Upgrade",
-			Context:    "provisioner.Package",
-			DriverName: h.Driver.DriverName(),
-		}
+		return err
 	}
 
 	log.Info("Restarting docker...")

--- a/libmachine/libmachinetest/fake_api.go
+++ b/libmachine/libmachinetest/fake_api.go
@@ -72,6 +72,10 @@ func (api *FakeAPI) Save(host *host.Host) error {
 	return nil
 }
 
+func (api FakeAPI) GetMachinesDir() string {
+	return ""
+}
+
 func State(api libmachine.API, name string) state.State {
 	host, _ := api.Load(name)
 	machineState, _ := host.Driver.GetState()


### PR DESCRIPTION
I broke Bugsnag reports in 0.5.6.

This PR fixes the report on a create error and disables reports on upgrade for now.

We need to find a way to:
+ Re-enable reports on upgrades
+ Write a proper integration tests that verifies BugSnag reports are OK