### PR TITLE
Fix #2905, a Swarm host will now show as active by the active command when using the env --swarm option

### DIFF
--- a/commands/active.go
+++ b/commands/active.go
@@ -24,12 +24,21 @@ func cmdActive(c CommandLine, api libmachine.API) error {
 
 	items := getHostListItems(hosts, hostsInError)
 
-	for _, item := range items {
-		if item.ActiveHost {
-			fmt.Println(item.Name)
-			return nil
-		}
+	active, err := activeHost(items)
+
+	if err != nil {
+		return err
 	}
 
-	return errNoActiveHost
+	fmt.Println(active.Name)
+	return nil
+}
+
+func activeHost(items []HostListItem) (HostListItem, error) {
+	for _, item := range items {
+		if item.ActiveHost || item.ActiveSwarm {
+			return item, nil
+		}
+	}
+	return HostListItem{}, errNoActiveHost
 }

--- a/commands/active_test.go
+++ b/commands/active_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdActiveNone(t *testing.T) {
+	hostListItems := []HostListItem{
+		{
+			Name:        "host1",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host2",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host3",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+	}
+	_, err := activeHost(hostListItems)
+	assert.Equal(t, err, errNoActiveHost)
+}
+
+func TestCmdActiveHost(t *testing.T) {
+	hostListItems := []HostListItem{
+		{
+			Name:        "host1",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host2",
+			ActiveHost:  true,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host3",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+	}
+	active, err := activeHost(hostListItems)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, active.Name, "host2")
+}
+
+func TestCmdActiveSwarm(t *testing.T) {
+	hostListItems := []HostListItem{
+		{
+			Name:        "host1",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host2",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+		},
+		{
+			Name:        "host3",
+			ActiveHost:  false,
+			ActiveSwarm: true,
+		},
+	}
+	active, err := activeHost(hostListItems)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, active.Name, "host3")
+}

--- a/test/integration/core/swarm-options.bats
+++ b/test/integration/core/swarm-options.bats
@@ -27,15 +27,29 @@ export TOKEN=$(curl -sS -X POST "https://discovery.hub.docker.com/v1/clusters")
     [[ "$heartbeat_arg" =~ "--heartbeat=5s" ]]
 }
 
-@test "should not show as swarm active if normal active" {
+@test "ls command should not show as swarm active if normal active" {
     eval $(machine env queenbee)
     run machine ls --filter name=queenbee
-    [[ ${lines[1]} != *"* (swarm)"*  ]]
+    [[ ${lines[1]} != *"* (swarm)"* ]]
 }
 
-@test "should show as swarm active" {
+@test "ls command should show as swarm active" {
     eval $(machine env --swarm queenbee)
     run machine ls --filter name=queenbee
     echo ${output}
-    [[ ${lines[1]} == *"* (swarm)"*  ]]
+    [[ ${lines[1]} == *"* (swarm)"* ]]
+}
+
+@test "active command should show the host as active if normal active" {
+    eval $(machine env queenbee)
+    run machine active
+    echo ${output}
+    [[ ${lines[0]} == "queenbee" ]]
+}
+
+@test "active command should show the host as active if swarm active" {
+    eval $(machine env --swarm queenbee)
+    run machine active
+    echo ${output}
+    [[ ${lines[0]} == "queenbee" ]]
 }


### PR DESCRIPTION
In `active.go` only `item.ActiveHost` was checked when determining if the host was active. I have changed that so that the host is determined to be active if either `item.ActiveHost` or `item.ActiveSwarm` is set.

There were no unit tests or integration tests covering `docker-machine active`.
The `cmdActive` command was not easily possible to do unit testing on, so I broke out the function checking what host is active, to make it possible to add unit tests. I added unit tests in `active_test.go`. I also added two integration tests in `swarm-options.bats`.

Signed-off-by: Patrik Erdes <patrik@erdes.se>