### PR TITLE
Add appveyor.yml for native windows tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+# appveyor.yml reference : http://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+skip_tags: true
+
+os: Windows Server 2012 R2
+
+environment:
+  GOPATH: c:\gopath
+  # Support go1.5 vendoring (let us avoid messing with GOPATH or using godep)
+  GO15VENDOREXPERIMENT: 1
+  matrix:
+  # - GOARCH: 386
+  #   GOVERSION: 1.5.3
+  - GOARCH: amd64
+    GOVERSION: 1.5.3
+
+clone_folder: c:\gopath\src\github.com\docker\machine
+
+install:
+  - set Path=c:\go\bin;%Path%
+  - echo %Path%
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-%GOARCH%.msi
+  - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
+  - go version
+  - go env
+  - go get github.com/golang/lint/golint
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cover
+  - go get github.com/tools/godep
+  - go get github.com/aktau/github-release
+
+build_script:
+  - mkdir bin
+  - go build -o ./bin/docker-machine.exe ./cmd/machine.go
+
+test_script:
+  # test this from a PowerShell
+  - powershell -Command go test -v ./libmachine/shell
+  # - go test -v ./...
+  # - go vet ./...
+
+deploy: off


### PR DESCRIPTION
For #2821 I started a test at AppVeyor. Here is the `appveyor.yml`. Feel free to tweak it for an official CI build + test.

An example can be found here: https://ci.appveyor.com/project/hypriot/machine/build/9
