### PR TITLE
exoscale: support for CoreOS

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -293,7 +293,7 @@
 		},
 		{
 			"ImportPath": "github.com/pyr/egoscale/src/egoscale",
-			"Rev": "bbaa67324aeeacc90430c1fe0a9c620d3929512e"
+			"Rev": "347f81398d2ea1f3eebf1cd27ee3183669e34819"
 		},
 		{
 			"ImportPath": "github.com/rackspace/gophercloud",

--- a/docs/drivers/exoscale.md
+++ b/docs/drivers/exoscale.md
@@ -25,7 +25,9 @@ Options:
 -   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400).
 -   `--exoscale-image`: Image template (eg. ubuntu-14.04, ubuntu-15.10).
 -   `--exoscale-security-group`: Security group. It will be created if it doesn't exist.
--   `--exoscale-availability-zone`: exoscale availability zone.
+-   `--exoscale-availability-zone`: Exoscale availability zone.
+-   `--exoscale-ssh-user`: SSH username, which must match the default SSH user for the used image.
+-   `--exoscale-userdata`: Path to file containing user data for cloud-init.
 
 If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.
 
@@ -41,3 +43,5 @@ Environment variables and default values:
 | `--exoscale-image`              | `EXOSCALE_IMAGE`             | `ubuntu-15.10`                    |
 | `--exoscale-security-group`     | `EXOSCALE_SECURITY_GROUP`    | `docker-machine`                  |
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-gva-2`                        |
+| `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | `ubuntu`                          |
+| `--exoscale-userdata`           | `EXOSCALE_USERDATA`          | -                                 |

--- a/vendor/github.com/pyr/egoscale/src/egoscale/topology.go
+++ b/vendor/github.com/pyr/egoscale/src/egoscale/topology.go
@@ -114,12 +114,12 @@ func (exo *Client) GetImages() (map[string]map[int]string, error) {
 		return nil, err
 	}
 
-	re := regexp.MustCompile(`^Linux (?P<name>Ubuntu|Debian) (?P<version>[0-9.]+).*$`)
+	re := regexp.MustCompile(`^Linux (?P<name>.+?) (?P<version>[0-9.]+).*$`)
 	for _, template := range r.Templates {
 		size := int(template.Size / (1024 * 1024 * 1024))
 		submatch := re.FindStringSubmatch(template.Name)
 		if len(submatch) > 0 {
-			name := strings.ToLower(submatch[1])
+			name := strings.Replace(strings.ToLower(submatch[1]), " ", "-", -1)
 			version := submatch[2]
 			image := fmt.Sprintf("%s-%s", name, version)
 


### PR DESCRIPTION
Hey!

Here is a small update for the exoscale driver to properly support CoreOS. The first commit enables the use of the CoreOS image by updating the egoscale binding. The second one allows one to specify an chosen SSH user (for CoreOS, "core"). The third one enables the user to provide its own user-data. It was quite useless when provisioning Ubuntu OS, but some users are asking it for CoreOS (notably to configure etcd).