### PR TITLE
Fixup create command flag application.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -42,6 +42,8 @@ type CommandLine interface {
 
 	Args() cli.Args
 
+	IsSet(name string) bool
+
 	Bool(name string) bool
 
 	Int(name string) int

--- a/commands/commandstest/fake_command_line.go
+++ b/commands/commandstest/fake_command_line.go
@@ -42,6 +42,11 @@ func (ff FakeFlagger) Bool(key string) bool {
 	return false
 }
 
+func (fcli *FakeCommandLine) IsSet(key string) bool {
+	_, ok := fcli.LocalFlags.Data[key]
+	return ok
+}
+
 func (fcli *FakeCommandLine) String(key string) string {
 	return fcli.LocalFlags.String(key)
 }

--- a/commands/create.go
+++ b/commands/create.go
@@ -364,7 +364,9 @@ func getDriverOpts(c CommandLine, mcnflags []mcnflag.Flag) drivers.DriverOptions
 			// TODO: This is pretty hacky.  StringSlice is the only
 			// type so far we have to worry about which is not a
 			// Getter, though.
-			driverOpts.Values[name] = c.StringSlice(name)
+			if c.IsSet(name) {
+				driverOpts.Values[name] = c.StringSlice(name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously StringSlice flag defaults were not respected.  These use
special handling and that handling did not take account of default
values, always over-writing them.  Expand the CommandLine interface to
take advantage of the underlying codegansta/cli.Context IsSet method and
guard default string slice overwrites with an IsSet test.

This addresses #3242

Signed-off-by: John Sirois <john.sirois@gmail.com>