### PR TITLE
Bump to version 0.6.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 0.6.0-rc2 (2016-01-28)
+
+- Fix issue creating Swarms
+- Fix `ls` header issue
+- Add code to wait for Docker daemon before returning from `start` / `restart`
+- Start porting integration tests to Go from BATS
+- Add Appveyor for Windows tests
+- Update CoreOS provisioner to use `docker daemon`
+- Various documentation and error message fixes
+- Add ability to create GCE machine using existing VM
+
 # 0.6.0-rc1 (2016-01-18)
 
 General

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 var (
 	// Version should be updated by hand at each release
-	Version = "0.6.0-rc2-dev"
+	Version = "0.6.0-dev"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"


### PR DESCRIPTION
Bump to `0.6.0-dev`.  I'm thinking that since if all goes according to plan the 0.6.0 release will be next week, it's likely RC2 is the last RC.

cc @docker/machine-maintainers FYI

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>