### PR TITLE
FIX #494 - Use same binary filename scheme as other docker-project

### DIFF
--- a/docs/install-machine.md
+++ b/docs/install-machine.md
@@ -30,26 +30,23 @@ instructions in the next section.
 
 2.  Download the Docker Machine binary and extract it to your PATH.
 
-        Linux:
+    If you are running OS X or Linux:
 
-            $ curl -L https://github.com/docker/machine/releases/download/v0.5.5/docker-machine_linux-amd64 >/usr/local/bin/docker-machine && \
-            chmod +x /usr/local/bin/docker-machine
+        $ curl -L https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-`uname -s`-`uname -m` > /usr/local/bin/docker-machine && \
+        chmod +x /usr/local/bin/docker-machine
 
-        OSX:
+    If you are running Windows with git bash
 
-            $ curl -L https://github.com/docker/machine/releases/download/v0.5.5/docker-machine_darwin-amd64 >/usr/local/bin/docker-machine && \
-            chmod +x /usr/local/bin/docker-machine
+        $ if [[ ! -d "$HOME/bin" ]]; then mkdir -p "$HOME/bin"; fi && \
+        curl -L https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
+        chmod +x "$HOME/bin/docker-machine.exe"
 
-        Windows (using Git Bash):
-
-            $ if [[ ! -d "$HOME/bin" ]]; then mkdir -p "$HOME/bin"; fi && \
-            curl -L https://github.com/docker/machine/releases/download/v0.5.5/docker-machine_windows-amd64.exe > "$HOME/bin/docker-machine.exe" && \
-            chmod +x "$HOME/bin/docker-machine.exe"
+    Otherwise, download one of the releases from the [release page](https://github.com/docker/machine/releases/) directly.
 
 3.  Check the installation by displaying the Machine version:
 
         $ docker-machine version
-        docker-machine version 0.5.5, build 02c4254
+        docker-machine version 0.6.0, build 61388e9
 
 ## Installing bash completion scripts
 

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -3,11 +3,18 @@ extension = $(patsubst windows,.exe,$(filter windows,$(1)))
 # Valid target combinations
 VALID_OS_ARCH := "[darwin/amd64][linux/amd64][windows/amd64][windows/386]"
 
+os.darwin := Darwin
+os.linux := Linux
+os.windows := Windows
+
+arch.amd64 := x86_64
+arch.386 := i386
+
 define gocross
 	$(if $(findstring [$(1)/$(2)],$(VALID_OS_ARCH)), \
 	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 \
 		$(GO) build \
-		-o $(PREFIX)/bin/docker-machine_$(1)-$(2)$(call extension,$(GOOS)) \
+		-o $(PREFIX)/bin/docker-machine-${os.$(1)}-${arch.$(2)}$(call extension,$(GOOS)) \
 		-a $(VERBOSE_GO) -tags "static_build netgo $(BUILDTAGS)" -installsuffix netgo \
 		-ldflags "$(GO_LDFLAGS) -extldflags -static" $(GO_GCFLAGS) ./cmd/machine.go;)
 endef

--- a/script/release/github-release-template.md
+++ b/script/release/github-release-template.md
@@ -1,29 +1,24 @@
 ## Installation
 
-1. Download the file for your OS and architecture.
-2. Move the binary to your PATH.
+If you're a Mac or Windows user, the [Docker Toolbox](https://www.docker.com/docker-toolbox) will install Docker Machine {{VERSION}} for you, alongside the latest versions of the Docker Engine, Compose and Kitematic.
 
-e.g., for Mac OSX:
+You can use the usual commands to install or upgrade:
 
+On OS X or Linux
 ```console
-$ curl -L https://github.com/docker/machine/releases/download/{{VERSION}}/docker-machine_darwin-amd64 >/usr/local/bin/docker-machine && \
+$ curl -L https://github.com/docker/machine/releases/download/{{VERSION}}/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine && \
   chmod +x /usr/local/bin/docker-machine
 ```
-
-Linux:
-
-```console
-$ curl -L https://github.com/docker/machine/releases/download/{{VERSION}}/docker-machine_linux-amd64 >/usr/local/bin/docker-machine && \
-  chmod +x /usr/local/bin/docker-machine
-```
-
-Windows (using [git bash](https://git-for-windows.github.io/)):
-
+On Windows with git bash
 ```console
 $ if [[ ! -d "$HOME/bin" ]]; then mkdir -p "$HOME/bin"; fi && \
-  curl -L https://github.com/docker/machine/releases/download/{{VERSION}}/docker-machine_windows-amd64.exe > "$HOME/bin/docker-machine.exe" && \
-  chmod +x "$HOME/bin/docker-machine.exe"
+curl -L https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-Windows-x86_64.exe > "$HOME/bin/docker-machine.exe" && \
+chmod +x "$HOME/bin/docker-machine.exe"
 ```
+
+Otherwise, download one of the releases from the [release page](https://github.com/docker/machine/releases/) directly.
+
+See the install [docs](https://docs.docker.com/machine/install-machine/) for more install options and instructions.
 
 ## Changelog
 


### PR DESCRIPTION
This PR puts docker-machine binaries in the same format as the other docker binaries (docker/docker and docker/compose).

This also update install instructions and release template.

btw the windows bash script instruction where badly failing under mingw.

This fix #985 and #494
