### PR TITLE
Machine output redirected to stdout.

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -10,9 +10,9 @@ import (
 )
 
 func cmdConfig(c CommandLine, api libmachine.API) error {
-	// Ensure that log messages always go to stderr when this command is
-	// being run (it is intended to be run in a subshell)
-	log.SetOutWriter(os.Stderr)
+
+	log.SetOutWriter(os.Stdout)
+	log.SetErrWriter(os.Stderr)
 
 	target, err := targetHost(c, api)
 	if err != nil {


### PR DESCRIPTION
log functions are used both writing output and logging errors.
As raised in bug #2920, output redirection in script creates confusion.
This fixes the issue by redirecting error to stderr and output to stdout.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>