### PR TITLE
Google driver: add `--google-use-internal-ip-only` flag

### DIFF
--- a/docs/drivers/gce.md
+++ b/docs/drivers/gce.md
@@ -50,7 +50,7 @@ To create a machine instance, specify `--driver google`, the project id and the 
     -   `--google-preemptible`: Instance preemptibility.
     -   `--google-tags`: Instance tags (comma-separated).
     -   `--google-use-internal-ip`: When this option is used during create it will make docker-machine use internal rather than public NATed IPs. The flag is persistent in the sense that a machine created with it retains the IP. It's useful for managing docker machines from another machine on the same network e.g. while deploying swarm.
-    -   `--google-use-internal-ip-only`: When this option is used during create, the new VM will not be assigned a public IP address. This is useful only when the host running `docker-machine` is located inside the Google Cloud infrastructure; otherwise, `docker-machine` can't reach the VM to provision the Docker daemon.
+    -   `--google-use-internal-ip-only`: When this option is used during create, the new VM will not be assigned a public IP address. This is useful only when the host running `docker-machine` is located inside the Google Cloud infrastructure; otherwise, `docker-machine` can't reach the VM to provision the Docker daemon. The presence of this flag implies `--google-use-internal-ip`.
     -   `--google-use-existing`: Don't create a new VM, use an existing one. This is useful when you'd like to provision Docker on a VM you created yourself, maybe because it uses create options not supported by this driver. 
 
 The GCE driver will use the `ubuntu-1510-wily-v20151114` instance image unless otherwise specified. To obtain a

--- a/docs/drivers/gce.md
+++ b/docs/drivers/gce.md
@@ -50,6 +50,7 @@ To create a machine instance, specify `--driver google`, the project id and the 
     -   `--google-preemptible`: Instance preemptibility.
     -   `--google-tags`: Instance tags (comma-separated).
     -   `--google-use-internal-ip`: When this option is used during create it will make docker-machine use internal rather than public NATed IPs. The flag is persistent in the sense that a machine created with it retains the IP. It's useful for managing docker machines from another machine on the same network e.g. while deploying swarm.
+    -   `--google-use-internal-ip-only`: When this option is used during create, the new VM will not be assigned a public IP address. This is useful only when the host running `docker-machine` is located inside the Google Cloud infrastructure; otherwise, `docker-machine` can't reach the VM to provision the Docker daemon.
     -   `--google-use-existing`: Don't create a new VM, use an existing one. This is useful when you'd like to provision Docker on a VM you created yourself, maybe because it uses create options not supported by this driver. 
 
 The GCE driver will use the `ubuntu-1510-wily-v20151114` instance image unless otherwise specified. To obtain a

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -15,18 +15,19 @@ import (
 // Driver is a struct compatible with the docker.hosts.drivers.Driver interface.
 type Driver struct {
 	*drivers.BaseDriver
-	Zone          string
-	MachineType   string
-	MachineImage  string
-	DiskType      string
-	Address       string
-	Preemptible   bool
-	UseInternalIP bool
-	Scopes        string
-	DiskSize      int
-	Project       string
-	Tags          string
-	UseExisting   bool
+	Zone              string
+	MachineType       string
+	MachineImage      string
+	DiskType          string
+	Address           string
+	Preemptible       bool
+	UseInternalIP     bool
+	UseInternalIPOnly bool
+	Scopes            string
+	DiskSize          int
+	Project           string
+	Tags              string
+	UseExisting       bool
 }
 
 const (
@@ -112,6 +113,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "GOOGLE_USE_INTERNAL_IP",
 		},
 		mcnflag.BoolFlag{
+			Name:   "google-use-internal-ip-only",
+			Usage:  "Configure GCE instance to not have an external IP address",
+			EnvVar: "GOOGLE_USE_INTERNAL_IP_ONLY",
+		},
+		mcnflag.BoolFlag{
 			Name:   "google-use-existing",
 			Usage:  "Don't create a new VM, use an existing one",
 			EnvVar: "GOOGLE_USE_EXISTING",
@@ -170,7 +176,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.DiskType = flags.String("google-disk-type")
 		d.Address = flags.String("google-address")
 		d.Preemptible = flags.Bool("google-preemptible")
-		d.UseInternalIP = flags.Bool("google-use-internal-ip")
+		d.UseInternalIP = flags.Bool("google-use-internal-ip") || flags.Bool("google-use-internal-ip-only")
+		d.UseInternalIPOnly = flags.Bool("google-use-internal-ip-only")
 		d.Scopes = flags.String("google-scopes")
 		d.Tags = flags.String("google-tags")
 	}


### PR DESCRIPTION
This addresses previously-closed issue #2876, which points out that instances created with the `--google-use-internal-ip` command-line flag are still assigned an external IP address. The new flag (which implies the presence of `--google-use-internal-ip` if it isn't specified) will cause the new instance to have no externally-accessible IP address.