### PR TITLE
[DigitalOcean] Allow to use an existing SSH key (closes #1445)

### DIFF
--- a/docs/drivers/digital-ocean.md
+++ b/docs/drivers/digital-ocean.md
@@ -29,6 +29,7 @@ Options:
 -   `--digitalocean-userdata`: Path to file containing User Data for the droplet.
 -   `--digitalocean-ssh-user`: SSH username.
 -   `--digitalocean-ssh-port`: SSH port.
+-   `--digitalocean-ssh-key-fingerprint`: Use an existing SSH key instead of creating a new one, see [SSH keys](https://developers.digitalocean.com/documentation/v2/#ssh-keys).
 
 The DigitalOcean driver will use `ubuntu-15-10-x64` as the default image.
 
@@ -46,3 +47,4 @@ Environment variables and default values:
 | `--digitalocean-userdata`           | `DIGITALOCEAN_USERDATA`           | -                  |
 | `--digitalocean-ssh-user`           | `DIGITALOCEAN_SSH_USER`           | `root`             |
 | `--digitalocean-ssh-port`           | `DIGITALOCEAN_SSH_PORT`           | 22                 |
+| `--digitalocean-ssh-key-fingerprint`| `DIGITALOCEAN_SSH_KEY_FINGERPRINT`| -                  |


### PR DESCRIPTION
I also suggest to use the key fingerprint for this feature, it is more meaningful than digital ocean's internal id. It can then be used to avoid deleting the key when removing the machine, as it's most likely undesirable.