### PR TITLE
Specify correct name for virtio net nic device

### DIFF
--- a/docs/drivers/virtualbox.md
+++ b/docs/drivers/virtualbox.md
@@ -36,7 +36,7 @@ Options:
 -   `--virtualbox-boot2docker-url`: The URL of the boot2docker image. Defaults to the latest available version.
 -   `--virtualbox-import-boot2docker-vm`: The name of a Boot2Docker VM to import.
 -   `--virtualbox-hostonly-cidr`: The CIDR of the host only adapter.
--   `--virtualbox-hostonly-nictype`: Host Only Network Adapter Type. Possible values are are '82540EM' (Intel PRO/1000), 'Am79C973' (PCnet-FAST III) and 'virtio-net' Paravirtualized network adapter.
+-   `--virtualbox-hostonly-nictype`: Host Only Network Adapter Type. Possible values are are '82540EM' (Intel PRO/1000), 'Am79C973' (PCnet-FAST III) and 'virtio' Paravirtualized network adapter.
 -   `--virtualbox-hostonly-nicpromisc`: Host Only Network Adapter Promiscuous Mode. Possible options are deny , allow-vms, allow-all
 -   `--virtualbox-no-share`: Disable the mount of your home directory
 -   `--virtualbox-dns-proxy`: Proxy all DNS requests to the host (Boolean value, default to false)


### PR DESCRIPTION
With VirtualBox 5.0.14r105127, 'virtio-net' is not a valid name for the option. The correct option appears to be 'virtio'.