### PR TITLE
docs: remove reference to lxc-docker

### DIFF
--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -14,14 +14,15 @@ Upgrade a machine to the latest version of Docker. How this upgrade happens
 depends on the underlying distribution used on the created instance.
 
 For example, if the machine uses Ubuntu as the underlying operating system, it
-will run a command similar to `sudo apt-get upgrade lxc-docker`, because Machine
-expects Ubuntu machines it manages to use this package. As another example, if
-the machine uses boot2docker for its OS, this command will download the latest
-boot2docker ISO and replace the machine's existing ISO with the latest.
+will run a command similar to `sudo apt-get upgrade docker-engine`, because
+Machine expects Ubuntu machines it manages to use this package. As another
+example, if the machine uses boot2docker for its OS, this command will download
+the latest boot2docker ISO and replace the machine's existing ISO with the
+latest.
 
-    $ docker-machine upgrade dev
+    $ docker-machine upgrade default
     Stopping machine to do the upgrade...
-    Upgrading machine dev...
+    Upgrading machine default...
     Downloading latest boot2docker release to /home/username/.docker/machine/cache/boot2docker.iso...
     Starting machine back up...
     Waiting for VM to start...


### PR DESCRIPTION
The package on apt.dockerproject.org is now called 'docker-engine'.

Also replaced 'dev' with 'default', because that's the default name for machines.
