### PR TITLE
Fix #2903, revert #2833 since it makes it impossible to start up a Swarm master with the token discovery method

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -42,7 +42,7 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 
 	if swarmOptions.Master {
 		advertiseMasterInfo := fmt.Sprintf("%s:%s", ip, "3376")
-		cmd := fmt.Sprintf("manage --tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H %s --strategy %s --replication  --advertise %s",
+		cmd := fmt.Sprintf("manage --tlsverify --tlscacert=%s --tlscert=%s --tlskey=%s -H %s --strategy %s --advertise %s",
 			authOptions.CaCertRemotePath,
 			authOptions.ServerCertRemotePath,
 			authOptions.ServerKeyRemotePath,


### PR DESCRIPTION
I propose that the --replication option is removed since it makes it impossible to start up a Swarm master with the token discovery method, which is the default method described for getting started at https://docs.docker.com/swarm/install-w-machine/

(Another option would be to parse the discovery url and only add the `--replication` option if the swarm discovery url starts with etcd, consul or zk.)

There are also currently failing integration tests in test/integration/core/swarm-options.bats, which are passing again after this fix.

Signed-off-by: Patrik Erdes <patrik@erdes.se>