### PR TITLE
Use golang 1.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
 
 The requirements to build Machine are:
 
-1.  A running instance of Docker or a Golang 1.5.3 development environment
+1.  A running instance of Docker or a Golang 1.6 development environment
 2.  The `bash` shell
 3.  [Make](https://www.gnu.org/software/make/)
 
@@ -32,8 +32,8 @@ To build the `docker-machine` binary using containers, simply run:
 
 ## Local Go development environment
 
-Make sure the source code directory is under a correct directory structure to use Go 1.5 vendoring;
-example of cloning and preparing the correct environment `GOPATH`:
+Make sure the source code directory is under a correct directory structure;
+Example of cloning and preparing the correct environment `GOPATH`:
 
         mkdir docker-machine
         cd docker-machine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:1.5.3
+FROM golang:1.6
 
 RUN go get  github.com/golang/lint/golint \
             github.com/mattn/goveralls \
-            golang.org/x/tools/cover \
-            github.com/tools/godep \
-            github.com/aktau/github-release
+            golang.org/x/tools/cover
 
 ENV USER root
 WORKDIR /go/src/github.com/docker/machine
 
-COPY . /go/src/github.com/docker/machine
+COPY . ./
 RUN mkdir bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,16 +6,15 @@ os: Windows Server 2012 R2
 
 environment:
   GOPATH: c:\gopath
-  GO15VENDOREXPERIMENT: 1
-  GOARCH: amd64
-  GOVERSION: 1.5.3
+  GOVERSION: 1.6
 
 clone_folder: c:\gopath\src\github.com\docker\machine
 
 install:
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+  - ps: rmdir C:\go -Force -Recurse -Confirm:$false
+  - 7z x go%GOVERSION%.windows-amd64.zip -o"C:\" -y > nul
   - set Path=c:\go\bin;%Path%
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-%GOARCH%.msi
-  - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
 
 build_script:
   - go build -i -o ./bin/docker-machine.exe ./cmd/machine.go

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/1.0.22/binscripts/gvm-installer)
 
   post:
-    - gvm install go1.5.3 -B --name=stable
+    - gvm install go1.6 -B --name=stable
 
   environment:
     CHECKOUT: /home/ubuntu/$CIRCLE_PROJECT_REPONAME

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -5,9 +5,6 @@ GO_GCFLAGS :=
 # Full package list
 PKGS := $(shell go list -tags "$(BUILDTAGS)" ./... | grep -v "/vendor/" | grep -v "/cmd")
 
-# Support go1.5 vendoring (let us avoid messing with GOPATH or using godep)
-export GO15VENDOREXPERIMENT = 1
-
 # Resolving binary dependencies for specific targets
 GOLINT_BIN := $(GOPATH)/bin/golint
 GOLINT := $(shell [ -x $(GOLINT_BIN) ] && echo $(GOLINT_BIN) || echo '')


### PR DESCRIPTION
- Use golang 1.6rc2
- Get rid of all the vendor experiment things
- Take the opportunity to clean up the dockerfile and Makefile a little

Signed-off-by: David Gageot <david@gageot.net>