### PR TITLE
Update release script for GNU sed compatibility

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -116,8 +116,13 @@ checkError "Can't clone into ${RELEASE_DIR}, aborting"
 cd "${RELEASE_DIR}"
 
 display "Bump version number to ${VERSION}"
-sed -i "" "s/Version = \".*-dev\"/Version = \"${VERSION}\"/g" version/version.go
+
+# Why 'sed' and then 'mv' instead of 'sed -i'?  BSD / GNU sed compatibility.
+# Macs have BSD sed by default, Linux has GNU sed.  See
+# http://unix.stackexchange.com/questions/92895/how-to-achieve-portability-with-sed-i-in-place-editing
+sed -e "s/Version = \".*-dev\"/Version = \"${VERSION}\"/g" version/version.go >version/version.go.new
 checkError "Unable to change version in version/version.go"
+mv -- version/version.go.new version/version.go
 
 git add version/version.go
 git commit -q -m"Bump version to ${VERSION}" -s


### PR DESCRIPTION
I changed my default OSX `sed` to GNU `sed`, so this line blows up on me.

This change should work with both BSD `sed` and GNU `sed`.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>