### PR TITLE
Add RESPONSE time to available columns in ls

### DIFF
--- a/commands/ls_test.go
+++ b/commands/ls_test.go
@@ -475,6 +475,7 @@ func TestGetHostStateTimeout(t *testing.T) {
 	assert.Equal(t, "foo", hostItem.Name)
 	assert.Equal(t, state.Timeout, hostItem.State)
 	assert.Equal(t, "Driver", hostItem.DriverName)
+	assert.Equal(t, stateTimeoutDuration, hostItem.ResponseTime)
 }
 
 func TestGetHostStateError(t *testing.T) {

--- a/docs/reference/ls.md
+++ b/docs/reference/ls.md
@@ -88,6 +88,7 @@ Valid placeholders for the Go template are listed below:
 | .Swarm         | Machine swarm name                       |
 | .Error         | Machine errors                           |
 | .DockerVersion | Docker Daemon version                    |
+| .ResponseTime  | Time taken by the host to respond        |
 
 When using the `--format` option, the `ls` command will either output the data exactly as the template declares or,
 when using the table directive, will include column headers as well.


### PR DESCRIPTION
This is a rebased version of https://github.com/docker/machine/pull/1475 where the response time is not displayed by default but is available when used with `docker-machine ls -f {{.ResponseTime}}'

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>

Signed-off-by: David Gageot <david@gageot.net>