### PR TITLE
FIX #1858 Add engine port

### DIFF
--- a/docs/drivers/generic.md
+++ b/docs/drivers/generic.md
@@ -62,6 +62,7 @@ as a sudoer with `NOPASSWD`. See https://help.ubuntu.com/community/Sudoers.
 
 ### Options
 
+-   `--generic-engine-port`: Port to use for Docker Daemon (Note: This flag will not work with boot2docker).
 -   `--generic-ip-address`: **required** IP Address of host.
 -   `--generic-ssh-key`: Path to the SSH user private key.
 -   `--generic-ssh-user`: SSH username used to connect.
@@ -73,6 +74,7 @@ Environment variables and default values:
 
 | CLI option                 | Environment variable | Default                   |
 | -------------------------- | -------------------- | ------------------------- |
+| `--generic-engine-port`    | `GENERIC_ENGINE_PORT`| `2376`                    |
 | **`--generic-ip-address`** | `GENERIC_IP_ADDRESS` | -                         |
 | `--generic-ssh-key`        | `GENERIC_SSH_KEY`    | _(defers to `ssh-agent`)_ |
 | `--generic-ssh-user`       | `GENERIC_SSH_USER`   | `root`                    |

--- a/drivers/generic/generic_test.go
+++ b/drivers/generic/generic_test.go
@@ -12,8 +12,9 @@ func TestSetConfigFromFlags(t *testing.T) {
 
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
-			"generic-ip-address": "localhost",
-			"generic-ssh-key":    "path",
+			"generic-engine-port": "3000",
+			"generic-ip-address":  "localhost",
+			"generic-ssh-key":     "path",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}


### PR DESCRIPTION
Added flag `--generic-engine-port` to `generic` driver in order to specify other port than `2376` on
Docker engine.

Signed-off-by: Tiago Pires <tandrepires@gmail.com>