### PR TITLE
drivers/exoscale: fix configuration of exoscale endpoint

### DIFF
--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -118,7 +118,7 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	d.URL = flags.String("exoscale-endpoint")
+	d.URL = flags.String("exoscale-url")
 	d.APIKey = flags.String("exoscale-api-key")
 	d.APISecretKey = flags.String("exoscale-api-secret-key")
 	d.InstanceProfile = flags.String("exoscale-instance-profile")


### PR DESCRIPTION
The environment variable was `EXOSCALE_ENDPOINT` but the flag was
`--exoscale-url`. When configuring from flags, the wrong name was
used. Therefore, a user was unable to use an alternate endpoint.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>