### PR TITLE
Improve --virtualbox-no-vtx-check option to allow starting the VM

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -507,14 +507,16 @@ func (d *Driver) Start() error {
 		log.Infof("VM not in restartable state")
 	}
 
-	// Verify that VT-X is not disabled in the started VM
-	vtxIsDisabled, err := d.IsVTXDisabledInTheVM()
-	if err != nil {
-		return fmt.Errorf("Checking if hardware virtualization is enabled failed: %s", err)
-	}
+	if !d.NoVTXCheck {
+		// Verify that VT-X is not disabled in the started VM
+		vtxIsDisabled, err := d.IsVTXDisabledInTheVM()
+		if err != nil {
+			return fmt.Errorf("Checking if hardware virtualization is enabled failed: %s", err)
+		}
 
-	if vtxIsDisabled {
-		return ErrMustEnableVTX
+		if vtxIsDisabled {
+			return ErrMustEnableVTX
+		}
 	}
 
 	log.Infof("Waiting for an IP...")


### PR DESCRIPTION
The VirtualBox driver option `--virtualbox-no-vtx-check` can be used to turn off the VT-X checks. The flag is used only once, but there is a second place in the code to allow to start VM without this check.

With this PR the VM can be started without any VT-X checks.
