### PR TITLE
Add test for 'docker-machine inspect'

### DIFF
--- a/commands/inspect_test.go
+++ b/commands/inspect_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/docker/machine/commands/commandstest"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/libmachinetest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdInspect(t *testing.T) {
+	testCases := []struct {
+		commandLine CommandLine
+		api         libmachine.API
+		expectedErr error
+	}{
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"foo", "bar"},
+			},
+			api:         &libmachinetest.FakeAPI{},
+			expectedErr: ErrExpectedOneMachine,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := cmdInspect(tc.commandLine, tc.api)
+		assert.Equal(t, tc.expectedErr, err)
+	}
+}


### PR DESCRIPTION
cc @docker/machine-maintainers 

This is a test I originally wrote for https://github.com/docker/machine/pull/2843 but forgot to include in that commit.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>