### PR TITLE
Add docker daemon systemd requirement on redhat

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -26,7 +26,12 @@ priority=1
 enabled=1
 gpgkey=https://yum.dockerproject.org/gpg
 `
-	engineConfigTemplate = `[Service]
+	engineConfigTemplate = `[Unit]
+Description=Docker Application Container Engine
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
 ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
 MountFlags=slave
 LimitNOFILE=1048576


### PR DESCRIPTION
I'm using docker-engine 1.10.3 on centos 7. I got a daemon error when I reboot machine:

```
Mar 15 15:24:24 cd26794995c5c4e639528bd0ddbad80c6-node1 docker: ........time="2016-03-15T15:24:24.568724407+08:00" level=warning msg="Failed getting network for ep 95d55a90b3ddeaef6b85184faadb00fbcc489f45410b9fb267b6e2975a86dae0 during sandbox 038e9459e4604d5045c5d15ad9a5e0db3ec118656cea91c3c3d9c9b8accc283d delete: network f37a5be223fc6397585eab977064255c8ebdb198141979f8d61793ffeaf71249 not found"
Mar 15 15:24:24 cd26794995c5c4e639528bd0ddbad80c6-node1 docker: time="2016-03-15T15:24:24.572166528+08:00" level=warning msg="Failed detaching sandbox 038e9459e4604d5045c5d15ad9a5e0db3ec118656cea91c3c3d9c9b8accc283d from endpoint fdd8ca1d1eaa078d095e82a2bc944566522cdb6838cb9bec9eb2a831237f954f: failed to get endpoint from store during leave: could not find endpoint fdd8ca1d1eaa078d095e82a2bc944566522cdb6838cb9bec9eb2a831237f954f: [{global:client: etcd cluster is unavailable or misconfigured}, ]\n"
```      
This problem will produce my containers with `restart:always` and in global network start fail.  
After my screening, the bug is docker daemon's global network depending on network.target and now docker daemon dependence is empty when provision RedHat machines. So I create this pull request to solve this problem.