### PR TITLE
FIX #3056 ls timeout when instance is stopped

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -603,6 +603,10 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
@@ -610,6 +614,7 @@ func (d *Driver) GetURL() (string, error) {
 	if ip == "" {
 		return "", nil
 	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, strconv.Itoa(dockerPort))), nil
 }
 

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -238,6 +238,10 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	url := fmt.Sprintf("tcp://%s:%v", d.getHostname(), d.DockerPort)
 	return url, nil
 }

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -255,10 +255,15 @@ func (d *Driver) createSSHKey() (*godo.Key, error) {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
 	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
 }
 

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -143,10 +143,15 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
 	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
 }
 

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -133,10 +133,15 @@ func (d *Driver) Create() error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
 	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
 }
 

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -276,6 +276,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
@@ -283,6 +287,7 @@ func (d *Driver) GetURL() (string, error) {
 	if ip == "" {
 		return "", nil
 	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(ip, "2376")), nil
 }
 

--- a/drivers/softlayer/driver.go
+++ b/drivers/softlayer/driver.go
@@ -257,6 +257,10 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	ip, err := d.GetIP()
 	if err != nil {
 		return "", err
@@ -264,6 +268,7 @@ func (d *Driver) GetURL() (string, error) {
 	if ip == "" {
 		return "", nil
 	}
+
 	return "tcp://" + net.JoinHostPort(ip, "2376"), nil
 }
 

--- a/drivers/vmwarevcloudair/vcloudair.go
+++ b/drivers/vmwarevcloudair/vcloudair.go
@@ -196,6 +196,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 }
 
 func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
 	return fmt.Sprintf("tcp://%s", net.JoinHostPort(d.PublicIP, strconv.Itoa(d.DockerPort))), nil
 }
 

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -93,3 +93,17 @@ func MachineInState(d Driver, desiredState state.State) func() bool {
 		return false
 	}
 }
+
+// MustBeRunning will return an error if the machine is not in a running state.
+func MustBeRunning(d Driver) error {
+	s, err := d.GetState()
+	if err != nil {
+		return err
+	}
+
+	if s != state.Running {
+		return ErrHostIsNotRunning
+	}
+
+	return nil
+}


### PR DESCRIPTION
Carry https://github.com/docker/machine/pull/3067 due to Coveralls failure

Closes https://github.com/docker/machine/pull/3067

Signed-off-by: David Gageot <david@gageot.net>