### PR TITLE
Simplify appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,8 @@ os: Windows Server 2012 R2
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.6
 
 clone_folder: c:\gopath\src\github.com\docker\machine
-
-install:
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
-  - ps: rmdir C:\go -Force -Recurse -Confirm:$false
-  - 7z x go%GOVERSION%.windows-amd64.zip -o"C:\" -y > nul
-  - set Path=c:\go\bin;%Path%
 
 build_script:
   - go build -i -o ./bin/docker-machine.exe ./cmd/machine.go


### PR DESCRIPTION
Now that go 1.6 is the default, we can simplify the AppVeyor configuration file.

Signed-off-by: David Gageot <david@gageot.net>