### PR TITLE
[Issue-2989] Allow non administrators to create docker-machines

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -69,6 +69,36 @@ func hypervAvailable() error {
 }
 
 func isAdministrator() (bool, error) {
+	var hypervAdmin bool
+	var windowsAdmin bool
+	var windowsErr error
+
+	hypervAdmin = isHypervAdministrator()
+
+	if hypervAdmin == true {
+		return true, nil
+	}
+
+	windowsAdmin, windowsErr = isWindowsAdministrator()
+
+	if windowsErr != nil {
+		return false, windowsErr
+	}
+
+	return windowsAdmin, nil
+}
+
+func isHypervAdministrator() bool {
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Hyper-V Administrators")`)
+	if err != nil {
+		return false
+	}
+
+	resp := parseLines(stdout)
+	return resp[0] == "True"
+}
+
+func isWindowsAdministrator() (bool, error) {
 	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")`)
 	if err != nil {
 		return false, err

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -69,20 +69,16 @@ func hypervAvailable() error {
 }
 
 func isAdministrator() (bool, error) {
-	var hypervAdmin bool
-	var windowsAdmin bool
-	var windowsErr error
+	hypervAdmin := isHypervAdministrator()
 
-	hypervAdmin = isHypervAdministrator()
-
-	if hypervAdmin == true {
+	if hypervAdmin {
 		return true, nil
 	}
 
-	windowsAdmin, windowsErr = isWindowsAdministrator()
+	windowsAdmin, err := isWindowsAdministrator()
 
-	if windowsErr != nil {
-		return false, windowsErr
+	if err != nil {
+		return false, err
 	}
 
 	return windowsAdmin, nil
@@ -91,6 +87,7 @@ func isAdministrator() (bool, error) {
 func isHypervAdministrator() bool {
 	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Hyper-V Administrators")`)
 	if err != nil {
+		log.Debug(err)
 		return false
 	}
 


### PR DESCRIPTION
If the user has "hyper-v administrator" permissions but not Windows "Administrator" permissions they should still be able to create a docker machine.

Unfortunately resizing a VHD still requires windows administrator permissions so in the case the user only has Hyper-V Administrator permissions then create the disk with the correct size upfront.  (this is a much slower process but it is one that will allow non admins to create machines)