### PR TITLE
Add option --longmode on to support Windows 32bit hosts

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -342,7 +342,8 @@ func (d *Driver) CreateVM() error {
 		dnsProxy = "on"
 	}
 
-	if err := d.vbm("modifyvm", d.MachineName,
+	var modifyFlags = []string{
+		"modifyvm", d.MachineName,
 		"--firmware", "bios",
 		"--bioslogofadein", "off",
 		"--bioslogofadeout", "off",
@@ -364,7 +365,13 @@ func (d *Driver) CreateVM() error {
 		"--largepages", "on",
 		"--vtxvpid", "on",
 		"--accelerate3d", "off",
-		"--boot1", "dvd"); err != nil {
+		"--boot1", "dvd"}
+
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		modifyFlags = append(modifyFlags, "--longmode", "on")
+	}
+
+	if err := d.vbm(modifyFlags...); err != nil {
 		return err
 	}
 

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -3,6 +3,7 @@ package virtualbox
 import (
 	"errors"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -320,13 +321,18 @@ func mockCalls(t *testing.T, driver *Driver, expectedCalls []Call) {
 func TestCreateVM(t *testing.T) {
 	shareName, shareDir := getShareDriveAndName()
 
+	modifyVMcommand := "vbm modifyvm default --firmware bios --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled --ostype Linux26_64 --cpus 1 --memory 1024 --acpi on --ioapic on --rtcuseutc on --natdnshostresolver1 off --natdnsproxy1 on --cpuhotplug off --pae on --hpet on --hwvirtex on --nestedpaging on --largepages on --vtxvpid on --accelerate3d off --boot1 dvd"
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		modifyVMcommand += " --longmode on"
+	}
+
 	driver := NewDriver("default", "path")
 	mockCalls(t, driver, []Call{
 		{"CopyIsoToMachineDir path default http://b2d.org", "", nil},
 		{"Generate path/machines/default/id_rsa", "", nil},
 		{"Create 20000 path/machines/default/id_rsa.pub path/machines/default/disk.vmdk", "", nil},
 		{"vbm createvm --basefolder path/machines/default --name default --register", "", nil},
-		{"vbm modifyvm default --firmware bios --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled --ostype Linux26_64 --cpus 1 --memory 1024 --acpi on --ioapic on --rtcuseutc on --natdnshostresolver1 off --natdnsproxy1 on --cpuhotplug off --pae on --hpet on --hwvirtex on --nestedpaging on --largepages on --vtxvpid on --accelerate3d off --boot1 dvd", "", nil},
+		{modifyVMcommand, "", nil},
 		{"vbm modifyvm default --nic1 nat --nictype1 82540EM --cableconnected1 on", "", nil},
 		{"vbm storagectl default --name SATA --add sata --hostiocache on", "", nil},
 		{"vbm storageattach default --storagectl SATA --port 0 --device 0 --type dvddrive --medium path/machines/default/boot2docker.iso", "", nil},


### PR DESCRIPTION
After some investigations in issue [boot2docker/windows-installer#65 Allow installation on 32bit Machines!](https://github.com/boot2docker/windows-installer/issues/65) I just added the option `--longmode on` to make docker-machine working on my 32bit Windows 10 PC to start up the official 64bit `boot2docker.iso`.

![docker-machine-386-running-amd64-virtualbox](https://cloud.githubusercontent.com/assets/207759/12887427/7ad3be32-ce74-11e5-855a-07227eed095e.png)

I haven't tested implications with 64bit hosts or other VirtualBox host platforms. But in doubt we could just add the `--longmode on` flag if the docker-machine binary is `windows/386`.
