### PR TITLE
Fix #3015

### DIFF
--- a/commands/active_test.go
+++ b/commands/active_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"testing"
 
+	"github.com/docker/machine/libmachine/state"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,16 +13,19 @@ func TestCmdActiveNone(t *testing.T) {
 			Name:        "host1",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 		{
 			Name:        "host2",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 		{
 			Name:        "host3",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 	}
 	_, err := activeHost(hostListItems)
@@ -34,16 +38,19 @@ func TestCmdActiveHost(t *testing.T) {
 			Name:        "host1",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Timeout,
 		},
 		{
 			Name:        "host2",
 			ActiveHost:  true,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 		{
 			Name:        "host3",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 	}
 	active, err := activeHost(hostListItems)
@@ -57,19 +64,47 @@ func TestCmdActiveSwarm(t *testing.T) {
 			Name:        "host1",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 		{
 			Name:        "host2",
 			ActiveHost:  false,
 			ActiveSwarm: false,
+			State:       state.Running,
 		},
 		{
 			Name:        "host3",
 			ActiveHost:  false,
 			ActiveSwarm: true,
+			State:       state.Running,
 		},
 	}
 	active, err := activeHost(hostListItems)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, active.Name, "host3")
+}
+
+func TestCmdActiveTimeout(t *testing.T) {
+	hostListItems := []HostListItem{
+		{
+			Name:        "host1",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+			State:       state.Running,
+		},
+		{
+			Name:        "host2",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+			State:       state.Running,
+		},
+		{
+			Name:        "host3",
+			ActiveHost:  false,
+			ActiveSwarm: false,
+			State:       state.Timeout,
+		},
+	}
+	_, err := activeHost(hostListItems)
+	assert.Equal(t, err, errActiveTimeout)
 }


### PR DESCRIPTION
After this fix, the logic for determining the outcome of `docker-machine active` will be:
1. If any active docker host or swarm is found, return it as active
2. If no active host is found, and any host is in state `state.Timeout`, then the error is `errActiveTimeout`: "Error getting active host: timeout"
3. If no active host is found, and no host is in state `state.Timeout`, then the error is `errNoActiveHost`: "No active host found"

I have implemented step 2, and I have added one unit test and modified old unit tests to check 1-3 above.

Signed-off-by: Patrik Erdes <patrik@erdes.se>