### PR TITLE
Replace public IPs with reserved ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To see how to connect Docker to this machine, run: docker-machine env staging
 $ docker-machine ls
 NAME      ACTIVE   DRIVER         STATE     URL                         SWARM   DOCKER   ERRORS
 default   -        virtualbox     Running   tcp://192.168.99.188:2376           v1.9.1
-staging   -        digitalocean   Running   tcp://45.55.21.28:2376              v1.9.1
+staging   -        digitalocean   Running   tcp://203.0.113.81:2376             v1.9.1
 ```
 
 ## Installation and documentation

--- a/docs/get-started-cloud.md
+++ b/docs/get-started-cloud.md
@@ -76,7 +76,7 @@ From this point, the remote host behaves much like the local host we created in 
     $ docker-machine ls
     NAME      ACTIVE   DRIVER         STATE     URL
     dev       -        virtualbox     Running   tcp://192.168.99.103:2376
-    staging   *        digitalocean   Running   tcp://104.236.50.118:2376
+    staging   *        digitalocean   Running   tcp://203.0.113.81:2376
 
 To remove a host and all of its containers and images, use `docker-machine rm`:
 

--- a/docs/reference/active.md
+++ b/docs/reference/active.md
@@ -16,8 +16,8 @@ See which machine is "active" (a machine is considered active if the
     $ docker-machine ls
     NAME      ACTIVE   DRIVER         STATE     URL
     dev       -        virtualbox     Running   tcp://192.168.99.103:2376
-    staging   *        digitalocean   Running   tcp://104.236.50.118:2376
+    staging   *        digitalocean   Running   tcp://203.0.113.81:2376
     $ echo $DOCKER_HOST
-    tcp://104.236.50.118:2376
+    tcp://203.0.113.81:2376
     $ docker-machine active
     staging


### PR DESCRIPTION
In the documentation, I've noticed a few examples where real public (DigitalOcean owned) IPv4 addresses were used. When the droplet with this address is destroyed, the address will eventually be reassigned to a new customer, probably after a cool-down period. In my opinion, such IP addresses should not be used in public documentation, especially for a project of this popularity.

In fact, the IETF came up with a few IPv4 blocks, reserved especially for this purpose. [RFC 5737](https://tools.ietf.org/html/rfc5737) describes these blocks and what they're for. For this PR, I've picked the `203.0.113.0/24` prefix, since it's the most "public looking" of the three. For no particular reason, `203.0.113.81` is the IP I've used to change the DigitalOcean addresses in the documentation.

I realise the old IP was used in examples of the `digitalocean` driver, and this IP does not belong to DigitalOcean. However, I think it's more important to use addresses which aren't routable (and never will be), than to use an address that happens to assigned to DigitalOcean (which I doubt many people will notice anyway).