### PR TITLE
Docs typo, generic driver uses _public_ key

### DIFF
--- a/docs/drivers/generic.md
+++ b/docs/drivers/generic.md
@@ -28,7 +28,7 @@ The driver will perform a list of tasks on create:
 Options:
 
 -   `--generic-ip-address`: **required** IP Address of host.
--   `--generic-ssh-key`: Path to the SSH user private key.
+-   `--generic-ssh-key`: Path to the SSH user public key.
 -   `--generic-ssh-user`: SSH username used to connect.
 -   `--generic-ssh-port`: Port to use for SSH.
 

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -41,7 +41,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   "generic-ssh-key",
-			Usage:  "SSH private key path (if not provided, identities in ssh-agent will be used)",
+			Usage:  "SSH public key path (if not provided, identities in ssh-agent will be used)",
 			Value:  "",
 			EnvVar: "GENERIC_SSH_KEY",
 		},


### PR DESCRIPTION
This is a docs update, they should say `public` not private.
The public key works, the private key does not.

This PR updates the documentation for the `--generic-ssh-key` flag to ask for the `public` key instead of the private key.

## How to reproduce ... the confusion:
Given a server where your `~/.ssh/id_rsa.pub` key is an `authorized_key`.
When you use create a new docker-machine with the generic driver with the following command.
```
docker-machine create --driver=generic --generic-ip-address=example.com --generic-ssh-key=/Users/robert/.ssh/id_rsa failing-machine
```
(note: the above command is using the private key `id_rsa`, not `id_rsa.pub` as directed by the documentation)
Then the command will hang and eventually fail with the following output.
```
Running pre-create checks...
Creating machine...
(failing-machine) Importing SSH key...
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Error creating machine: Error detecting OS: Too many retries waiting for SSH to be available.  Last error: Maximum number of retries (60) exceeded
```

However if you simply use the public key in the `id_rsa.pub` file instead the driver functions correctly.