### PR TITLE
Add more logs, specially for windows users

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -478,7 +478,8 @@ func (d *Driver) Start() error {
 
 	var hostOnlyAdapter *hostOnlyNetwork
 	if s == state.Stopped {
-		// check network to re-create if needed
+		log.Infof("Check network to re-create if needed...")
+
 		if hostOnlyAdapter, err = d.setupHostOnlyNetwork(d.MachineName); err != nil {
 			return fmt.Errorf("Error setting up host only network on machine start: %s", err)
 		}
@@ -715,7 +716,6 @@ func (d *Driver) setupHostOnlyNetwork(machineName string) (*hostOnlyNetwork, err
 		return nil, err
 	}
 
-	log.Debug("Removing orphan DHCP servers...")
 	if err := removeOrphanDHCPServers(d.VBoxManager); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On windows, Machine is sometimes waiting for the user to accept modifications to Virtualbox networks adapters. Sometimes those notifications are shown only in the taskbar which can be easily missed.

Signed-off-by: David Gageot <david@gageot.net>