### PR TITLE
Fix: missing AMI for ap-northeast-2

### DIFF
--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -12,6 +12,7 @@ type region struct {
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
 	"ap-northeast-1": {"ami-b36d4edd"},
+	"ap-northeast-2": {"ami-09dc1267"},
 	"ap-southeast-1": {"ami-1069af73"},
 	"ap-southeast-2": {"ami-1d336a7e"},
 	"cn-north-1":     {"ami-79eb2214"},


### PR DESCRIPTION
The AMI id has been taken from Amazon launch wizard when choosing AMI.

Ubuntu Server 14.04 LTS (HVM), EBS General Purpose (SSD) Volume Type. Support available from Canonical (http://www.ubuntu.com/cloud/services ).