### PR TITLE
Override default machine name with $DOCKER_MACHINE_NAME

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -19,10 +19,13 @@ import (
 )
 
 const (
-	defaultMachineName = "default"
+	defaultMachineNameEnvVar   = "DOCKER_MACHINE_NAME"
+	defaultMachineNameFallback = "default"
 )
 
 var (
+	defaultMachineName = getEnvWithFallback(defaultMachineNameEnvVar, defaultMachineNameFallback)
+
 	ErrHostLoad           = errors.New("All specified hosts had errors loading their configuration.")
 	ErrNoDefault          = fmt.Errorf("Error: No machine name(s) specified and no %q machine exists.", defaultMachineName)
 	ErrNoMachineSpecified = errors.New("Error: Expected to get one or more machine names as arguments")
@@ -73,6 +76,14 @@ func (c *contextCommandLine) Application() *cli.App {
 	return c.App
 }
 
+func getEnvWithFallback(envVar string, fallback string) string {
+	value := os.Getenv(envVar)
+	if value == "" {
+		value = fallback
+	}
+	return value
+}
+
 // targetHost returns a specific host name if one is indicated by the first CLI
 // arg, or the default host name if no host is specified.
 func targetHost(c CommandLine, api libmachine.API) (string, error) {
@@ -97,8 +108,8 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 		hostsToLoad []string
 	)
 
-	// If user did not specify a machine name explicitly, use the 'default'
-	// machine if it exists.  This allows short form commands such as
+	// If user did not specify a machine name explicitly, use the default
+	// machine name if it exists.  This allows short form commands such as
 	// 'docker-machine stop' for convenience.
 	if len(c.Args()) == 0 {
 		target, err := targetHost(c, api)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -148,11 +148,11 @@ If you are finished using a host for the time being, you can stop it with
 
 ## Operating on machines without specifying the name
 
-Some commands will assume that the specified operation should be run on a
-machine named `default` (if it exists) if no machine name is passed to them as
-an argument.  Because using a local VM named `default` is such a common pattern,
-this allows you to save some typing on Machine commands that may be frequently
-invoked.
+Some commands will assume that the specified operation should be run on the default
+machine (if it exists) if no machine name is passed to them as an argument. The default
+machine name can be specified in an environment variable `DOCKER_MACHINE_NAME`, or is
+simply named `default` if this environment variable does not exist. This allows you to
+save some typing on Machine commands that may be frequently invoked.
 
 For instance:
 
@@ -171,6 +171,17 @@ For instance:
     $ docker-machine ip
     192.168.99.100
 
+And, because `docker-machine env` also defines `DOCKER_MACHINE_NAME`:
+
+    $ eval $(docker-machine env staging)
+
+    $ docker-machine start
+    Starting "staging"...
+    Machine "staging" is already running.
+
+    $ docker-machine ip
+    203.0.113.81
+
 Commands that will follow this style are:
 
 - `docker-machine config`
@@ -188,5 +199,5 @@ Commands that will follow this style are:
 - `docker-machine upgrade`
 - `docker-machine url`
 
-For machines other than `default`, and commands other than those listed above,
+For machines other than the default machine, and commands other than those listed above,
 you must always specify the name explicitly as an argument.

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,3 +1,9 @@
+# Unset docker-machine env vars, so they won't affect tests
+unexport DOCKER_CERT_PATH
+unexport DOCKER_HOST
+unexport DOCKER_MACHINE_NAME
+unexport DOCKER_TLS_VERIFY
+
 # Quick test. You can bypass long tests using: `if testing.Short() { t.Skip("Skipping in short mode.") }`
 test-short:
 	$(GO) test $(VERBOSE_GO) -test.short -tags "$(BUILDTAGS)" $(PKGS)


### PR DESCRIPTION
See #2877 for a description of the proposed feature, or rather addition to the default machine feature introduced with #2843.

This is a pretty straightforward change to override `defaultMachineName` with the value of `$DOCKER_MACHINE_NAME`, including the related documentation changes. To keep the current tests from failing whenever `$DOCKER_MACHINE_NAME` is set, it (and related variables) are unset in the makefile.

To add proper testcases, the environment variable should be set (using `os.Setenv()`) before each testcase, and removed afterwards. While this would probably work, it does not feel like a particular clean solution to me. In my opinion the test cases should not depend on the outside environment (e.g. unsetting environment vars in the makefile should not be needed) and the test cases should not mess with the 'real' environment, even though they run in their own subprocess and are not exported to parent processes.

The ideal way to me would be to have all environment stuff in a separate map, which is filled from `os.Environ()` and have all other places interact with it. Then for test cases it can be faked, similar to what is done for the command line. Ideally, this would be incorporated for all places involving environment variables (there are a few more).

Would the above be the right way to go? If so, I can look into a solution along those lines and update the PR. Or perhaps any other suggestions or comments on the proposed changes currently in this PR? Thanks!