### PR TITLE
docs: fix --exoscale-image description in documentation

### DIFF
--- a/docs/drivers/exoscale.md
+++ b/docs/drivers/exoscale.md
@@ -20,8 +20,8 @@ Options:
 -   `--exoscale-api-key`: **required** Your API key.
 -   `--exoscale-api-secret-key`: **required** Your API secret key.
 -   `--exoscale-instance-profile`: Instance profile.
--   `--exoscale-disk-size`: Disk size for the host in GB.
--   `--exoscale-image`: exoscale disk size. (10, 50, 100, 200, 400)
+-   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400).
+-   `--exoscale-image`: Image template (eg. ubuntu-14.04, ubuntu-15.10).
 -   `--exoscale-security-group`: Security group. It will be created if it doesn't exist.
 -   `--exoscale-availability-zone`: exoscale availability zone.
 


### PR DESCRIPTION
There was a small error in `--exoscale-image` description.