### PR TITLE
Add retry support to AWS driver

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -71,6 +71,8 @@ You can use environment variables:
 -   `--amazonec2-monitoring`: Enable CloudWatch Monitoring.
 -   `--amazonec2-use-ebs-optimized-instance`: Create an EBS Optimized Instance, instance type must support it.
 -   `--amazonec2-ssh-keypath`: Path to Private Key file to use for instance. Matching public key with .pub extension should exist
+-   `--amazonec2-retries`:  Set retry count for recoverable failures (use -1 to disable)
+
 
 Environment variables and default values:
 
@@ -99,6 +101,7 @@ Environment variables and default values:
 | `--amazonec2-monitoring`                 | -                       | `false`          |
 | `--amazonec2-use-ebs-optimized-instance` | -                       | `false`          |
 | `--amazonec2-ssh-keypath`                | `AWS_SSH_KEYPATH`       | -                |
+| `--amazonec2-retries`                    | -                       | `5`              |
 
 ## Default AMIs
 


### PR DESCRIPTION
Some AWS API failures are retryable, so we should give the option to attempt
retries in these cases.  One particular example is the API rate limiting that
kicks in if you try to create many machines in parallel.  Without this change,
I can only create ~3 machines in parallel, but with this change I can easily
create 10 or more machines in parallel.

While this change helps `ls`, given the current fan-out model for plugins, once
you get a large number of AWS machines, you'll still wind up seeing
"RequestLimitExceeded: Request limit exceeded." errors.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>