### PR TITLE
Specify the format for azure-image specification

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -45,7 +45,7 @@ Required:
 
 Optional:
 
-- `--azure-image`: Azure virtual machine image. [[?][vm-image]]
+- `--azure-image`: Azure virtual machine image in the format of Publisher:Offer:Sku:Version [[?][vm-image]]
 - `--azure-location`: Azure region to create the virtual machine. [[?][location]]
 - `--azure-resource-group`: Azure Resource Group name to create the resources in.
 - `--azure-size`: Size for Azure Virtual Machine. [[?][vm-size]]


### PR DESCRIPTION
The format for azure-image is not specified anywhere in the docs. The link for more information talks about how to get information on publisher,offer,sku and version, but doesn't specify format for azuere-image option for azure driver.

cc @ahmetalpbalkan 