### PR TITLE
Exit with code 3 if error is during pre-create check

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -164,13 +164,15 @@ func runCommand(command func(commandLine CommandLine, api libmachine.API) error)
 			if crashErr, ok := err.(crashreport.CrashError); ok {
 				crashReporter := crashreport.NewCrashReporter(mcndirs.GetBaseDir(), context.GlobalString("bugsnag-api-token"))
 				crashReporter.Send(crashErr)
+
+				if _, ok := crashErr.Cause.(mcnerror.ErrDuringPreCreate); ok {
+					osExit(3)
+					return
+				}
 			}
 
-			if _, ok := err.(mcnerror.ErrDuringPreCreate); ok {
-				osExit(3)
-			} else {
-				osExit(1)
-			}
+			osExit(1)
+			return
 		}
 	}
 }


### PR DESCRIPTION
cc @docker/machine-maintainers 

Would be good to get a test for this, but also could be pretty drawn out (need to have a plugin with a reliable precreate fail, and write an integration test for it).

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>