### PR TITLE
fix: --engine-env was not effective when provisioning on CoreOS

### DIFF
--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -76,6 +76,7 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 ExecStart=/usr/lib/coreos/dockerd daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }} \$DOCKER_OPTS \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPT_IPMASQ
+Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The `--engine-env` command-line arguments used to set environment variables in the Docker engine are not effective when provisioning hosts on CoreOS. The provisioning code generates a systemd script that invokes the daemon; it appears that the line needed to insert the environment variables was omitted by accident. This change (copied from the Red Hat provisioner) inserts the environment variables properly.