### PR TITLE
Add flag --virtualbox-nictype to set NIC type of eth0

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -53,6 +53,7 @@ type Driver struct {
 	CPU                 int
 	Memory              int
 	DiskSize            int
+	NatNicType          string
 	Boot2DockerURL      string
 	Boot2DockerImportVM string
 	HostDNSResolver     bool
@@ -78,6 +79,7 @@ func NewDriver(hostName, storePath string) *Driver {
 		Memory:              defaultMemory,
 		CPU:                 defaultCPU,
 		DiskSize:            defaultDiskSize,
+		NatNicType:          defaultHostOnlyNictype,
 		HostOnlyCIDR:        defaultHostOnlyCIDR,
 		HostOnlyNicType:     defaultHostOnlyNictype,
 		HostOnlyPromiscMode: defaultHostOnlyPromiscMode,
@@ -128,6 +130,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "virtualbox-host-dns-resolver",
 			Usage:  "Use the host DNS resolver",
 			EnvVar: "VIRTUALBOX_HOST_DNS_RESOLVER",
+		},
+		mcnflag.StringFlag{
+			Name:   "virtualbox-nat-nictype",
+			Usage:  "Specify the Network Adapter Type",
+			Value:  defaultHostOnlyNictype,
+			EnvVar: "VIRTUALBOX_NAT_NICTYPE",
 		},
 		mcnflag.StringFlag{
 			Name:   "virtualbox-hostonly-cidr",
@@ -205,6 +213,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = "docker"
 	d.Boot2DockerImportVM = flags.String("virtualbox-import-boot2docker-vm")
 	d.HostDNSResolver = flags.Bool("virtualbox-host-dns-resolver")
+	d.NatNicType = flags.String("virtualbox-nat-nictype")
 	d.HostOnlyCIDR = flags.String("virtualbox-hostonly-cidr")
 	d.HostOnlyNicType = flags.String("virtualbox-hostonly-nictype")
 	d.HostOnlyPromiscMode = flags.String("virtualbox-hostonly-nicpromisc")
@@ -377,7 +386,7 @@ func (d *Driver) CreateVM() error {
 
 	if err := d.vbm("modifyvm", d.MachineName,
 		"--nic1", "nat",
-		"--nictype1", "82540EM",
+		"--nictype1", d.NatNicType,
 		"--cableconnected1", "on"); err != nil {
 		return err
 	}

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -391,6 +391,37 @@ func TestCreateVM(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCreateVMWithSpecificNatNicType(t *testing.T) {
+	shareName, shareDir := getShareDriveAndName()
+
+	modifyVMcommand := "vbm modifyvm default --firmware bios --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled --ostype Linux26_64 --cpus 1 --memory 1024 --acpi on --ioapic on --rtcuseutc on --natdnshostresolver1 off --natdnsproxy1 on --cpuhotplug off --pae on --hpet on --hwvirtex on --nestedpaging on --largepages on --vtxvpid on --accelerate3d off --boot1 dvd"
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		modifyVMcommand += " --longmode on"
+	}
+
+	driver := NewDriver("default", "path")
+	driver.NatNicType = "Am79C973"
+	mockCalls(t, driver, []Call{
+		{"CopyIsoToMachineDir path default http://b2d.org", "", nil},
+		{"Generate path/machines/default/id_rsa", "", nil},
+		{"Create 20000 path/machines/default/id_rsa.pub path/machines/default/disk.vmdk", "", nil},
+		{"vbm createvm --basefolder path/machines/default --name default --register", "", nil},
+		{modifyVMcommand, "", nil},
+		{"vbm modifyvm default --nic1 nat --nictype1 Am79C973 --cableconnected1 on", "", nil},
+		{"vbm storagectl default --name SATA --add sata --hostiocache on", "", nil},
+		{"vbm storageattach default --storagectl SATA --port 0 --device 0 --type dvddrive --medium path/machines/default/boot2docker.iso", "", nil},
+		{"vbm storageattach default --storagectl SATA --port 1 --device 0 --type hdd --medium path/machines/default/disk.vmdk", "", nil},
+		{"vbm guestproperty set default /VirtualBox/GuestAdd/SharedFolders/MountPrefix /", "", nil},
+		{"vbm guestproperty set default /VirtualBox/GuestAdd/SharedFolders/MountDir /", "", nil},
+		{"vbm sharedfolder add default --name " + shareName + " --hostpath " + shareDir + " --automount", "", nil},
+		{"vbm setextradata default VBoxInternal2/SharedFoldersEnableSymlinksCreate/" + shareName + " 1", "", nil},
+	})
+
+	err := driver.CreateVM()
+
+	assert.NoError(t, err)
+}
+
 func TestStart(t *testing.T) {
 	driver := NewDriver("default", "path")
 	mockCalls(t, driver, []Call{


### PR DESCRIPTION
This may be totally crazy, but I had to try it out. 

Somebody found out the missing part running a 32bit VM in an AppVeyor server VM. See the [discussion at AppVeyor](http://help.appveyor.com/discussions/problems/1247-vagrant-not-working-inside-appveyor#comment_39277805). TL/DR: Use `--nictype1 "Am79C973"` for both network devices.

So I added another flag to docker-machine to do this and run a proof-of-concept build in the boot2docker fork with the already built 32bit docker binary and 32bit boot2docker.iso.

So here it is, a first AppVeyor build which downloads VirtualBox for Windows, the patched docker-machine.exe, the official docker.exe Client and then creates a 32bit Docker Machine VM:

* https://ci.appveyor.com/project/StefanScherer/boot2docker/build/44
* And the corresponding [appveyor.yml](https://github.com/StefanScherer/boot2docker/blob/x86/appveyor.yml)

But often I get errors with the plugin server:
```
(dev) DBG | Creating dynamic image with size 20971520000 bytes (20000MB)...
Error attempting heartbeat call to plugin server: read tcp 127.0.0.1:1062->127.0.0.1:1061: wsarecv: An existing connection was forcibly closed by the remote host.
Error creating machine: Error in driver during machine creation: read tcp 127.0.0.1:1062->127.0.0.1:1061: wsarecv: An existing connection was forcibly closed by the remote host.
Error attempting heartbeat call to plugin server: connection is shut down
open C:\Users\appveyor\.docker\machine\machines\dev\dev\Logs\VBox.log: The system cannot find the path specified.
notifying bugsnag: [Error creating machine: Error in driver during machine creation: read tcp 127.0.0.1:1062->127.0.0.1:1061: wsarecv: An existing connection was forcibly closed by the remote host.]
```

Maybe some timing problem or port conflict? It worked in build 44 with ports 1051/1055.
