### PR TITLE
Fix infinite loop when deleting machine in ultra weird state

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -615,7 +615,7 @@ func (d *Driver) Kill() error {
 }
 
 func (d *Driver) Remove() error {
-	s, err := d.GetState()
+	_, err := d.GetState()
 	if err != nil {
 		if err == ErrMachineNotExist {
 			log.Infof("machine does not exist, assuming it has been removed already")
@@ -623,14 +623,8 @@ func (d *Driver) Remove() error {
 		}
 		return err
 	}
-	if s == state.Running {
-		if err := d.Stop(); err != nil {
-			return err
-		}
-	} else if s != state.Stopped {
-		if err := d.Kill(); err != nil {
-			return err
-		}
+	if err := d.Kill(); err != nil {
+		return err
 	}
 	// vbox will not release it's lock immediately after the stop
 	d.sleeper.Sleep(1 * time.Second)


### PR DESCRIPTION
If you try to force delete a machine in a weird state ( actually a boot2docker which kernel panicked, while the vm in virtualbox is still running). The remove command fall into an infinite loop, and the machine is not removed.

This PR kills the machine rather than wait for its state to be changing.