### PR TITLE
Wait for Docker daemon on host start

### DIFF
--- a/libmachine/engine/engine.go
+++ b/libmachine/engine/engine.go
@@ -1,5 +1,9 @@
 package engine
 
+const (
+	DefaultPort = 2376
+)
+
 type Options struct {
 	ArbitraryFlags   []string
 	DNS              []string `json:"Dns"`

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -111,6 +111,17 @@ func (h *Host) Start() error {
 	}
 
 	log.Infof("Machine %q was started.", h.Name)
+
+	provisioner, err := provision.DetectProvisioner(h.Driver)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Migrate away from using hardcoded daemon port.
+	if err := provision.WaitForDocker(provisioner, engine.DefaultPort); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/libmachine/host/host_test.go
+++ b/libmachine/host/host_test.go
@@ -3,7 +3,10 @@ package host
 import (
 	"testing"
 
+	"github.com/docker/machine/drivers/fakedriver"
 	_ "github.com/docker/machine/drivers/none"
+	"github.com/docker/machine/libmachine/provision"
+	"github.com/docker/machine/libmachine/state"
 )
 
 func TestValidateHostnameValid(t *testing.T) {
@@ -33,5 +36,49 @@ func TestValidateHostnameInvalid(t *testing.T) {
 		if isValid {
 			t.Fatalf("Thought an invalid hostname was valid: %s", v)
 		}
+	}
+}
+
+type NetstatProvisioner struct {
+	*provision.FakeProvisioner
+}
+
+func (p *NetstatProvisioner) SSHCommand(args string) (string, error) {
+	return `Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+tcp        0      0 0.0.0.0:ssh             0.0.0.0:*               LISTEN
+tcp        0     72 192.168.25.141:ssh      192.168.25.1:63235      ESTABLISHED
+tcp        0      0 :::2376                 :::*                    LISTEN
+tcp        0      0 :::ssh                  :::*                    LISTEN
+Active UNIX domain sockets (servers and established)
+Proto RefCnt Flags       Type       State         I-Node Path
+unix  2      [ ACC ]     STREAM     LISTENING      17990 /var/run/acpid.socket
+unix  2      [ ACC ]     SEQPACKET  LISTENING      14233 /run/udev/control
+unix  2      [ ACC ]     STREAM     LISTENING      19365 /var/run/docker.sock
+unix  3      [ ]         STREAM     CONNECTED      19774
+unix  3      [ ]         STREAM     CONNECTED      19775
+unix  3      [ ]         DGRAM                     14243
+unix  3      [ ]         DGRAM                     14242`, nil
+}
+
+func NewNetstatProvisioner() provision.Provisioner {
+	return &NetstatProvisioner{
+		&provision.FakeProvisioner{},
+	}
+}
+
+func TestStart(t *testing.T) {
+	provision.SetDetector(&provision.FakeDetector{
+		NewNetstatProvisioner(),
+	})
+
+	host := &Host{
+		Driver: &fakedriver.Driver{
+			MockState: state.Stopped,
+		},
+	}
+
+	if err := host.Start(); err != nil {
+		t.Fatalf("Expected no error but got one: %s", err)
 	}
 }

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/machine/libmachine/auth"
 	"github.com/docker/machine/libmachine/cert"
+	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/provision/serviceaction"
@@ -161,7 +162,7 @@ func ConfigureAuth(p Provisioner) error {
 	if err != nil {
 		return err
 	}
-	dockerPort := 2376
+	dockerPort := engine.DefaultPort
 	parts := strings.Split(u.Host, ":")
 	if len(parts) == 2 {
 		dPort, err := strconv.Atoi(parts[1])
@@ -186,7 +187,7 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	return waitForDocker(p, dockerPort)
+	return WaitForDocker(p, dockerPort)
 }
 
 func matchNetstatOut(reDaemonListening, netstatOut string) bool {
@@ -262,7 +263,7 @@ func checkDaemonUp(p Provisioner, dockerPort int) func() bool {
 	}
 }
 
-func waitForDocker(p Provisioner, dockerPort int) error {
+func WaitForDocker(p Provisioner, dockerPort int) error {
 	if err := mcnutils.WaitForSpecific(checkDaemonUp(p, dockerPort), 10, 3*time.Second); err != nil {
 		return NewErrDaemonAvailable(err)
 	}

--- a/libmachine/provision/utils_test.go
+++ b/libmachine/provision/utils_test.go
@@ -102,7 +102,7 @@ func TestMachinePortBoot2Docker(t *testing.T) {
 	p := &Boot2DockerProvisioner{
 		Driver: &fakedriver.Driver{},
 	}
-	dockerPort := 2376
+	dockerPort := engine.DefaultPort
 	bindURL := fmt.Sprintf("tcp://0.0.0.0:%d", dockerPort)
 	p.AuthOptions = auth.Options{
 		CaCertRemotePath:     "/test/ca-cert",


### PR DESCRIPTION
cc @docker/machine-maintainers 

Closes https://github.com/docker/machine/issues/2175

(some of the instances of the problem, at least)

You should be able to duplicate this bug by doing something like this with the most recent Machine RC:

```console
$ docker-machine stop
$ docker-machine start; docker-machine env
Error checking TLS connection: Error checking and/or regenerating the certs: There was an error validating certificates for host "192.168.99.100:2376": dial tcp 192.168.99.100:2376: getsockopt: connection refused
You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
Be advised that this will trigger a Docker daemon restart which will stop running containers.
```

This patch fixes the issue by waiting for the Docker daemon as part of the `Host` `Start`.




Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>