### PR TITLE
Propogate given configuration to plugin servers

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnerror"
-	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/opt"
 	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/ssh"
 )
@@ -143,20 +143,20 @@ func runCommand(command func(commandLine CommandLine, api libmachine.API) error)
 		api := libmachine.NewClient(mcndirs.GetBaseDir(), mcndirs.GetMachineCertDir())
 		defer api.Close()
 
-		if context.GlobalBool("native-ssh") {
-			api.SSHClientType = ssh.Native
+		libmachineOpts := &mcnopt.Options{
+			BaseDir:        context.GlobalString("storage-path"),
+			GithubAPIToken: context.GlobalString("github-api-token"),
 		}
-		api.GithubAPIToken = context.GlobalString("github-api-token")
-		api.Filestore.Path = context.GlobalString("storage-path")
 
-		// TODO (nathanleclaire): These should ultimately be accessed
-		// through the libmachine client by the rest of the code and
-		// not through their respective modules.  For now, however,
-		// they are also being set the way that they originally were
-		// set to preserve backwards compatibility.
-		mcndirs.BaseDir = api.Filestore.Path
-		mcnutils.GithubAPIToken = api.GithubAPIToken
-		ssh.SetDefaultClient(api.SSHClientType)
+		if context.GlobalBool("native-ssh") {
+			libmachineOpts.SSHClientType = ssh.Native
+		} else {
+			libmachineOpts.SSHClientType = ssh.External
+		}
+
+		mcnopt.SetOpts(libmachineOpts)
+
+		api.Filestore.Path = libmachineOpts.BaseDir
 
 		if err := command(&contextCommandLine{context}, api); err != nil {
 			log.Error(err)

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/opt"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/docker/machine/libmachine/version"
 )
@@ -33,6 +34,7 @@ func init() {
 	gob.Register(new(mcnflag.StringFlag))
 	gob.Register(new(mcnflag.StringSliceFlag))
 	gob.Register(new(mcnflag.BoolFlag))
+	gob.Register(new(mcnopt.Options))
 }
 
 type RPCFlags struct {
@@ -96,6 +98,11 @@ func NewRPCServerDriver(d drivers.Driver) *RPCServerDriver {
 
 func (r *RPCServerDriver) Close(_, _ *struct{}) error {
 	r.CloseCh <- true
+	return nil
+}
+
+func (r *RPCServerDriver) SetMachineOptions(opts *mcnopt.Options, _ *struct{}) error {
+	mcnopt.SetOpts(opts)
 	return nil
 }
 

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/persist"
 	"github.com/docker/machine/libmachine/provision"
-	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/libmachine/version"
@@ -35,10 +34,8 @@ type API interface {
 }
 
 type Client struct {
-	certsDir       string
-	IsDebug        bool
-	SSHClientType  ssh.ClientType
-	GithubAPIToken string
+	certsDir string
+	IsDebug  bool
 	*persist.Filestore
 	clientDriverFactory rpcdriver.RPCClientDriverFactory
 }
@@ -47,7 +44,6 @@ func NewClient(storePath, certsDir string) *Client {
 	return &Client{
 		certsDir:            certsDir,
 		IsDebug:             false,
-		SSHClientType:       ssh.External,
 		Filestore:           persist.NewFilestore(storePath, certsDir, certsDir),
 		clientDriverFactory: rpcdriver.NewRPCClientDriverFactory(),
 	}

--- a/libmachine/opt/options.go
+++ b/libmachine/opt/options.go
@@ -1,0 +1,34 @@
+package mcnopt
+
+import (
+	"github.com/docker/machine/commands/mcndirs"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/ssh"
+)
+
+type Options struct {
+	BaseDir        string
+	SSHClientType  ssh.ClientType
+	GithubAPIToken string
+}
+
+var (
+	defaultOptions = &Options{
+		SSHClientType: ssh.External,
+		BaseDir:       mcndirs.GetBaseDir(),
+	}
+)
+
+func Opts() *Options {
+	return defaultOptions
+}
+
+func SetOpts(opts *Options) {
+	defaultOptions = opts
+
+	// TODO: Ideally this would not be scattered state across several
+	// modules, but rather presented through a uniform interface.
+	mcndirs.BaseDir = opts.BaseDir
+	mcnutils.GithubAPIToken = opts.GithubAPIToken
+	ssh.SetDefaultClient(opts.SSHClientType)
+}


### PR DESCRIPTION
Closes https://github.com/docker/machine/issues/3181

cc @dgageot for review -- this one is a bit tricky and we need to define what our expectations are around API breakage / versioning.  Because this would introduce a call to a RPC endpoint which won't be present in all cases.  I'm open to other ideas if you have them of course.

I guess my feeling is that in this case, we are creating a brand new method, and if we try to call it but it's not there, nothing is different than it was before (when the plugin servers weren't getting the propagated config information anyway) and we can keep moving forward.  It doesn't break existing plugins (shouldn't at least), just adds a new method. 

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>