### PR TITLE
adding hypervisor check to virtualbox pre-create check

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -36,7 +36,7 @@ const (
 var (
 	ErrUnableToGenerateRandomIP = errors.New("unable to generate random IP")
 	ErrMustEnableVTX            = errors.New("This computer doesn't have VT-X/AMD-v enabled. Enabling it in the BIOS is mandatory")
-	ErrNotCompatibleWithHyperV  = errors.New("Hyper-V is installed. VirtualBox won't boot a 64bits VM when Hyper-V is activated. If it's installed but deactivated, you can use --virtualbox-no-vtx-check to try anyways")
+	ErrNotCompatibleWithHyperV  = errors.New("This computer is running Hyper-V. VirtualBox won't boot a 64bits VM when Hyper-V is activated. Either use Hyper-V as a driver, or disable the Hyper-V hypervisor. (To skip this check, use --virtualbox-no-vtx-check)")
 	ErrNetworkAddrCidr          = errors.New("host-only cidr must be specified with a host address, not a network address")
 	ErrNetworkAddrCollision     = errors.New("host-only cidr conflicts with the network address of a host interface")
 )

--- a/drivers/virtualbox/virtualbox_windows.go
+++ b/drivers/virtualbox/virtualbox_windows.go
@@ -95,6 +95,25 @@ func getShareDriveAndName() (string, string) {
 }
 
 func isHyperVInstalled() bool {
+	// check if hyper-v is installed
 	_, err := exec.LookPath("vmms.exe")
-	return err == nil
+	if err != nil {
+		errmsg := "Hyper-V is not installed."
+		log.Debugf(errmsg, err)
+		return false
+	}
+
+	// check to see if a hypervisor is present. if hyper-v is installed and enabled,
+	// display an error explaining the incompatibility between virtualbox and hyper-v.
+	output, err := cmdOutput("wmic", "computersystem", "get", "hypervisorpresent")
+
+	if err != nil {
+		errmsg := "Could not check to see if Hyper-V is running."
+		log.Debugf(errmsg, err)
+		return false
+	}
+
+	enabled := strings.Contains(output, "TRUE")
+	return enabled
+
 }


### PR DESCRIPTION
Based on feedback from https://github.com/docker/docker/pull/21042. 

The Hyper-V hypervisor and VirtualBox are currently incompatible. However, Hyper-V can be installed without running the hypervisor.

Added a check to see if the hypervisor is running. If it is, we should point people to use Hyper-V as a driver, or disable the hypervisor if they want to use VirtualBox.