### PR TITLE
Prevent /var/lib/boot2docker/bootlocal.sh munging on restart

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -612,8 +612,12 @@ func (d *Driver) Stop() error {
 
 // Restart restarts a machine which is known to be running.
 func (d *Driver) Restart() error {
-	if err := d.vbm("controlvm", d.MachineName, "reset"); err != nil {
-		return err
+	if err := d.Stop(); err != nil {
+		return fmt.Errorf("Problem stopping the VM: %s", err)
+	}
+
+	if err := d.Start(); err != nil {
+		return fmt.Errorf("Problem starting the VM: %s", err)
 	}
 
 	d.IPAddress = ""


### PR DESCRIPTION
cc @dgageot @tianon FYI

Closes https://github.com/docker/machine/issues/3166

Seems the `reset` is problematic.  We could maybe look more into why, but this fixes the problem for now.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>