### PR TITLE
Dockerfile: use COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN go get  github.com/golang/lint/golint \
 ENV USER root
 WORKDIR /go/src/github.com/docker/machine
 
-ADD . /go/src/github.com/docker/machine
+COPY . /go/src/github.com/docker/machine
 RUN mkdir bin


### PR DESCRIPTION
ADD is far too magical, and we should be steering people away from it,
so using it in an official Docker project sends a mixed message.

Signed-off-by: Aleksa Sarai <asarai@suse.com>