### PR TITLE
azure: Add --azure-static-public-ip flag

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -58,6 +58,7 @@ Optional:
 - `--azure-private-ip-address`: Specify a static private IP address for the machine.
 - `--azure-use-private-ip`: Use private IP address of the machine to connect.
 - `--azure-no-public-ip`: Do not create a public IP address for the machine.
+- `--azure-static-public-ip`: Assign a static public IP address to the machine.
 - `--azure-docker-port`: Port number for Docker engine [$AZURE_DOCKER_PORT]
 - `--azure-environment`: Azure environment (e.g. `AzurePublicCloud`, `AzureChinaCloud`).
 
@@ -86,6 +87,7 @@ Environment variables and default values:
 | `--azure-private-ip-address`    | -                             | -                  |
 | `--azure-use-private-ip`        | -                             | -                  |
 | `--azure-no-public-ip`          | -                             | -                  |
+| `--azure-static-public-ip`      | -                             | -                  |
 | `--azure-docker-port`           | `AZURE_DOCKER_PORT`           | `2376`             |
 
 ## Notes

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -46,6 +46,7 @@ const (
 	flAzurePorts           = "azure-open-port"
 	flAzurePrivateIPAddr   = "azure-private-ip-address"
 	flAzureUsePrivateIP    = "azure-use-private-ip"
+	flAzureStaticPublicIP  = "azure-static-public-ip"
 	flAzureNoPublicIP      = "azure-no-public-ip"
 )
 
@@ -71,10 +72,11 @@ type Driver struct {
 	SubnetPrefix    string
 	AvailabilitySet string
 
-	OpenPorts     []string
-	PrivateIPAddr string
-	UsePrivateIP  bool
-	NoPublicIP    bool
+	OpenPorts      []string
+	PrivateIPAddr  string
+	UsePrivateIP   bool
+	NoPublicIP     bool
+	StaticPublicIP bool
 
 	// Ephemeral fields
 	ctx        *azureutil.DeploymentContext
@@ -183,6 +185,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  flAzureNoPublicIP,
 			Usage: "Do not create a public IP address for the machine",
 		},
+		mcnflag.BoolFlag{
+			Name:  flAzureStaticPublicIP,
+			Usage: "Assign a static public IP address to the machine",
+		},
 		mcnflag.StringSliceFlag{
 			Name:  flAzurePorts,
 			Usage: "Make the specified port number accessible from the Internet",
@@ -225,6 +231,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.PrivateIPAddr = fl.String(flAzurePrivateIPAddr)
 	d.UsePrivateIP = fl.Bool(flAzureUsePrivateIP)
 	d.NoPublicIP = fl.Bool(flAzureNoPublicIP)
+	d.StaticPublicIP = fl.Bool(flAzureStaticPublicIP)
 	d.DockerPort = fl.Int(flAzureDockerPort)
 
 	// Set flags on the BaseDriver
@@ -307,7 +314,7 @@ func (d *Driver) Create() error {
 	if d.NoPublicIP {
 		log.Info("Not creating a public IP address.")
 	} else {
-		if err := c.CreatePublicIPAddress(d.ctx, d.ResourceGroup, d.naming().IP(), d.Location); err != nil {
+		if err := c.CreatePublicIPAddress(d.ctx, d.ResourceGroup, d.naming().IP(), d.Location, d.StaticPublicIP); err != nil {
 			return err
 		}
 	}

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -142,13 +142,23 @@ func (a AzureClient) DeleteNetworkSecurityGroupIfExists(resourceGroup, name stri
 		func() (autorest.Response, error) { return a.securityGroupsClient().Delete(resourceGroup, name) })
 }
 
-func (a AzureClient) CreatePublicIPAddress(ctx *DeploymentContext, resourceGroup, name, location string) error {
-	log.Info("Creating public IP address...", logutil.Fields{"name": name})
+func (a AzureClient) CreatePublicIPAddress(ctx *DeploymentContext, resourceGroup, name, location string, isStatic bool) error {
+	log.Info("Creating public IP address...", logutil.Fields{
+		"name":   name,
+		"static": isStatic})
+
+	var ipType network.IPAllocationMethod
+	if isStatic {
+		ipType = network.Static
+	} else {
+		ipType = network.Dynamic
+	}
+
 	_, err := a.publicIPAddressClient().CreateOrUpdate(resourceGroup, name,
 		network.PublicIPAddress{
 			Location: to.StringPtr(location),
 			Properties: &network.PublicIPAddressPropertiesFormat{
-				PublicIPAllocationMethod: network.Dynamic,
+				PublicIPAllocationMethod: ipType,
 			},
 		})
 	if err != nil {


### PR DESCRIPTION
This flag creates Azure VMs with static public IP addresses that don’t get released when the VM gets deallocated.