### PR TITLE
driver/azure: Performance improvements

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -66,53 +66,53 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/compute",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/network",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/resources/resources",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/storage",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",
-			"Comment": "v2.0.0-beta",
-			"Rev": "b4e3bc02a65dca5237084eba6e94f06a169f09c3"
+			"Comment": "v2.1.0-beta-14-g19292e1",
+			"Rev": "19292e1e4146b32fb0da296cd8c89edb41b8b5bc"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest",
-			"Comment": "v6.0.0",
-			"Rev": "c6f4f7f3678803fbe8975c884e80affad9d31998"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-			"Comment": "v6.0.0",
-			"Rev": "c6f4f7f3678803fbe8975c884e80affad9d31998"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
-			"Comment": "v6.0.0",
-			"Rev": "c6f4f7f3678803fbe8975c884e80affad9d31998"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/to",
-			"Comment": "v6.0.0",
-			"Rev": "c6f4f7f3678803fbe8975c884e80affad9d31998"
+			"Comment": "v7.0.3",
+			"Rev": "a48248c3a3a847d2359ce7c262b4e4686307256f"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",

--- a/drivers/azure/azureutil/auth.go
+++ b/drivers/azure/azureutil/auth.go
@@ -46,7 +46,7 @@ func Authenticate(env azure.Environment, subscriptionID string) (*azure.ServiceP
 	// tenant (which could have multiple subscriptions)
 	log.Debug("Looking up AAD Tenant ID.", logutil.Fields{
 		"subs": subscriptionID})
-	tenantID, err := findTenantID(env, subscriptionID)
+	tenantID, err := loadOrFindTenantID(env, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -173,10 +173,21 @@ func tokenFromDeviceFlow(oauthCfg azure.OAuthConfig, tokenPath, clientID, resour
 	return spt, nil
 }
 
+// azureCredsPath returns the directory the azure credentials are stored in.
+func azureCredsPath() string {
+	return filepath.Join(mcnutils.GetHomeDir(), ".docker", "machine", "credentials", "azure")
+}
+
 // tokenCachePath returns the full path the OAuth 2.0 token should be saved at
 // for given tenant ID.
 func tokenCachePath(tenantID string) string {
-	return filepath.Join(mcnutils.GetHomeDir(), ".docker", "machine", "credentials", "azure", fmt.Sprintf("%s.json", tenantID))
+	return filepath.Join(azureCredsPath(), fmt.Sprintf("%s.json", tenantID))
+}
+
+// tenantIDPath returns the full path the tenant ID for the given subscription
+// should be saved at.
+func tenantIDPath(subscriptionID string) string {
+	return filepath.Join(azureCredsPath(), fmt.Sprintf("%s.tenantid", subscriptionID))
 }
 
 // mkTokenCallback returns a callback function that can be used to save the

--- a/drivers/azure/azureutil/cleanup.go
+++ b/drivers/azure/azureutil/cleanup.go
@@ -65,7 +65,7 @@ func (c *subnetCleanup) Get(a AzureClient) (err error) {
 }
 
 func (c *subnetCleanup) Delete(a AzureClient) error {
-	_, err := a.subnetsClient().Delete(c.rg, c.vnet, c.name)
+	_, err := a.subnetsClient().Delete(c.rg, c.vnet, c.name, nil)
 	return err
 }
 
@@ -89,7 +89,7 @@ func (c *vnetCleanup) Get(a AzureClient) (err error) {
 }
 
 func (c *vnetCleanup) Delete(a AzureClient) error {
-	_, err := a.virtualNetworksClient().Delete(c.rg, c.name)
+	_, err := a.virtualNetworksClient().Delete(c.rg, c.name, nil)
 	return err
 }
 

--- a/drivers/azure/azureutil/clients.go
+++ b/drivers/azure/azureutil/clients.go
@@ -2,6 +2,7 @@ package azureutil
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/docker/machine/version"
 
@@ -31,6 +32,7 @@ func subscriptionsClient(baseURI string) subscriptions.Client {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -40,6 +42,7 @@ func (a AzureClient) providersClient() resources.ProvidersClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -49,6 +52,7 @@ func (a AzureClient) resourceGroupsClient() resources.GroupsClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -58,6 +62,7 @@ func (a AzureClient) securityGroupsClient() network.SecurityGroupsClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -67,6 +72,7 @@ func (a AzureClient) virtualNetworksClient() network.VirtualNetworksClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -76,6 +82,7 @@ func (a AzureClient) subnetsClient() network.SubnetsClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -85,6 +92,7 @@ func (a AzureClient) networkInterfacesClient() network.InterfacesClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -94,6 +102,7 @@ func (a AzureClient) publicIPAddressClient() network.PublicIPAddressesClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -103,6 +112,7 @@ func (a AzureClient) storageAccountsClient() storage.AccountsClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -112,6 +122,7 @@ func (a AzureClient) virtualMachinesClient() compute.VirtualMachinesClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }
 
@@ -121,5 +132,6 @@ func (a AzureClient) availabilitySetsClient() compute.AvailabilitySetsClient {
 	c.Client.UserAgent += fmt.Sprintf(";docker-machine/%s", version.Version)
 	c.RequestInspector = withInspection()
 	c.ResponseInspector = byInspecting()
+	c.PollingDelay = time.Second * 5
 	return c
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
@@ -520,6 +520,12 @@ func (client ListUsagesResult) ListUsagesResultPreparer() (*http.Request, error)
 		autorest.WithBaseURL(to.String(client.NextLink)))
 }
 
+// ListVirtualMachineImageResource is
+type ListVirtualMachineImageResource struct {
+	autorest.Response `json:"-"`
+	Value             *[]VirtualMachineImageResource `json:"value,omitempty"`
+}
+
 // LongRunningOperationProperties is compute-specific operation properties,
 // including output
 type LongRunningOperationProperties struct {
@@ -803,12 +809,6 @@ type VirtualMachineImageResource struct {
 	Name     *string             `json:"name,omitempty"`
 	Location *string             `json:"location,omitempty"`
 	Tags     *map[string]*string `json:"tags,omitempty"`
-}
-
-// VirtualMachineImageResourceList is
-type VirtualMachineImageResourceList struct {
-	autorest.Response `json:"-"`
-	Value             *VirtualMachineImageResource `json:"value,omitempty"`
 }
 
 // VirtualMachineInstanceView is the instance view of a virtual machine.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "6"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensionimages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensionimages.go
@@ -108,7 +108,7 @@ func (client VirtualMachineExtensionImagesClient) GetResponder(resp *http.Respon
 
 // ListTypes gets a list of virtual machine extension image types.
 //
-func (client VirtualMachineExtensionImagesClient) ListTypes(location string, publisherName string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListTypes(location string, publisherName string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListTypesPreparer(location, publisherName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListTypes", nil, "Failure preparing request")
@@ -157,7 +157,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypesSender(req *http.Requ
 
 // ListTypesResponder handles the response to the ListTypes request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -171,7 +171,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypesResponder(resp *http.
 // ListVersions gets a list of virtual machine extension image versions.
 //
 // filter is the filter to apply on the operation.
-func (client VirtualMachineExtensionImagesClient) ListVersions(location string, publisherName string, typeParameter string, filter string, top *int32, orderBy string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListVersions(location string, publisherName string, typeParameter string, filter string, top *int32, orderBy string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListVersionsPreparer(location, publisherName, typeParameter, filter, top, orderBy)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionImagesClient", "ListVersions", nil, "Failure preparing request")
@@ -230,7 +230,7 @@ func (client VirtualMachineExtensionImagesClient) ListVersionsSender(req *http.R
 
 // ListVersionsResponder handles the response to the ListVersions request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineExtensionImagesClient) ListVersionsResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineExtensionImagesClient) ListVersionsResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineextensions.go
@@ -42,15 +42,18 @@ func NewVirtualMachineExtensionsClientWithBaseURI(baseURI string, subscriptionID
 	return VirtualMachineExtensionsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// CreateOrUpdate the operation to create or update the extension.
+// CreateOrUpdate the operation to create or update the extension. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine where the extension should be create or updated.
 // vmExtensionName is the name of the virtual machine extension.
 // extensionParameters is parameters supplied to the Create Virtual Machine
 // Extension operation.
-func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, vmExtensionName, extensionParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -70,7 +73,7 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdate(resourceGroupName st
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*http.Request, error) {
+func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -82,7 +85,7 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -97,8 +100,7 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdatePreparer(resourceGrou
 func (client VirtualMachineExtensionsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -113,13 +115,16 @@ func (client VirtualMachineExtensionsClient) CreateOrUpdateResponder(resp *http.
 	return
 }
 
-// Delete the operation to delete the extension.
+// Delete the operation to delete the extension. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine where the extension should be deleted. vmExtensionName
 // is the name of the virtual machine extension.
-func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vmName string, vmExtensionName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmName, vmExtensionName)
+func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vmName string, vmExtensionName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmName, vmExtensionName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineExtensionsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -139,7 +144,7 @@ func (client VirtualMachineExtensionsClient) Delete(resourceGroupName string, vm
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName string, vmName string, vmExtensionName string) (*http.Request, error) {
+func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName string, vmName string, vmExtensionName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -151,7 +156,7 @@ func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName st
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -165,8 +170,7 @@ func (client VirtualMachineExtensionsClient) DeletePreparer(resourceGroupName st
 func (client VirtualMachineExtensionsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineimages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachineimages.go
@@ -110,7 +110,7 @@ func (client VirtualMachineImagesClient) GetResponder(resp *http.Response) (resu
 // List gets a list of virtual machine images.
 //
 // filter is the filter to apply on the operation.
-func (client VirtualMachineImagesClient) List(location string, publisherName string, offer string, skus string, filter string, top *int32, orderby string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) List(location string, publisherName string, offer string, skus string, filter string, top *int32, orderby string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListPreparer(location, publisherName, offer, skus, filter, top, orderby)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "List", nil, "Failure preparing request")
@@ -170,7 +170,7 @@ func (client VirtualMachineImagesClient) ListSender(req *http.Request) (*http.Re
 
 // ListResponder handles the response to the List request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -183,7 +183,7 @@ func (client VirtualMachineImagesClient) ListResponder(resp *http.Response) (res
 
 // ListOffers gets a list of virtual machine image offers.
 //
-func (client VirtualMachineImagesClient) ListOffers(location string, publisherName string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListOffers(location string, publisherName string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListOffersPreparer(location, publisherName)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListOffers", nil, "Failure preparing request")
@@ -232,7 +232,7 @@ func (client VirtualMachineImagesClient) ListOffersSender(req *http.Request) (*h
 
 // ListOffersResponder handles the response to the ListOffers request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -245,7 +245,7 @@ func (client VirtualMachineImagesClient) ListOffersResponder(resp *http.Response
 
 // ListPublishers gets a list of virtual machine image publishers.
 //
-func (client VirtualMachineImagesClient) ListPublishers(location string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListPublishers(location string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListPublishersPreparer(location)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListPublishers", nil, "Failure preparing request")
@@ -293,7 +293,7 @@ func (client VirtualMachineImagesClient) ListPublishersSender(req *http.Request)
 
 // ListPublishersResponder handles the response to the ListPublishers request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
@@ -306,7 +306,7 @@ func (client VirtualMachineImagesClient) ListPublishersResponder(resp *http.Resp
 
 // ListSkus gets a list of virtual machine image skus.
 //
-func (client VirtualMachineImagesClient) ListSkus(location string, publisherName string, offer string) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListSkus(location string, publisherName string, offer string) (result ListVirtualMachineImageResource, err error) {
 	req, err := client.ListSkusPreparer(location, publisherName, offer)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineImagesClient", "ListSkus", nil, "Failure preparing request")
@@ -356,7 +356,7 @@ func (client VirtualMachineImagesClient) ListSkusSender(req *http.Request) (*htt
 
 // ListSkusResponder handles the response to the ListSkus request. The method always
 // closes the http.Response Body.
-func (client VirtualMachineImagesClient) ListSkusResponder(resp *http.Response) (result VirtualMachineImageResourceList, err error) {
+func (client VirtualMachineImagesClient) ListSkusResponder(resp *http.Response) (result ListVirtualMachineImageResource, err error) {
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachines.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachines.go
@@ -43,13 +43,16 @@ func NewVirtualMachinesClientWithBaseURI(baseURI string, subscriptionID string) 
 }
 
 // Capture captures the VM by copying VirtualHardDisks of the VM and outputs a
-// template that can be used to create similar VMs.
+// template that can be used to create similar VMs. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine. parameters is parameters supplied to the Capture
 // Virtual Machine operation.
-func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (result autorest.Response, err error) {
-	req, err := client.CapturePreparer(resourceGroupName, vmName, parameters)
+func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CapturePreparer(resourceGroupName, vmName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Capture", nil, "Failure preparing request")
 	}
@@ -69,7 +72,7 @@ func (client VirtualMachinesClient) Capture(resourceGroupName string, vmName str
 }
 
 // CapturePreparer prepares the Capture request.
-func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*http.Request, error) {
+func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -80,7 +83,7 @@ func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vm
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -95,8 +98,7 @@ func (client VirtualMachinesClient) CapturePreparer(resourceGroupName string, vm
 func (client VirtualMachinesClient) CaptureSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CaptureResponder handles the response to the Capture request. The method always
@@ -111,13 +113,16 @@ func (client VirtualMachinesClient) CaptureResponder(resp *http.Response) (resul
 	return
 }
 
-// CreateOrUpdate the operation to create or update a virtual machine.
+// CreateOrUpdate the operation to create or update a virtual machine. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine. parameters is parameters supplied to the Create
 // Virtual Machine operation.
-func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmName string, parameters VirtualMachine) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, parameters)
+func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmName string, parameters VirtualMachine, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, vmName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -137,7 +142,7 @@ func (client VirtualMachinesClient) CreateOrUpdate(resourceGroupName string, vmN
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, parameters VirtualMachine) (*http.Request, error) {
+func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName string, vmName string, parameters VirtualMachine, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -148,7 +153,7 @@ func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -163,8 +168,7 @@ func (client VirtualMachinesClient) CreateOrUpdatePreparer(resourceGroupName str
 func (client VirtualMachinesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -181,12 +185,14 @@ func (client VirtualMachinesClient) CreateOrUpdateResponder(resp *http.Response)
 
 // Deallocate shuts down the Virtual Machine and releases the compute
 // resources. You are not billed for the compute resources that this Virtual
-// Machine uses.
+// Machine uses. This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName string) (result autorest.Response, err error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -206,7 +212,7 @@ func (client VirtualMachinesClient) Deallocate(resourceGroupName string, vmName 
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -217,7 +223,7 @@ func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -231,8 +237,7 @@ func (client VirtualMachinesClient) DeallocatePreparer(resourceGroupName string,
 func (client VirtualMachinesClient) DeallocateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -247,12 +252,15 @@ func (client VirtualMachinesClient) DeallocateResponder(resp *http.Response) (re
 	return
 }
 
-// Delete the operation to delete a virtual machine.
+// Delete the operation to delete a virtual machine. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -272,7 +280,7 @@ func (client VirtualMachinesClient) Delete(resourceGroupName string, vmName stri
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -283,7 +291,7 @@ func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmN
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -297,8 +305,7 @@ func (client VirtualMachinesClient) DeletePreparer(resourceGroupName string, vmN
 func (client VirtualMachinesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -704,12 +711,15 @@ func (client VirtualMachinesClient) ListAvailableSizesNextResults(lastResults Vi
 	return
 }
 
-// PowerOff the operation to power off (stop) a virtual machine.
+// PowerOff the operation to power off (stop) a virtual machine. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName string) (result autorest.Response, err error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -729,7 +739,7 @@ func (client VirtualMachinesClient) PowerOff(resourceGroupName string, vmName st
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -740,7 +750,7 @@ func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, v
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -754,8 +764,7 @@ func (client VirtualMachinesClient) PowerOffPreparer(resourceGroupName string, v
 func (client VirtualMachinesClient) PowerOffSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -770,12 +779,15 @@ func (client VirtualMachinesClient) PowerOffResponder(resp *http.Response) (resu
 	return
 }
 
-// Restart the operation to restart a virtual machine.
+// Restart the operation to restart a virtual machine. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName string) (result autorest.Response, err error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Restart", nil, "Failure preparing request")
 	}
@@ -795,7 +807,7 @@ func (client VirtualMachinesClient) Restart(resourceGroupName string, vmName str
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -806,7 +818,7 @@ func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vm
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -820,8 +832,7 @@ func (client VirtualMachinesClient) RestartPreparer(resourceGroupName string, vm
 func (client VirtualMachinesClient) RestartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -836,12 +847,15 @@ func (client VirtualMachinesClient) RestartResponder(resp *http.Response) (resul
 	return
 }
 
-// Start the operation to start a virtual machine.
+// Start the operation to start a virtual machine. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmName is the name of
 // the virtual machine.
-func (client VirtualMachinesClient) Start(resourceGroupName string, vmName string) (result autorest.Response, err error) {
-	req, err := client.StartPreparer(resourceGroupName, vmName)
+func (client VirtualMachinesClient) Start(resourceGroupName string, vmName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachinesClient", "Start", nil, "Failure preparing request")
 	}
@@ -861,7 +875,7 @@ func (client VirtualMachinesClient) Start(resourceGroupName string, vmName strin
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmName string) (*http.Request, error) {
+func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -872,7 +886,7 @@ func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -886,8 +900,7 @@ func (client VirtualMachinesClient) StartPreparer(resourceGroupName string, vmNa
 func (client VirtualMachinesClient) StartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesets.go
@@ -43,13 +43,15 @@ func NewVirtualMachineScaleSetsClientWithBaseURI(baseURI string, subscriptionID 
 }
 
 // CreateOrUpdate the operation to create or update a virtual machine scale
-// set.
+// set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. name is parameters
 // supplied to the Create Virtual Machine Scale Set operation. parameters is
 // parameters supplied to the Create Virtual Machine Scale Set operation.
-func (client VirtualMachineScaleSetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters VirtualMachineScaleSet) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, name, parameters)
+func (client VirtualMachineScaleSetsClient) CreateOrUpdate(resourceGroupName string, name string, parameters VirtualMachineScaleSet, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, name, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -69,7 +71,7 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdate(resourceGroupName str
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroupName string, name string, parameters VirtualMachineScaleSet) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroupName string, name string, parameters VirtualMachineScaleSet, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"name":              url.QueryEscape(name),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -80,7 +82,7 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroup
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -95,8 +97,7 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdatePreparer(resourceGroup
 func (client VirtualMachineScaleSetsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -112,13 +113,15 @@ func (client VirtualMachineScaleSetsClient) CreateOrUpdateResponder(resp *http.R
 }
 
 // Deallocate the operation to deallocate virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, err error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -138,7 +141,7 @@ func (client VirtualMachineScaleSetsClient) Deallocate(resourceGroupName string,
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -160,7 +163,7 @@ func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // DeallocateSender sends the Deallocate request. The method will close the
@@ -168,8 +171,7 @@ func (client VirtualMachineScaleSetsClient) DeallocatePreparer(resourceGroupName
 func (client VirtualMachineScaleSetsClient) DeallocateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -184,12 +186,15 @@ func (client VirtualMachineScaleSetsClient) DeallocateResponder(resp *http.Respo
 	return
 }
 
-// Delete the operation to delete a virtual machine scale set.
+// Delete the operation to delete a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set.
-func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmScaleSetName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName)
+func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmScaleSetName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -209,7 +214,7 @@ func (client VirtualMachineScaleSetsClient) Delete(resourceGroupName string, vmS
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -220,7 +225,7 @@ func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -234,8 +239,7 @@ func (client VirtualMachineScaleSetsClient) DeletePreparer(resourceGroupName str
 func (client VirtualMachineScaleSetsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -251,13 +255,15 @@ func (client VirtualMachineScaleSetsClient) DeleteResponder(resp *http.Response)
 }
 
 // DeleteInstances the operation to delete virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (result autorest.Response, err error) {
-	req, err := client.DeleteInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeleteInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "DeleteInstances", nil, "Failure preparing request")
 	}
@@ -277,7 +283,7 @@ func (client VirtualMachineScaleSetsClient) DeleteInstances(resourceGroupName st
 }
 
 // DeleteInstancesPreparer prepares the DeleteInstances request.
-func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -288,7 +294,7 @@ func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -303,8 +309,7 @@ func (client VirtualMachineScaleSetsClient) DeleteInstancesPreparer(resourceGrou
 func (client VirtualMachineScaleSetsClient) DeleteInstancesSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteInstancesResponder handles the response to the DeleteInstances request. The method always
@@ -711,13 +716,15 @@ func (client VirtualMachineScaleSetsClient) ListSkusNextResults(lastResults Virt
 }
 
 // PowerOff the operation to power off (stop) virtual machines in a virtual
-// machine scale set.
+// machine scale set. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, err error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -737,7 +744,7 @@ func (client VirtualMachineScaleSetsClient) PowerOff(resourceGroupName string, v
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -759,7 +766,7 @@ func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName s
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // PowerOffSender sends the PowerOff request. The method will close the
@@ -767,8 +774,7 @@ func (client VirtualMachineScaleSetsClient) PowerOffPreparer(resourceGroupName s
 func (client VirtualMachineScaleSetsClient) PowerOffSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -784,13 +790,15 @@ func (client VirtualMachineScaleSetsClient) PowerOffResponder(resp *http.Respons
 }
 
 // Restart the operation to restart virtual machines in a virtual machine
-// scale set.
+// scale set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, err error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Restart", nil, "Failure preparing request")
 	}
@@ -810,7 +818,7 @@ func (client VirtualMachineScaleSetsClient) Restart(resourceGroupName string, vm
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -832,7 +840,7 @@ func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName st
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // RestartSender sends the Restart request. The method will close the
@@ -840,8 +848,7 @@ func (client VirtualMachineScaleSetsClient) RestartPreparer(resourceGroupName st
 func (client VirtualMachineScaleSetsClient) RestartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -857,13 +864,15 @@ func (client VirtualMachineScaleSetsClient) RestartResponder(resp *http.Response
 }
 
 // Start the operation to start virtual machines in a virtual machine scale
-// set.
+// set. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (result autorest.Response, err error) {
-	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "Start", nil, "Failure preparing request")
 	}
@@ -883,7 +892,7 @@ func (client VirtualMachineScaleSetsClient) Start(resourceGroupName string, vmSc
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs *VirtualMachineScaleSetVMInstanceIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -905,7 +914,7 @@ func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName stri
 		preparer = autorest.DecoratePreparer(preparer,
 			autorest.WithJSON(vmInstanceIDs))
 	}
-	return preparer.Prepare(&http.Request{})
+	return preparer.Prepare(&http.Request{Cancel: cancel})
 }
 
 // StartSender sends the Start request. The method will close the
@@ -913,8 +922,7 @@ func (client VirtualMachineScaleSetsClient) StartPreparer(resourceGroupName stri
 func (client VirtualMachineScaleSetsClient) StartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always
@@ -930,13 +938,15 @@ func (client VirtualMachineScaleSetsClient) StartResponder(resp *http.Response) 
 }
 
 // UpdateInstances the operation to manually upgrade virtual machines in a
-// virtual machine scale set.
+// virtual machine scale set. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. vmInstanceIDs is the list of
 // virtual machine scale set instance IDs.
-func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (result autorest.Response, err error) {
-	req, err := client.UpdateInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.UpdateInstancesPreparer(resourceGroupName, vmScaleSetName, vmInstanceIDs, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetsClient", "UpdateInstances", nil, "Failure preparing request")
 	}
@@ -956,7 +966,7 @@ func (client VirtualMachineScaleSetsClient) UpdateInstances(resourceGroupName st
 }
 
 // UpdateInstancesPreparer prepares the UpdateInstances request.
-func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*http.Request, error) {
+func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -967,7 +977,7 @@ func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -982,8 +992,7 @@ func (client VirtualMachineScaleSetsClient) UpdateInstancesPreparer(resourceGrou
 func (client VirtualMachineScaleSetsClient) UpdateInstancesSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // UpdateInstancesResponder handles the response to the UpdateInstances request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesetvms.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/virtualmachinescalesetvms.go
@@ -42,13 +42,16 @@ func NewVirtualMachineScaleSetVMsClientWithBaseURI(baseURI string, subscriptionI
 	return VirtualMachineScaleSetVMsClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// Deallocate the operation to deallocate a virtual machine scale set.
+// Deallocate the operation to deallocate a virtual machine scale set. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, err error) {
-	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeallocatePreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Deallocate", nil, "Failure preparing request")
 	}
@@ -68,7 +71,7 @@ func (client VirtualMachineScaleSetVMsClient) Deallocate(resourceGroupName strin
 }
 
 // DeallocatePreparer prepares the Deallocate request.
-func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -80,7 +83,7 @@ func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -94,8 +97,7 @@ func (client VirtualMachineScaleSetVMsClient) DeallocatePreparer(resourceGroupNa
 func (client VirtualMachineScaleSetVMsClient) DeallocateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeallocateResponder handles the response to the Deallocate request. The method always
@@ -110,13 +112,16 @@ func (client VirtualMachineScaleSetVMsClient) DeallocateResponder(resp *http.Res
 	return
 }
 
-// Delete the operation to delete a virtual machine scale set.
+// Delete the operation to delete a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -136,7 +141,7 @@ func (client VirtualMachineScaleSetVMsClient) Delete(resourceGroupName string, v
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -148,7 +153,7 @@ func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName s
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -162,8 +167,7 @@ func (client VirtualMachineScaleSetVMsClient) DeletePreparer(resourceGroupName s
 func (client VirtualMachineScaleSetVMsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -412,12 +416,15 @@ func (client VirtualMachineScaleSetVMsClient) ListNextResults(lastResults Virtua
 }
 
 // PowerOff the operation to power off (stop) a virtual machine scale set.
+// This method may poll for completion. Polling can be canceled by passing
+// the cancel channel argument. The channel will be used to cancel polling
+// and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, err error) {
-	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.PowerOffPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "PowerOff", nil, "Failure preparing request")
 	}
@@ -437,7 +444,7 @@ func (client VirtualMachineScaleSetVMsClient) PowerOff(resourceGroupName string,
 }
 
 // PowerOffPreparer prepares the PowerOff request.
-func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -449,7 +456,7 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -463,8 +470,7 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffPreparer(resourceGroupName
 func (client VirtualMachineScaleSetVMsClient) PowerOffSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // PowerOffResponder handles the response to the PowerOff request. The method always
@@ -479,13 +485,16 @@ func (client VirtualMachineScaleSetVMsClient) PowerOffResponder(resp *http.Respo
 	return
 }
 
-// Restart the operation to restart a virtual machine scale set.
+// Restart the operation to restart a virtual machine scale set. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, err error) {
-	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.RestartPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Restart", nil, "Failure preparing request")
 	}
@@ -505,7 +514,7 @@ func (client VirtualMachineScaleSetVMsClient) Restart(resourceGroupName string, 
 }
 
 // RestartPreparer prepares the Restart request.
-func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -517,7 +526,7 @@ func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -531,8 +540,7 @@ func (client VirtualMachineScaleSetVMsClient) RestartPreparer(resourceGroupName 
 func (client VirtualMachineScaleSetVMsClient) RestartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // RestartResponder handles the response to the Restart request. The method always
@@ -547,13 +555,16 @@ func (client VirtualMachineScaleSetVMsClient) RestartResponder(resp *http.Respon
 	return
 }
 
-// Start the operation to start a virtual machine scale set.
+// Start the operation to start a virtual machine scale set. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. vmScaleSetName is the
 // name of the virtual machine scale set. instanceID is the instance id of
 // the virtual machine.
-func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vmScaleSetName string, instanceID string) (result autorest.Response, err error) {
-	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, instanceID)
+func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, vmScaleSetName, instanceID, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "compute/VirtualMachineScaleSetVMsClient", "Start", nil, "Failure preparing request")
 	}
@@ -573,7 +584,7 @@ func (client VirtualMachineScaleSetVMsClient) Start(resourceGroupName string, vm
 }
 
 // StartPreparer prepares the Start request.
-func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string) (*http.Request, error) {
+func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName string, vmScaleSetName string, instanceID string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"instanceId":        url.QueryEscape(instanceID),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -585,7 +596,7 @@ func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName st
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -599,8 +610,7 @@ func (client VirtualMachineScaleSetVMsClient) StartPreparer(resourceGroupName st
 func (client VirtualMachineScaleSetVMsClient) StartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/applicationgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/applicationgateways.go
@@ -47,13 +47,15 @@ func NewApplicationGatewaysClientWithBaseURI(baseURI string, subscriptionID stri
 }
 
 // CreateOrUpdate the Put ApplicationGateway operation creates/updates a
-// ApplicationGateway
+// ApplicationGateway This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the ApplicationGateway. parameters is parameters supplied
 // to the create/delete ApplicationGateway operation
-func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, applicationGatewayName, parameters)
+func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, applicationGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -73,7 +75,7 @@ func (client ApplicationGatewaysClient) CreateOrUpdate(resourceGroupName string,
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*http.Request, error) {
+func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,8 +101,7 @@ func (client ApplicationGatewaysClient) CreateOrUpdatePreparer(resourceGroupName
 func (client ApplicationGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -116,12 +117,14 @@ func (client ApplicationGatewaysClient) CreateOrUpdateResponder(resp *http.Respo
 }
 
 // Delete the delete applicationgateway operation deletes the specified
-// applicationgateway.
+// applicationgateway. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the applicationgateway.
-func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applicationGatewayName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -141,7 +144,7 @@ func (client ApplicationGatewaysClient) Delete(resourceGroupName string, applica
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -152,7 +155,7 @@ func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +169,7 @@ func (client ApplicationGatewaysClient) DeletePreparer(resourceGroupName string,
 func (client ApplicationGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -419,12 +421,15 @@ func (client ApplicationGatewaysClient) ListAllNextResults(lastResults Applicati
 }
 
 // Start the Start ApplicationGateway operation starts application gatewayin
-// the specified resource group through Network resource provider.
+// the specified resource group through Network resource provider. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the application gateway.
-func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicationGatewayName string) (result autorest.Response, err error) {
-	req, err := client.StartPreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StartPreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Start", nil, "Failure preparing request")
 	}
@@ -444,7 +449,7 @@ func (client ApplicationGatewaysClient) Start(resourceGroupName string, applicat
 }
 
 // StartPreparer prepares the Start request.
-func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -455,7 +460,7 @@ func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -469,8 +474,7 @@ func (client ApplicationGatewaysClient) StartPreparer(resourceGroupName string, 
 func (client ApplicationGatewaysClient) StartSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StartResponder handles the response to the Start request. The method always
@@ -486,12 +490,15 @@ func (client ApplicationGatewaysClient) StartResponder(resp *http.Response) (res
 }
 
 // Stop the STOP ApplicationGateway operation stops application gatewayin the
-// specified resource group through Network resource provider.
+// specified resource group through Network resource provider. This method
+// may poll for completion. Polling can be canceled by passing the cancel
+// channel argument. The channel will be used to cancel polling and any
+// outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. applicationGatewayName
 // is the name of the application gateway.
-func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicationGatewayName string) (result autorest.Response, err error) {
-	req, err := client.StopPreparer(resourceGroupName, applicationGatewayName)
+func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.StopPreparer(resourceGroupName, applicationGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ApplicationGatewaysClient", "Stop", nil, "Failure preparing request")
 	}
@@ -511,7 +518,7 @@ func (client ApplicationGatewaysClient) Stop(resourceGroupName string, applicati
 }
 
 // StopPreparer prepares the Stop request.
-func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, applicationGatewayName string) (*http.Request, error) {
+func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, applicationGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"applicationGatewayName": url.QueryEscape(applicationGatewayName),
 		"resourceGroupName":      url.QueryEscape(resourceGroupName),
@@ -522,7 +529,7 @@ func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, a
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -536,8 +543,7 @@ func (client ApplicationGatewaysClient) StopPreparer(resourceGroupName string, a
 func (client ApplicationGatewaysClient) StopSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // StopResponder handles the response to the Stop request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitauthorizations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitauthorizations.go
@@ -47,14 +47,17 @@ func NewExpressRouteCircuitAuthorizationsClientWithBaseURI(baseURI string, subsc
 }
 
 // CreateOrUpdate the Put Authorization operation creates/updates an
-// authorization in thespecified ExpressRouteCircuits
+// authorization in thespecified ExpressRouteCircuits This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. authorizationName is the name of the
 // authorization. authorizationParameters is parameters supplied to the
 // create/update ExpressRouteCircuitAuthorization operation
-func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, authorizationName, authorizationParameters)
+func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, authorizationName, authorizationParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -74,7 +77,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(resourceGro
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*http.Request, error) {
+func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"authorizationName": url.QueryEscape(authorizationName),
 		"circuitName":       url.QueryEscape(circuitName),
@@ -86,7 +89,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(res
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -101,8 +104,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdatePreparer(res
 func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -118,13 +120,16 @@ func (client ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateResponder(re
 }
 
 // Delete the delete authorization operation deletes the specified
-// authorization from the specified ExpressRouteCircuit.
+// authorization from the specified ExpressRouteCircuit. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. authorizationName is the name of the
 // authorization.
-func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName string, circuitName string, authorizationName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName, authorizationName)
+func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName string, circuitName string, authorizationName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, authorizationName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitAuthorizationsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -144,7 +149,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) Delete(resourceGroupName s
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGroupName string, circuitName string, authorizationName string) (*http.Request, error) {
+func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGroupName string, circuitName string, authorizationName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"authorizationName": url.QueryEscape(authorizationName),
 		"circuitName":       url.QueryEscape(circuitName),
@@ -156,7 +161,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGro
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -170,8 +175,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) DeletePreparer(resourceGro
 func (client ExpressRouteCircuitAuthorizationsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitpeerings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuitpeerings.go
@@ -47,14 +47,16 @@ func NewExpressRouteCircuitPeeringsClientWithBaseURI(baseURI string, subscriptio
 }
 
 // CreateOrUpdate the Put Pering operation creates/updates an peering in the
-// specified ExpressRouteCircuits
+// specified ExpressRouteCircuits This method may poll for completion.
+// Polling can be canceled by passing the cancel channel argument. The
+// channel will be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. peeringName is the name of the peering.
 // peeringParameters is parameters supplied to the create/update
 // ExpressRouteCircuit Peering operation
-func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdate(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, peeringName, peeringParameters)
+func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdate(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, peeringName, peeringParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -74,7 +76,7 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdate(resourceGroupName
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*http.Request, error) {
+func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"peeringName":       url.QueryEscape(peeringName),
@@ -86,7 +88,7 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceG
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -101,8 +103,7 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdatePreparer(resourceG
 func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -118,12 +119,14 @@ func (client ExpressRouteCircuitPeeringsClient) CreateOrUpdateResponder(resp *ht
 }
 
 // Delete the delete peering operation deletes the specified peering from the
-// ExpressRouteCircuit.
+// ExpressRouteCircuit. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route circuit. peeringName is the name of the peering.
-func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string, circuitName string, peeringName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName, peeringName)
+func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string, circuitName string, peeringName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, peeringName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitPeeringsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -143,7 +146,7 @@ func (client ExpressRouteCircuitPeeringsClient) Delete(resourceGroupName string,
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName string, circuitName string, peeringName string) (*http.Request, error) {
+func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName string, circuitName string, peeringName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"peeringName":       url.QueryEscape(peeringName),
@@ -155,7 +158,7 @@ func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -169,8 +172,7 @@ func (client ExpressRouteCircuitPeeringsClient) DeletePreparer(resourceGroupName
 func (client ExpressRouteCircuitPeeringsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuits.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/expressroutecircuits.go
@@ -47,13 +47,15 @@ func NewExpressRouteCircuitsClientWithBaseURI(baseURI string, subscriptionID str
 }
 
 // CreateOrUpdate the Put ExpressRouteCircuit operation creates/updates a
-// ExpressRouteCircuit
+// ExpressRouteCircuit This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the circuit. parameters is parameters supplied to the
 // create/delete ExpressRouteCircuit operation
-func (client ExpressRouteCircuitsClient) CreateOrUpdate(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, parameters)
+func (client ExpressRouteCircuitsClient) CreateOrUpdate(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, circuitName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -73,7 +75,7 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdate(resourceGroupName string
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*http.Request, error) {
+func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupNam
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,8 +101,7 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdatePreparer(resourceGroupNam
 func (client ExpressRouteCircuitsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -116,12 +117,14 @@ func (client ExpressRouteCircuitsClient) CreateOrUpdateResponder(resp *http.Resp
 }
 
 // Delete the delete ExpressRouteCircuit operation deletes the specified
-// ExpressRouteCircuit.
+// ExpressRouteCircuit. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. circuitName is the
 // name of the express route Circuit.
-func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circuitName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, circuitName)
+func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circuitName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, circuitName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/ExpressRouteCircuitsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -141,7 +144,7 @@ func (client ExpressRouteCircuitsClient) Delete(resourceGroupName string, circui
 }
 
 // DeletePreparer prepares the Delete request.
-func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string, circuitName string) (*http.Request, error) {
+func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string, circuitName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"circuitName":       url.QueryEscape(circuitName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -152,7 +155,7 @@ func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +169,7 @@ func (client ExpressRouteCircuitsClient) DeletePreparer(resourceGroupName string
 func (client ExpressRouteCircuitsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/interfaces.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/interfaces.go
@@ -46,13 +46,15 @@ func NewInterfacesClientWithBaseURI(baseURI string, subscriptionID string) Inter
 }
 
 // CreateOrUpdate the Put NetworkInterface operation creates/updates a
-// networkInterface
+// networkInterface This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. networkInterfaceName
 // is the name of the network interface. parameters is parameters supplied to
 // the create/update NetworkInterface operation
-func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkInterfaceName string, parameters Interface) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkInterfaceName, parameters)
+func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkInterfaceName string, parameters Interface, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkInterfaceName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -72,7 +74,7 @@ func (client InterfacesClient) CreateOrUpdate(resourceGroupName string, networkI
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, networkInterfaceName string, parameters Interface) (*http.Request, error) {
+func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, networkInterfaceName string, parameters Interface, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkInterfaceName": url.QueryEscape(networkInterfaceName),
 		"resourceGroupName":    url.QueryEscape(resourceGroupName),
@@ -83,7 +85,7 @@ func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, 
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -98,8 +100,7 @@ func (client InterfacesClient) CreateOrUpdatePreparer(resourceGroupName string, 
 func (client InterfacesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -115,12 +116,14 @@ func (client InterfacesClient) CreateOrUpdateResponder(resp *http.Response) (res
 }
 
 // Delete the delete netwokInterface operation deletes the specified
-// netwokInterface.
+// netwokInterface. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. networkInterfaceName
 // is the name of the network interface.
-func (client InterfacesClient) Delete(resourceGroupName string, networkInterfaceName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkInterfaceName)
+func (client InterfacesClient) Delete(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkInterfaceName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/InterfacesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -140,7 +143,7 @@ func (client InterfacesClient) Delete(resourceGroupName string, networkInterface
 }
 
 // DeletePreparer prepares the Delete request.
-func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkInterfaceName string) (*http.Request, error) {
+func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkInterfaceName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkInterfaceName": url.QueryEscape(networkInterfaceName),
 		"resourceGroupName":    url.QueryEscape(resourceGroupName),
@@ -151,7 +154,7 @@ func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkI
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -165,8 +168,7 @@ func (client InterfacesClient) DeletePreparer(resourceGroupName string, networkI
 func (client InterfacesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/loadbalancers.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/loadbalancers.go
@@ -46,13 +46,16 @@ func NewLoadBalancersClientWithBaseURI(baseURI string, subscriptionID string) Lo
 	return LoadBalancersClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// CreateOrUpdate the Put LoadBalancer operation creates/updates a LoadBalancer
+// CreateOrUpdate the Put LoadBalancer operation creates/updates a
+// LoadBalancer This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. loadBalancerName is
 // the name of the loadBalancer. parameters is parameters supplied to the
 // create/delete LoadBalancer operation
-func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, loadBalancerName, parameters)
+func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadBalancerName string, parameters LoadBalancer, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, loadBalancerName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -72,7 +75,7 @@ func (client LoadBalancersClient) CreateOrUpdate(resourceGroupName string, loadB
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*http.Request, error) {
+func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName string, loadBalancerName string, parameters LoadBalancer, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"loadBalancerName":  url.QueryEscape(loadBalancerName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -83,7 +86,7 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -98,8 +101,7 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(resourceGroupName strin
 func (client LoadBalancersClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -114,12 +116,15 @@ func (client LoadBalancersClient) CreateOrUpdateResponder(resp *http.Response) (
 	return
 }
 
-// Delete the delete loadbalancer operation deletes the specified loadbalancer.
+// Delete the delete loadbalancer operation deletes the specified
+// loadbalancer. This method may poll for completion. Polling can be canceled
+// by passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. loadBalancerName is
 // the name of the loadBalancer.
-func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, loadBalancerName)
+func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, loadBalancerName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LoadBalancersClient", "Delete", nil, "Failure preparing request")
 	}
@@ -139,7 +144,7 @@ func (client LoadBalancersClient) Delete(resourceGroupName string, loadBalancerN
 }
 
 // DeletePreparer prepares the Delete request.
-func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadBalancerName string) (*http.Request, error) {
+func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadBalancerName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"loadBalancerName":  url.QueryEscape(loadBalancerName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -150,7 +155,7 @@ func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadB
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -164,8 +169,7 @@ func (client LoadBalancersClient) DeletePreparer(resourceGroupName string, loadB
 func (client LoadBalancersClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/localnetworkgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/localnetworkgateways.go
@@ -48,14 +48,16 @@ func NewLocalNetworkGatewaysClientWithBaseURI(baseURI string, subscriptionID str
 
 // CreateOrUpdate the Put LocalNetworkGateway operation creates/updates a
 // local network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // localNetworkGatewayName is the name of the local network gateway.
 // parameters is parameters supplied to the Begin Create or update Local
 // Network Gateway operation through Network resource provider.
-func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, localNetworkGatewayName, parameters)
+func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, localNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -75,7 +77,7 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*http.Request, error) {
+func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"localNetworkGatewayName": url.QueryEscape(localNetworkGatewayName),
 		"resourceGroupName":       url.QueryEscape(resourceGroupName),
@@ -86,7 +88,7 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupNam
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -101,8 +103,7 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupNam
 func (client LocalNetworkGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -118,12 +119,15 @@ func (client LocalNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Resp
 }
 
 // Delete the Delete LocalNetworkGateway operation deletes the specifed local
-// network Gateway through Network resource provider.
+// network Gateway through Network resource provider. This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // localNetworkGatewayName is the name of the local network gateway.
-func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localNetworkGatewayName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, localNetworkGatewayName)
+func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localNetworkGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, localNetworkGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/LocalNetworkGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -143,7 +147,7 @@ func (client LocalNetworkGatewaysClient) Delete(resourceGroupName string, localN
 }
 
 // DeletePreparer prepares the Delete request.
-func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string, localNetworkGatewayName string) (*http.Request, error) {
+func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string, localNetworkGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"localNetworkGatewayName": url.QueryEscape(localNetworkGatewayName),
 		"resourceGroupName":       url.QueryEscape(resourceGroupName),
@@ -154,7 +158,7 @@ func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -168,8 +172,7 @@ func (client LocalNetworkGatewaysClient) DeletePreparer(resourceGroupName string
 func (client LocalNetworkGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/publicipaddresses.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/publicipaddresses.go
@@ -47,13 +47,15 @@ func NewPublicIPAddressesClientWithBaseURI(baseURI string, subscriptionID string
 }
 
 // CreateOrUpdate the Put PublicIPAddress operation creates/updates a
-// stable/dynamic PublicIP address
+// stable/dynamic PublicIP address This method may poll for completion.
+// Polling can be canceled by passing the cancel channel argument. The
+// channel will be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. publicIPAddressName is
 // the name of the publicIpAddress. parameters is parameters supplied to the
 // create/update PublicIPAddress operation
-func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, publicIPAddressName, parameters)
+func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, publicIPAddressName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -73,7 +75,7 @@ func (client PublicIPAddressesClient) CreateOrUpdate(resourceGroupName string, p
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*http.Request, error) {
+func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"publicIpAddressName": url.QueryEscape(publicIPAddressName),
 		"resourceGroupName":   url.QueryEscape(resourceGroupName),
@@ -84,7 +86,7 @@ func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName s
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,8 +101,7 @@ func (client PublicIPAddressesClient) CreateOrUpdatePreparer(resourceGroupName s
 func (client PublicIPAddressesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -116,12 +117,14 @@ func (client PublicIPAddressesClient) CreateOrUpdateResponder(resp *http.Respons
 }
 
 // Delete the delete publicIpAddress operation deletes the specified
-// publicIpAddress.
+// publicIpAddress. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. publicIPAddressName is
 // the name of the subnet.
-func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPAddressName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, publicIPAddressName)
+func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPAddressName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, publicIPAddressName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/PublicIPAddressesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -141,7 +144,7 @@ func (client PublicIPAddressesClient) Delete(resourceGroupName string, publicIPA
 }
 
 // DeletePreparer prepares the Delete request.
-func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, publicIPAddressName string) (*http.Request, error) {
+func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, publicIPAddressName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"publicIpAddressName": url.QueryEscape(publicIPAddressName),
 		"resourceGroupName":   url.QueryEscape(resourceGroupName),
@@ -152,7 +155,7 @@ func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, p
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +169,7 @@ func (client PublicIPAddressesClient) DeletePreparer(resourceGroupName string, p
 func (client PublicIPAddressesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routes.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routes.go
@@ -45,13 +45,15 @@ func NewRoutesClientWithBaseURI(baseURI string, subscriptionID string) RoutesCli
 }
 
 // CreateOrUpdate the Put route operation creates/updates a route in the
-// specified route table
+// specified route table This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. routeName is the name of the route.
 // routeParameters is parameters supplied to the create/update routeoperation
-func (client RoutesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, routeName, routeParameters)
+func (client RoutesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, routeName string, routeParameters Route, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, routeName, routeParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -71,7 +73,7 @@ func (client RoutesClient) CreateOrUpdate(resourceGroupName string, routeTableNa
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*http.Request, error) {
+func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, routeName string, routeParameters Route, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeName":         url.QueryEscape(routeName),
@@ -83,7 +85,7 @@ func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, rout
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -98,8 +100,7 @@ func (client RoutesClient) CreateOrUpdatePreparer(resourceGroupName string, rout
 func (client RoutesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -115,12 +116,14 @@ func (client RoutesClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete the delete route operation deletes the specified route from a route
-// table.
+// table. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. routeName is the name of the route.
-func (client RoutesClient) Delete(resourceGroupName string, routeTableName string, routeName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, routeTableName, routeName)
+func (client RoutesClient) Delete(resourceGroupName string, routeTableName string, routeName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, routeTableName, routeName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RoutesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -140,7 +143,7 @@ func (client RoutesClient) Delete(resourceGroupName string, routeTableName strin
 }
 
 // DeletePreparer prepares the Delete request.
-func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableName string, routeName string) (*http.Request, error) {
+func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableName string, routeName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeName":         url.QueryEscape(routeName),
@@ -152,7 +155,7 @@ func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableNa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +169,7 @@ func (client RoutesClient) DeletePreparer(resourceGroupName string, routeTableNa
 func (client RoutesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routetables.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/routetables.go
@@ -46,13 +46,15 @@ func NewRouteTablesClientWithBaseURI(baseURI string, subscriptionID string) Rout
 }
 
 // CreateOrUpdate the Put RouteTable operation creates/updates a route tablein
-// the specified resource group.
+// the specified resource group. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table. parameters is parameters supplied to the
 // create/update Route Table operation
-func (client RouteTablesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, parameters RouteTable) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, parameters)
+func (client RouteTablesClient) CreateOrUpdate(resourceGroupName string, routeTableName string, parameters RouteTable, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, routeTableName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -72,7 +74,7 @@ func (client RouteTablesClient) CreateOrUpdate(resourceGroupName string, routeTa
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, parameters RouteTable) (*http.Request, error) {
+func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string, routeTableName string, parameters RouteTable, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeTableName":    url.QueryEscape(routeTableName),
@@ -83,7 +85,7 @@ func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -98,8 +100,7 @@ func (client RouteTablesClient) CreateOrUpdatePreparer(resourceGroupName string,
 func (client RouteTablesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -115,11 +116,14 @@ func (client RouteTablesClient) CreateOrUpdateResponder(resp *http.Response) (re
 }
 
 // Delete the Delete RouteTable operation deletes the specifed Route Table
+// This method may poll for completion. Polling can be canceled by passing
+// the cancel channel argument. The channel will be used to cancel polling
+// and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. routeTableName is the
 // name of the route table.
-func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, routeTableName)
+func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, routeTableName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/RouteTablesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -139,7 +143,7 @@ func (client RouteTablesClient) Delete(resourceGroupName string, routeTableName 
 }
 
 // DeletePreparer prepares the Delete request.
-func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTableName string) (*http.Request, error) {
+func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTableName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"routeTableName":    url.QueryEscape(routeTableName),
@@ -150,7 +154,7 @@ func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTa
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -164,8 +168,7 @@ func (client RouteTablesClient) DeletePreparer(resourceGroupName string, routeTa
 func (client RouteTablesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securitygroups.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securitygroups.go
@@ -47,14 +47,17 @@ func NewSecurityGroupsClientWithBaseURI(baseURI string, subscriptionID string) S
 }
 
 // CreateOrUpdate the Put NetworkSecurityGroup operation creates/updates a
-// network security groupin the specified resource group.
+// network security groupin the specified resource group. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // parameters is parameters supplied to the create/update Network Security
 // Group operation
-func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, parameters)
+func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -74,7 +77,7 @@ func (client SecurityGroupsClient) CreateOrUpdate(resourceGroupName string, netw
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup) (*http.Request, error) {
+func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, parameters SecurityGroup, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -85,7 +88,7 @@ func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName stri
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -100,8 +103,7 @@ func (client SecurityGroupsClient) CreateOrUpdatePreparer(resourceGroupName stri
 func (client SecurityGroupsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -117,12 +119,14 @@ func (client SecurityGroupsClient) CreateOrUpdateResponder(resp *http.Response) 
 }
 
 // Delete the Delete NetworkSecurityGroup operation deletes the specifed
-// network security group
+// network security group This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
-func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecurityGroupName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName)
+func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecurityGroupName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityGroupsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -142,7 +146,7 @@ func (client SecurityGroupsClient) Delete(resourceGroupName string, networkSecur
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string) (*http.Request, error) {
+func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -153,7 +157,7 @@ func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, netw
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -167,8 +171,7 @@ func (client SecurityGroupsClient) DeletePreparer(resourceGroupName string, netw
 func (client SecurityGroupsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securityrules.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/securityrules.go
@@ -47,15 +47,18 @@ func NewSecurityRulesClientWithBaseURI(baseURI string, subscriptionID string) Se
 }
 
 // CreateOrUpdate the Put network security rule operation creates/updates a
-// security rule in the specified network security group
+// security rule in the specified network security group This method may poll
+// for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // securityRuleName is the name of the security rule. securityRuleParameters
 // is parameters supplied to the create/update network security rule
 // operation
-func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters)
+func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -75,7 +78,7 @@ func (client SecurityRulesClient) CreateOrUpdate(resourceGroupName string, netwo
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*http.Request, error) {
+func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -87,7 +90,7 @@ func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -102,8 +105,7 @@ func (client SecurityRulesClient) CreateOrUpdatePreparer(resourceGroupName strin
 func (client SecurityRulesClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -119,13 +121,15 @@ func (client SecurityRulesClient) CreateOrUpdateResponder(resp *http.Response) (
 }
 
 // Delete the delete network security rule operation deletes the specified
-// network security rule.
+// network security rule. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // networkSecurityGroupName is the name of the network security group.
 // securityRuleName is the name of the security rule.
-func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName)
+func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, networkSecurityGroupName, securityRuleName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SecurityRulesClient", "Delete", nil, "Failure preparing request")
 	}
@@ -145,7 +149,7 @@ func (client SecurityRulesClient) Delete(resourceGroupName string, networkSecuri
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*http.Request, error) {
+func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, networkSecurityGroupName string, securityRuleName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"networkSecurityGroupName": url.QueryEscape(networkSecurityGroupName),
 		"resourceGroupName":        url.QueryEscape(resourceGroupName),
@@ -157,7 +161,7 @@ func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, netwo
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -171,8 +175,7 @@ func (client SecurityRulesClient) DeletePreparer(resourceGroupName string, netwo
 func (client SecurityRulesClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/subnets.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/subnets.go
@@ -45,14 +45,16 @@ func NewSubnetsClientWithBaseURI(baseURI string, subscriptionID string) SubnetsC
 }
 
 // CreateOrUpdate the Put Subnet operation creates/updates a subnet in
-// thespecified virtual network
+// thespecified virtual network This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. subnetName is the name of the subnet.
 // subnetParameters is parameters supplied to the create/update Subnet
 // operation
-func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
+func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, subnetName, subnetParameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -72,7 +74,7 @@ func (client SubnetsClient) CreateOrUpdate(resourceGroupName string, virtualNetw
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*http.Request, error) {
+func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subnetName":         url.QueryEscape(subnetName),
@@ -84,7 +86,7 @@ func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, vir
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,8 +101,7 @@ func (client SubnetsClient) CreateOrUpdatePreparer(resourceGroupName string, vir
 func (client SubnetsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -115,12 +116,15 @@ func (client SubnetsClient) CreateOrUpdateResponder(resp *http.Response) (result
 	return
 }
 
-// Delete the delete subnet operation deletes the specified subnet.
+// Delete the delete subnet operation deletes the specified subnet. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. subnetName is the name of the subnet.
-func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName string, subnetName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, subnetName)
+func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName string, subnetName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, subnetName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/SubnetsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -140,7 +144,7 @@ func (client SubnetsClient) Delete(resourceGroupName string, virtualNetworkName 
 }
 
 // DeletePreparer prepares the Delete request.
-func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, subnetName string) (*http.Request, error) {
+func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, subnetName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subnetName":         url.QueryEscape(subnetName),
@@ -152,7 +156,7 @@ func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetw
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +170,7 @@ func (client SubnetsClient) DeletePreparer(resourceGroupName string, virtualNetw
 func (client SubnetsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "6"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgatewayconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgatewayconnections.go
@@ -48,15 +48,18 @@ func NewVirtualNetworkGatewayConnectionsClientWithBaseURI(baseURI string, subscr
 
 // CreateOrUpdate the Put VirtualNetworkGatewayConnection operation
 // creates/updates a virtual network gateway connection in the specified
-// resource group through Network resource provider.
+// resource group through Network resource provider. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the name of the virtual network
 // gateway conenction. parameters is parameters supplied to the Begin Create
 // or update Virtual Network Gateway connection operation through Network
 // resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -76,7 +79,7 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(resourceGrou
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -87,7 +90,7 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(reso
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -102,8 +105,7 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdatePreparer(reso
 func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -120,13 +122,15 @@ func (client VirtualNetworkGatewayConnectionsClient) CreateOrUpdateResponder(res
 
 // Delete the Delete VirtualNetworkGatewayConnection operation deletes the
 // specifed virtual network Gateway connection through Network resource
-// provider.
+// provider. This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the name of the virtual network
 // gateway connection.
-func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName string, virtualNetworkGatewayConnectionName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName string, virtualNetworkGatewayConnectionName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayConnectionName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -146,7 +150,7 @@ func (client VirtualNetworkGatewayConnectionsClient) Delete(resourceGroupName st
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -157,7 +161,7 @@ func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGrou
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -171,8 +175,7 @@ func (client VirtualNetworkGatewayConnectionsClient) DeletePreparer(resourceGrou
 func (client VirtualNetworkGatewayConnectionsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -411,15 +414,17 @@ func (client VirtualNetworkGatewayConnectionsClient) ListNextResults(lastResults
 // ResetSharedKey the VirtualNetworkGatewayConnectionResetSharedKey operation
 // resets the virtual network gateway connection shared key for passed
 // virtual network gateway connection in the specified resource group through
-// Network resource provider.
+// Network resource provider. This method may poll for completion. Polling
+// can be canceled by passing the cancel channel argument. The channel will
+// be used to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the virtual network gateway
 // connection reset shared key Name. parameters is parameters supplied to the
 // Begin Reset Virtual Network Gateway connection shared key operation
 // through Network resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (result autorest.Response, err error) {
-	req, err := client.ResetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.ResetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "ResetSharedKey", nil, "Failure preparing request")
 	}
@@ -439,7 +444,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKey(resourceGrou
 }
 
 // ResetSharedKeyPreparer prepares the ResetSharedKey request.
-func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -450,7 +455,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(reso
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -465,8 +470,7 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyPreparer(reso
 func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeySender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // ResetSharedKeyResponder handles the response to the ResetSharedKey request. The method always
@@ -484,15 +488,17 @@ func (client VirtualNetworkGatewayConnectionsClient) ResetSharedKeyResponder(res
 // SetSharedKey the Put VirtualNetworkGatewayConnectionSharedKey operation
 // sets the virtual network gateway connection shared key for passed virtual
 // network gateway connection in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayConnectionName is the virtual network gateway
 // connection name. parameters is parameters supplied to the Begin Set
 // Virtual Network Gateway conection Shared key operation throughNetwork
 // resource provider.
-func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (result autorest.Response, err error) {
-	req, err := client.SetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.SetSharedKeyPreparer(resourceGroupName, virtualNetworkGatewayConnectionName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewayConnectionsClient", "SetSharedKey", nil, "Failure preparing request")
 	}
@@ -512,7 +518,7 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKey(resourceGroupN
 }
 
 // SetSharedKeyPreparer prepares the SetSharedKey request.
-func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*http.Request, error) {
+func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":                   url.QueryEscape(resourceGroupName),
 		"subscriptionId":                      url.QueryEscape(client.SubscriptionID),
@@ -523,7 +529,7 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resour
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -538,8 +544,7 @@ func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeyPreparer(resour
 func (client VirtualNetworkGatewayConnectionsClient) SetSharedKeySender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // SetSharedKeyResponder handles the response to the SetSharedKey request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgateways.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworkgateways.go
@@ -48,14 +48,16 @@ func NewVirtualNetworkGatewaysClientWithBaseURI(baseURI string, subscriptionID s
 
 // CreateOrUpdate the Put VirtualNetworkGateway operation creates/updates a
 // virtual network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
 // parameters is parameters supplied to the Begin Create or update Virtual
 // Network Gateway operation through Network resource provider.
-func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -75,7 +77,7 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdate(resourceGroupName stri
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -86,7 +88,7 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupN
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -101,8 +103,7 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdatePreparer(resourceGroupN
 func (client VirtualNetworkGatewaysClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -118,12 +119,15 @@ func (client VirtualNetworkGatewaysClient) CreateOrUpdateResponder(resp *http.Re
 }
 
 // Delete the Delete VirtualNetworkGateway operation deletes the specifed
-// virtual network Gateway through Network resource provider.
+// virtual network Gateway through Network resource provider. This method may
+// poll for completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
-func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virtualNetworkGatewayName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayName)
+func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virtualNetworkGatewayName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkGatewayName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Delete", nil, "Failure preparing request")
 	}
@@ -143,7 +147,7 @@ func (client VirtualNetworkGatewaysClient) Delete(resourceGroupName string, virt
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayName string) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName string, virtualNetworkGatewayName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -154,7 +158,7 @@ func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName stri
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -168,8 +172,7 @@ func (client VirtualNetworkGatewaysClient) DeletePreparer(resourceGroupName stri
 func (client VirtualNetworkGatewaysClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always
@@ -407,14 +410,16 @@ func (client VirtualNetworkGatewaysClient) ListNextResults(lastResults VirtualNe
 
 // Reset the Reset VirtualNetworkGateway operation resets the primary of the
 // virtual network gateway in the specified resource group through Network
-// resource provider.
+// resource provider. This method may poll for completion. Polling can be
+// canceled by passing the cancel channel argument. The channel will be used
+// to cancel polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group.
 // virtualNetworkGatewayName is the name of the virtual network gateway.
 // parameters is parameters supplied to the Begin Reset Virtual Network
 // Gateway operation through Network resource provider.
-func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (result autorest.Response, err error) {
-	req, err := client.ResetPreparer(resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.ResetPreparer(resourceGroupName, virtualNetworkGatewayName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworkGatewaysClient", "Reset", nil, "Failure preparing request")
 	}
@@ -434,7 +439,7 @@ func (client VirtualNetworkGatewaysClient) Reset(resourceGroupName string, virtu
 }
 
 // ResetPreparer prepares the Reset request.
-func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*http.Request, error) {
+func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":         url.QueryEscape(resourceGroupName),
 		"subscriptionId":            url.QueryEscape(client.SubscriptionID),
@@ -445,7 +450,7 @@ func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName strin
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -460,8 +465,7 @@ func (client VirtualNetworkGatewaysClient) ResetPreparer(resourceGroupName strin
 func (client VirtualNetworkGatewaysClient) ResetSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // ResetResponder handles the response to the Reset request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworks.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/virtualnetworks.go
@@ -47,13 +47,16 @@ func NewVirtualNetworksClientWithBaseURI(baseURI string, subscriptionID string) 
 }
 
 // CreateOrUpdate the Put VirtualNetwork operation creates/updates a virtual
-// network in the specified resource group.
+// network in the specified resource group. This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network. parameters is parameters supplied to the
 // create/update Virtual Network operation
-func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, parameters)
+func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, virtualNetworkName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -73,7 +76,7 @@ func (client VirtualNetworksClient) CreateOrUpdate(resourceGroupName string, vir
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*http.Request, error) {
+func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subscriptionId":     url.QueryEscape(client.SubscriptionID),
@@ -84,7 +87,7 @@ func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName str
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -99,8 +102,7 @@ func (client VirtualNetworksClient) CreateOrUpdatePreparer(resourceGroupName str
 func (client VirtualNetworksClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -116,12 +118,14 @@ func (client VirtualNetworksClient) CreateOrUpdateResponder(resp *http.Response)
 }
 
 // Delete the Delete VirtualNetwork operation deletes the specifed virtual
-// network
+// network This method may poll for completion. Polling can be canceled by
+// passing the cancel channel argument. The channel will be used to cancel
+// polling and any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. virtualNetworkName is
 // the name of the virtual network.
-func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetworkName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName)
+func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetworkName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, virtualNetworkName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "network/VirtualNetworksClient", "Delete", nil, "Failure preparing request")
 	}
@@ -141,7 +145,7 @@ func (client VirtualNetworksClient) Delete(resourceGroupName string, virtualNetw
 }
 
 // DeletePreparer prepares the Delete request.
-func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, virtualNetworkName string) (*http.Request, error) {
+func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, virtualNetworkName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName":  url.QueryEscape(resourceGroupName),
 		"subscriptionId":     url.QueryEscape(client.SubscriptionID),
@@ -152,7 +156,7 @@ func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, vir
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -166,8 +170,7 @@ func (client VirtualNetworksClient) DeletePreparer(resourceGroupName string, vir
 func (client VirtualNetworksClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deployments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/deployments.go
@@ -168,13 +168,16 @@ func (client DeploymentsClient) CheckExistenceResponder(resp *http.Response) (re
 	return
 }
 
-// CreateOrUpdate create a named template deployment using a template.
+// CreateOrUpdate create a named template deployment using a template. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment. parameters is
 // additional parameters supplied to the operation.
-func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploymentName string, parameters Deployment) (result autorest.Response, err error) {
-	req, err := client.CreateOrUpdatePreparer(resourceGroupName, deploymentName, parameters)
+func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploymentName string, parameters Deployment, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreateOrUpdatePreparer(resourceGroupName, deploymentName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "CreateOrUpdate", nil, "Failure preparing request")
 	}
@@ -194,7 +197,7 @@ func (client DeploymentsClient) CreateOrUpdate(resourceGroupName string, deploym
 }
 
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
-func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string, deploymentName string, parameters Deployment) (*http.Request, error) {
+func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string, deploymentName string, parameters Deployment, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"deploymentName":    url.QueryEscape(deploymentName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -205,7 +208,7 @@ func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string,
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -220,8 +223,7 @@ func (client DeploymentsClient) CreateOrUpdatePreparer(resourceGroupName string,
 func (client DeploymentsClient) CreateOrUpdateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
@@ -237,12 +239,15 @@ func (client DeploymentsClient) CreateOrUpdateResponder(resp *http.Response) (re
 }
 
 // Delete begin deleting deployment.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group. The name is case
 // insensitive. deploymentName is the name of the deployment to be deleted.
-func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName, deploymentName)
+func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, deploymentName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/DeploymentsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -262,7 +267,7 @@ func (client DeploymentsClient) Delete(resourceGroupName string, deploymentName 
 }
 
 // DeletePreparer prepares the Delete request.
-func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploymentName string) (*http.Request, error) {
+func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploymentName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"deploymentName":    url.QueryEscape(deploymentName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -273,7 +278,7 @@ func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploym
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -287,8 +292,7 @@ func (client DeploymentsClient) DeletePreparer(resourceGroupName string, deploym
 func (client DeploymentsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/groups.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/groups.go
@@ -168,12 +168,15 @@ func (client GroupsClient) CreateOrUpdateResponder(resp *http.Response) (result 
 }
 
 // Delete begin deleting resource group.To determine whether the operation has
-// finished processing the request, call GetLongRunningOperationStatus.
+// finished processing the request, call GetLongRunningOperationStatus. This
+// method may poll for completion. Polling can be canceled by passing the
+// cancel channel argument. The channel will be used to cancel polling and
+// any outstanding HTTP requests.
 //
 // resourceGroupName is the name of the resource group to be deleted. The name
 // is case insensitive.
-func (client GroupsClient) Delete(resourceGroupName string) (result autorest.Response, err error) {
-	req, err := client.DeletePreparer(resourceGroupName)
+func (client GroupsClient) Delete(resourceGroupName string, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.DeletePreparer(resourceGroupName, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "resources/GroupsClient", "Delete", nil, "Failure preparing request")
 	}
@@ -193,7 +196,7 @@ func (client GroupsClient) Delete(resourceGroupName string) (result autorest.Res
 }
 
 // DeletePreparer prepares the Delete request.
-func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Request, error) {
+func (client GroupsClient) DeletePreparer(resourceGroupName string, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
 		"subscriptionId":    url.QueryEscape(client.SubscriptionID),
@@ -203,7 +206,7 @@ func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Reque
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -217,8 +220,7 @@ func (client GroupsClient) DeletePreparer(resourceGroupName string) (*http.Reque
 func (client GroupsClient) DeleteSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // DeleteResponder handles the response to the Delete request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "6"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "6"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/accounts.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/accounts.go
@@ -109,15 +109,18 @@ func (client AccountsClient) CheckNameAvailabilityResponder(resp *http.Response)
 // parameters. Existing accounts cannot be updated with this API and should
 // instead use the Update Storage Account API. If an account is already
 // created and subsequent PUT request is issued with exact same set of
-// properties, then HTTP 200 would be returned.
+// properties, then HTTP 200 would be returned.  This method may poll for
+// completion. Polling can be canceled by passing the cancel channel
+// argument. The channel will be used to cancel polling and any outstanding
+// HTTP requests.
 //
 // resourceGroupName is the name of the resource group within the user's
 // subscription. accountName is the name of the storage account within the
 // specified resource group. Storage account names must be between 3 and 24
 // characters in length and use numbers and lower-case letters only.
 // parameters is the parameters to provide for the created account.
-func (client AccountsClient) Create(resourceGroupName string, accountName string, parameters AccountCreateParameters) (result autorest.Response, err error) {
-	req, err := client.CreatePreparer(resourceGroupName, accountName, parameters)
+func (client AccountsClient) Create(resourceGroupName string, accountName string, parameters AccountCreateParameters, cancel <-chan struct{}) (result autorest.Response, err error) {
+	req, err := client.CreatePreparer(resourceGroupName, accountName, parameters, cancel)
 	if err != nil {
 		return result, autorest.NewErrorWithError(err, "storage/AccountsClient", "Create", nil, "Failure preparing request")
 	}
@@ -137,7 +140,7 @@ func (client AccountsClient) Create(resourceGroupName string, accountName string
 }
 
 // CreatePreparer prepares the Create request.
-func (client AccountsClient) CreatePreparer(resourceGroupName string, accountName string, parameters AccountCreateParameters) (*http.Request, error) {
+func (client AccountsClient) CreatePreparer(resourceGroupName string, accountName string, parameters AccountCreateParameters, cancel <-chan struct{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"accountName":       url.QueryEscape(accountName),
 		"resourceGroupName": url.QueryEscape(resourceGroupName),
@@ -148,7 +151,7 @@ func (client AccountsClient) CreatePreparer(resourceGroupName string, accountNam
 		"api-version": APIVersion,
 	}
 
-	return autorest.Prepare(&http.Request{},
+	return autorest.Prepare(&http.Request{Cancel: cancel},
 		autorest.AsJSON(),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
@@ -163,8 +166,7 @@ func (client AccountsClient) CreatePreparer(resourceGroupName string, accountNam
 func (client AccountsClient) CreateSender(req *http.Request) (*http.Response, error) {
 	return autorest.SendWithSender(client,
 		req,
-		azure.DoPollForAsynchronous(autorest.DefaultPollingDuration,
-			autorest.DefaultPollingDelay))
+		azure.DoPollForAsynchronous(client.PollingDelay))
 }
 
 // CreateResponder handles the response to the Create request. The method always

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	major = "0"
-	minor = "6"
+	major = "2"
+	minor = "1"
 	patch = "0"
 	// Always begin a "tag" with a dash (as per http://semver.org)
 	tag             = "-beta"
 	semVerFormat    = "%s.%s.%s%s"
-	userAgentFormat = "Azure-SDK-for-Go/%s;Package arm/%s;API %s"
+	userAgentFormat = "Azure-SDK-for-Go/%s arm-%s/%s"
 )
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/client.go
@@ -37,6 +37,10 @@ const (
 // Client is the object that needs to be constructed to perform
 // operations on the storage account.
 type Client struct {
+	// HTTPClient is the http.Client used to initiate API
+	// requests.  If it is nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
 	accountName string
 	accountKey  []byte
 	useHTTPS    bool
@@ -318,7 +322,11 @@ func (c Client) exec(verb, url string, headers map[string]string, body io.Reader
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
-	httpClient := http.Client{}
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/async.go
@@ -1,8 +1,11 @@
 package azure
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -10,150 +13,263 @@ import (
 )
 
 const (
-	// HeaderAsyncOperation is the Azure header providing the URL from which to obtain the
-	// OperationResource for an asynchronous (aka long running) operation.
-	HeaderAsyncOperation = "Azure-AsyncOperation"
+	headerAsyncOperation = "Azure-AsyncOperation"
 )
 
 const (
-	// OperationCanceled says the underlying operation was canceled.
-	OperationCanceled string = "Canceled"
-	// OperationFailed says the underlying operation failed.
-	OperationFailed string = "Failed"
-	// OperationSucceeded says the underlying opertion succeeded.
-	OperationSucceeded string = "Succeeded"
+	methodDelete = "DELETE"
+	methodPatch  = "PATCH"
+	methodPost   = "POST"
+	methodPut    = "PUT"
+	methodGet    = "GET"
+
+	operationInProgress string = "InProgress"
+	operationCanceled   string = "Canceled"
+	operationFailed     string = "Failed"
+	operationSucceeded  string = "Succeeded"
 )
 
-// OperationError provides additional detail when an operation fails or is canceled.
-type OperationError struct {
-	// Code provides an invariant error code useful for troubleshooting, aggregration, and analysis.
-	Code string `json:"code"`
-	// Message indicates what error occurred and what can be done to address the issue.
-	Message string `json:"message"`
+// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
+// long-running operation. It will delay between requests for the duration specified in the
+// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
+// closing the optional channel on the http.Request.
+func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			resp, err = s.Do(r)
+			if err != nil {
+				return resp, err
+			}
+
+			ps := pollingState{}
+			for err == nil {
+				err = updatePollingState(resp, &ps)
+				if err != nil {
+					break
+				}
+				if ps.hasTerminated() {
+					if !ps.hasSucceeded() {
+						err = autorest.NewError("azure", "DoPollForAsynchronous", "Polling terminated with status '%s'", ps.state)
+					}
+					break
+				}
+
+				r, err = newPollingRequest(resp, ps)
+				if err != nil {
+					return resp, err
+				}
+
+				resp, err = autorest.SendWithSender(s, r,
+					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
+			}
+
+			return resp, err
+		})
+	}
 }
 
-// Error implements the error interface returnin a string containing the code and message.
-func (oe OperationError) Error() string {
-	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+func getAsyncOperation(resp *http.Response) string {
+	return resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
 }
 
-// OperationResource defines a resource describing the state of a long-running operation.
-type OperationResource struct {
-	// Id is the identifier used in a GET for the underlying resource.
-	ID string `json:"id"`
-	// Name matches the last segment of the Id field (typically system generated).
-	Name string `json:"name"`
-	// Status provides the state of the operation. Non-terminal states vary by resource;
-	Status string `json:"status"`
-	// Properties, on operation success, optionally contains per-service / per-resource values.
-	Properties map[string]interface{} `json:"properties"`
-	// Error provides additional detail if the operation is canceled or failed.
-	OperationError OperationError `json:"error"`
-	// StartTime optionally provides the time the operation started.
-	StartTime date.Time `json:"startTime"`
-	// EndTime optionally provides the time the operation completed.
-	EndTime date.Time `json:"endTime"`
-	// PercentComplete optionally provides the percent complete between 0 and 100.
-	PercentComplete float64 `json:"percentComplete"`
+func hasSucceeded(state string) bool {
+	return state == operationSucceeded
 }
 
-// HasSucceeded returns true if the operation has succeeded; false otherwise.
-func (or OperationResource) HasSucceeded() bool {
-	return or.Status == OperationSucceeded
-}
-
-// HasTerminated returns true if the operation has terminated; false otherwise.
-func (or OperationResource) HasTerminated() bool {
-	switch or.Status {
-	case OperationCanceled, OperationFailed, OperationSucceeded:
+func hasTerminated(state string) bool {
+	switch state {
+	case operationCanceled, operationFailed, operationSucceeded:
 		return true
 	default:
 		return false
 	}
 }
 
-// GetError returns an error if the operation was canceled or failed and nil otherwise.
-func (or OperationResource) GetError() error {
-	switch or.Status {
-	case OperationCanceled, OperationFailed:
-		return or.OperationError
-	default:
-		return nil
+type provisioningTracker interface {
+	state() string
+	hasSucceeded() bool
+	hasTerminated() bool
+}
+
+type operationError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (oe operationError) Error() string {
+	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+}
+
+type operationResource struct {
+	// Note:
+	// 	The specification states services should return the "id" field. However some return it as
+	// 	"operationId".
+	ID              string                 `json:"id"`
+	OperationID     string                 `json:"operationId"`
+	Name            string                 `json:"name"`
+	Status          string                 `json:"status"`
+	Properties      map[string]interface{} `json:"properties"`
+	OperationError  operationError         `json:"error"`
+	StartTime       date.Time              `json:"startTime"`
+	EndTime         date.Time              `json:"endTime"`
+	PercentComplete float64                `json:"percentComplete"`
+}
+
+func (or operationResource) state() string {
+	return or.Status
+}
+
+func (or operationResource) hasSucceeded() bool {
+	return hasSucceeded(or.state())
+}
+
+func (or operationResource) hasTerminated() bool {
+	return hasTerminated(or.state())
+}
+
+type provisioningProperties struct {
+	ProvisioningState string `json:"provisioningState"`
+}
+
+type provisioningStatus struct {
+	Properties provisioningProperties `json:"properties"`
+}
+
+func (ps provisioningStatus) state() string {
+	return ps.Properties.ProvisioningState
+}
+
+func (ps provisioningStatus) hasSucceeded() bool {
+	return hasSucceeded(ps.state())
+}
+
+func (ps provisioningStatus) hasTerminated() bool {
+	return hasTerminated(ps.state())
+}
+
+type pollingResponseFormat string
+
+const (
+	usesOperationResponse  pollingResponseFormat = "OperationResponse"
+	usesProvisioningStatus pollingResponseFormat = "ProvisioningStatus"
+	formatIsUnknown        pollingResponseFormat = ""
+)
+
+type pollingState struct {
+	responseFormat pollingResponseFormat
+	uri            string
+	state          string
+	code           string
+	message        string
+}
+
+func (ps pollingState) hasSucceeded() bool {
+	return hasSucceeded(ps.state)
+}
+
+func (ps pollingState) hasTerminated() bool {
+	return hasTerminated(ps.state)
+}
+
+//	updatePollingState maps the operation status -- retrieved from either a provisioningState
+// 	field, the status field of an OperationResource, or inferred from the HTTP status code --
+// 	into a well-known states. Since the process begins from the initial request, the state
+//	always comes from either a the provisioningState returned or is inferred from the HTTP
+//	status code. Subsequent requests will read an Azure OperationResource object if the
+//	service initially returned the Azure-AsyncOperation header. The responseFormat field notes
+//	the expected response format.
+func updatePollingState(resp *http.Response, ps *pollingState) error {
+	// Determine the response shape
+	// -- The first response will always be a provisioningStatus response; only the polling requests,
+	//    depending on the header returned, may be something otherwise.
+	var pt provisioningTracker
+	if ps.responseFormat == usesOperationResponse {
+		pt = &operationResource{}
+	} else {
+		pt = &provisioningStatus{}
 	}
-}
 
-// GetAsyncOperation retrieves the long-running URL from which to retrieve the OperationResource.
-func GetAsyncOperation(resp *http.Response) string {
-	return resp.Header.Get(http.CanonicalHeaderKey(HeaderAsyncOperation))
-}
+	// If this is the first request (that is, the polling response shape is unknown), determine how
+	// to poll and what to expect
+	if ps.responseFormat == formatIsUnknown {
+		req := resp.Request
+		if req == nil {
+			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
+		}
 
-// IsAsynchronousResponse returns true if the passed response indicates that the request will
-// complete asynchronously. Such responses have either an http.StatusCreated or an
-// http.StatusAccepted status code and provide the Azure-AsyncOperation header.
-func IsAsynchronousResponse(resp *http.Response) bool {
-	return autorest.ResponseHasStatusCode(resp, http.StatusCreated, http.StatusAccepted) &&
-		GetAsyncOperation(resp) != ""
-}
+		// Prefer the Azure-AsyncOperation header
+		ps.uri = getAsyncOperation(resp)
+		if ps.uri != "" {
+			ps.responseFormat = usesOperationResponse
+		} else {
+			ps.responseFormat = usesProvisioningStatus
+		}
 
-// NewOperationResourceRequest allocates and returns a new http.Request to retrieve the
-// OperationResource for an asynchronous operation.
-func NewOperationResourceRequest(resp *http.Response, cancel <-chan struct{}) (*http.Request, error) {
-	location := GetAsyncOperation(resp)
-	if location == "" {
-		return nil, autorest.NewErrorWithResponse("azure", "NewOperationResourceRequest", resp, "Azure-AsyncOperation header missing from response that requires polling")
+		// Else, use the Location header
+		if ps.uri == "" {
+			ps.uri = autorest.GetLocation(resp)
+		}
+
+		// Lastly, requests against an existing resource, use the last request URI
+		if ps.uri == "" {
+			m := strings.ToUpper(req.Method)
+			if m == methodPatch || m == methodPut || m == methodGet {
+				ps.uri = req.URL.String()
+			}
+		}
+
+		if ps.uri == "" {
+			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", req.Method, req.RequestURI)
+		}
 	}
 
-	req, err := autorest.Prepare(&http.Request{Cancel: cancel},
-		autorest.AsGet(),
-		autorest.WithBaseURL(location))
+	// Read and interpret the response (saving the Body in case no polling is necessary)
+	b := &bytes.Buffer{}
+	err := autorest.Respond(resp,
+		autorest.ByCopying(b),
+		autorest.ByUnmarshallingJSON(pt),
+		autorest.ByClosing())
+	resp.Body = ioutil.NopCloser(b)
 	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "NewOperationResourceRequest", nil, "Failure creating poll request to %s", location)
+		return err
 	}
 
-	return req, nil
+	// Interpret the results
+	// -- Terminal states apply regardless
+	// -- Unknown states are per-service inprogress states
+	// -- Otherwise, infer state from HTTP status code
+	if pt.hasTerminated() {
+		ps.state = pt.state()
+	} else if pt.state() != "" {
+		ps.state = operationInProgress
+	} else {
+		switch resp.StatusCode {
+		case http.StatusAccepted:
+			ps.state = operationInProgress
+
+		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
+			ps.state = operationSucceeded
+
+		default:
+			ps.state = operationFailed
+		}
+	}
+
+	return nil
 }
 
-// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
-// long-running operation. It will poll until the time passed is equal to or greater than
-// the supplied duration. It will delay between requests for the duration specified in the
-// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
-// closing the optional channel on the http.Request.
-func DoPollForAsynchronous(duration time.Duration, delay time.Duration) autorest.SendDecorator {
-	return func(s autorest.Sender) autorest.Sender {
-		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
-			resp, err = s.Do(r)
-			if err != nil || !IsAsynchronousResponse(resp) {
-				return resp, err
-			}
-
-			r, err = NewOperationResourceRequest(resp, r.Cancel)
-			if err != nil {
-				return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred creating OperationResource request")
-			}
-
-			or := &OperationResource{}
-			for err == nil && !or.HasTerminated() {
-				autorest.Respond(resp,
-					autorest.ByClosing())
-
-				resp, err = autorest.SendWithSender(s, r,
-					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
-				if err != nil {
-					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred retrieving OperationResource")
-				}
-
-				err = autorest.Respond(resp,
-					autorest.ByUnmarshallingJSON(or))
-				if err != nil {
-					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred unmarshalling an OperationResource")
-				}
-			}
-
-			if err == nil && or.HasTerminated() {
-				err = or.GetError()
-			}
-
-			return resp, err
-		})
+func newPollingRequest(resp *http.Response, ps pollingState) (*http.Request, error) {
+	req := resp.Request
+	if req == nil {
+		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
 	}
+
+	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+		autorest.AsGet(),
+		autorest.WithBaseURL(ps.uri))
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.uri)
+	}
+
+	return reqPoll, nil
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -103,6 +103,12 @@ type Client struct {
 	RequestInspector  PrepareDecorator
 	ResponseInspector RespondDecorator
 
+	// PollingDelay sets the polling frequency used in absence of a Retry-After HTTP header
+	PollingDelay time.Duration
+
+	// PollingDuration sets the maximum polling time after which an error is returned.
+	PollingDuration time.Duration
+
 	// UserAgent, if not empty, will be set as the HTTP User-Agent header on all requests sent
 	// through the Do method.
 	UserAgent string
@@ -111,7 +117,7 @@ type Client struct {
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
 // string.
 func NewClientWithUserAgent(ua string) Client {
-	c := Client{}
+	c := Client{PollingDelay: DefaultPollingDelay, PollingDuration: DefaultPollingDuration}
 	c.UserAgent = ua
 	return c
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/date/date.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/date.go
@@ -7,17 +7,14 @@ package date
 
 import (
 	"fmt"
-	"github.com/Azure/go-autorest/autorest"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"time"
 )
 
 const (
-	rfc3339FullDate = "2006-01-02"
-	dateFormat      = "%4d-%02d-%02d"
-	jsonFormat      = `"%4d-%02d-%02d"`
+	fullDate     = "2006-01-02"
+	fullDateJSON = `"2006-01-02"`
+	dateFormat   = "%04d-%02d-%02d"
+	jsonFormat   = `"%04d-%02d-%02d"`
 )
 
 // Date defines a type similar to time.Time but assumes a layout of RFC3339 full-date (i.e.,
@@ -28,31 +25,12 @@ type Date struct {
 
 // ParseDate create a new Date from the passed string.
 func ParseDate(date string) (d Date, err error) {
-	d = Date{}
-	d.Time, err = time.Parse(rfc3339FullDate, date)
-	return d, err
+	return parseDate(date, fullDate)
 }
 
-func readDate(r io.Reader) (Date, error) {
-	b, err := ioutil.ReadAll(r)
-	if err == nil {
-		return ParseDate(string(b))
-	}
-	return Date{}, err
-}
-
-// ByUnmarshallingDate returns a RespondDecorator that decodes the http.Response Body into a Date
-// pointed to by d.
-func ByUnmarshallingDate(d *Date) autorest.RespondDecorator {
-	return func(r autorest.Responder) autorest.Responder {
-		return autorest.ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*d, err = readDate(resp.Body)
-			}
-			return err
-		})
-	}
+func parseDate(date string, format string) (Date, error) {
+	d, err := time.Parse(format, date)
+	return Date{Time: d}, err
 }
 
 // MarshalBinary preserves the Date as a byte array conforming to RFC3339 full-date (i.e.,
@@ -76,14 +54,8 @@ func (d Date) MarshalJSON() (json []byte, err error) {
 // UnmarshalJSON reconstitutes the Date from a JSON string conforming to RFC3339 full-date (i.e.,
 // 2006-01-02).
 func (d *Date) UnmarshalJSON(data []byte) (err error) {
-	if data[0] == '"' {
-		data = data[1 : len(data)-1]
-	}
-	d.Time, err = time.Parse(rfc3339FullDate, string(data))
-	if err != nil {
-		return err
-	}
-	return nil
+	d.Time, err = time.Parse(fullDateJSON, string(data))
+	return err
 }
 
 // MarshalText preserves the Date as a byte array conforming to RFC3339 full-date (i.e.,
@@ -95,11 +67,8 @@ func (d Date) MarshalText() (text []byte, err error) {
 // UnmarshalText reconstitutes a Date saved as a byte array conforming to RFC3339 full-date (i.e.,
 // 2006-01-02).
 func (d *Date) UnmarshalText(data []byte) (err error) {
-	d.Time, err = time.Parse(rfc3339FullDate, string(data))
-	if err != nil {
-		return err
-	}
-	return nil
+	d.Time, err = time.Parse(fullDate, string(data))
+	return err
 }
 
 // String returns the Date formatted as an RFC3339 full-date string (i.e., 2006-01-02).

--- a/vendor/github.com/Azure/go-autorest/autorest/date/time.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/time.go
@@ -1,11 +1,12 @@
 package date
 
 import (
-	"github.com/Azure/go-autorest/autorest"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"time"
+)
+
+const (
+	rfc3339JSON = `"` + time.RFC3339Nano + `"`
+	rfc3339     = time.RFC3339Nano
 )
 
 // Time defines a type similar to time.Time but assumes a layout of RFC3339 date-time (i.e.,
@@ -14,76 +15,49 @@ type Time struct {
 	time.Time
 }
 
-// ParseTime creates a new Time from the passed string.
-func ParseTime(date string) (d Time, err error) {
-	d = Time{}
-	d.Time, err = time.Parse(time.RFC3339, date)
-	return d, err
-}
-
-func readTime(r io.Reader) (Time, error) {
-	b, err := ioutil.ReadAll(r)
-	if err == nil {
-		return ParseTime(string(b))
-	}
-	return Time{}, err
-}
-
-// ByUnmarshallingTime returns a RespondDecorator that decodes the http.Response Body into a Time
-// pointed to by t.
-func ByUnmarshallingTime(t *Time) autorest.RespondDecorator {
-	return func(r autorest.Responder) autorest.Responder {
-		return autorest.ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*t, err = readTime(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
 // MarshalBinary preserves the Time as a byte array conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalBinary() ([]byte, error) {
-	return d.Time.MarshalText()
+func (t Time) MarshalBinary() ([]byte, error) {
+	return t.Time.MarshalText()
 }
 
 // UnmarshalBinary reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalBinary(data []byte) error {
-	return d.Time.UnmarshalText(data)
+func (t *Time) UnmarshalBinary(data []byte) error {
+	return t.UnmarshalText(data)
 }
 
 // MarshalJSON preserves the Time as a JSON string conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalJSON() (json []byte, err error) {
-	return d.Time.MarshalJSON()
+func (t Time) MarshalJSON() (json []byte, err error) {
+	return t.Time.MarshalJSON()
 }
 
 // UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalJSON(data []byte) (err error) {
-	return d.Time.UnmarshalJSON(data)
+func (t *Time) UnmarshalJSON(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc3339JSON, string(data))
+	return err
 }
 
 // MarshalText preserves the Time as a byte array conforming to RFC3339 date-time (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) MarshalText() (text []byte, err error) {
-	return d.Time.MarshalText()
+func (t Time) MarshalText() (text []byte, err error) {
+	return t.Time.MarshalText()
 }
 
 // UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
-func (d *Time) UnmarshalText(data []byte) (err error) {
-	return d.Time.UnmarshalText(data)
+func (t *Time) UnmarshalText(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc3339, string(data))
+	return err
 }
 
 // String returns the Time formatted as an RFC3339 date-time string (i.e.,
 // 2006-01-02T15:04:05Z).
-func (d Time) String() string {
+func (t Time) String() string {
 	// Note: time.Time.String does not return an RFC3339 compliant string, time.Time.MarshalText does.
-	b, err := d.Time.MarshalText()
+	b, err := t.MarshalText()
 	if err != nil {
 		return ""
 	}
@@ -91,6 +65,6 @@ func (d Time) String() string {
 }
 
 // ToTime returns a Time as a time.Time
-func (d Time) ToTime() time.Time {
-	return d.Time
+func (t Time) ToTime() time.Time {
+	return t.Time
 }

--- a/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/timerfc1123.go
@@ -1,0 +1,86 @@
+package date
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	rfc1123JSON = `"` + time.RFC1123 + `"`
+	rfc1123     = time.RFC1123
+)
+
+// TimeRFC1123 defines a type similar to time.Time but assumes a layout of RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+type TimeRFC1123 struct {
+	time.Time
+}
+
+// UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalJSON(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc1123JSON, string(data))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON preserves the Time as a JSON string conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalJSON() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("Time.MarshalJSON: year outside of range [0,9999]")
+	}
+	b := []byte(t.Format(rfc1123JSON))
+	return b, nil
+}
+
+// MarshalText preserves the Time as a byte array conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalText() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("Time.MarshalText: year outside of range [0,9999]")
+	}
+
+	b := []byte(t.Format(rfc1123))
+	return b, nil
+}
+
+// UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalText(data []byte) (err error) {
+	t.Time, err = ParseTime(rfc1123, string(data))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalBinary preserves the Time as a byte array conforming to RFC1123 date-time (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) MarshalBinary() ([]byte, error) {
+	return t.MarshalText()
+}
+
+// UnmarshalBinary reconstitutes a Time saved as a byte array conforming to RFC1123 date-time
+// (i.e., Mon, 02 Jan 2006 15:04:05 MST).
+func (t *TimeRFC1123) UnmarshalBinary(data []byte) error {
+	return t.UnmarshalText(data)
+}
+
+// ToTime returns a Time as a time.Time
+func (t TimeRFC1123) ToTime() time.Time {
+	return t.Time
+}
+
+// String returns the Time formatted as an RFC1123 date-time string (i.e.,
+// Mon, 02 Jan 2006 15:04:05 MST).
+func (t TimeRFC1123) String() string {
+	// Note: time.Time.String does not return an RFC1123 compliant string, time.Time.MarshalText does.
+	b, err := t.MarshalText()
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/date/utility.go
@@ -1,0 +1,11 @@
+package date
+
+import (
+	"strings"
+	"time"
+)
+
+// ParseTime to parse Time string to specified format.
+func ParseTime(format string, t string) (d time.Time, err error) {
+	return time.Parse(format, strings.ToUpper(t))
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -1,8 +1,13 @@
 package autorest
 
 import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Responder is the interface that wraps the Respond method.
@@ -68,6 +73,20 @@ func ByIgnoring() RespondDecorator {
 	}
 }
 
+// ByCopying copies the contents of the http.Response Body into the passed bytes.Buffer as
+// the Body is read.
+func ByCopying(b *bytes.Buffer) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil && resp != nil && resp.Body != nil {
+				resp.Body = TeeReadCloser(resp.Body, b)
+			}
+			return err
+		})
+	}
+}
+
 // ByClosing returns a RespondDecorator that first invokes the passed Responder after which it
 // closes the response body. Since the passed Responder is invoked prior to closing the response
 // body, the decorator may occur anywhere within the set.
@@ -97,116 +116,48 @@ func ByClosingIfError() RespondDecorator {
 	}
 }
 
-// ByUnmarshallingBool returns a RespondDecorator that decodes the http.Response Body into a bool
-// pointed to by b.
-func ByUnmarshallingBool(b *bool) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*b, err = readBool(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat32 returns a RespondDecorator that decodes the http.Response Body into a
-// float32 pointed to by f.
-func ByUnmarshallingFloat32(f *float32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat64 returns a RespondDecorator that decodes the http.Response Body into a
-// float64 pointed to by f.
-func ByUnmarshallingFloat64(f *float64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt32 returns a RespondDecorator that decodes the http.Response Body into an
-// int32 pointed to by i.
-func ByUnmarshallingInt32(i *int32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt64 returns a RespondDecorator that decodes the http.Response Body into an
-// int64 pointed to by i.
-func ByUnmarshallingInt64(i *int64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingString returns a RespondDecorator that decodes the http.Response Body into a
-// string pointed to by s.
-func ByUnmarshallingString(s *string) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*s, err = readString(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
 // ByUnmarshallingJSON returns a RespondDecorator that decodes a JSON document returned in the
 // response Body into the value pointed to by v.
 func ByUnmarshallingJSON(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsJSON, v)
-}
-
-// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
-// response Body into the value pointed to by v.
-func ByUnmarshallingXML(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsXML, v)
-}
-
-func byUnmarshallingAs(encodedAs EncodedAs, v interface{}) RespondDecorator {
 	return func(r Responder) Responder {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err == nil {
-				b, errDecode := CopyAndDecode(encodedAs, resp.Body, v)
-				if errDecode != nil {
-					err = fmt.Errorf("Error (%v) occurred decoding %s (\"%s\")", errDecode, encodedAs, b.String())
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else if len(strings.Trim(string(b), " ")) > 0 {
+					errInner = json.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling JSON - Error = '%v' JSON = '%s'", errInner, string(b))
+					}
 				}
 			}
 			return err
 		})
 	}
+}
 
+// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
+// response Body into the value pointed to by v.
+func ByUnmarshallingXML(v interface{}) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else {
+					errInner = xml.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling Xml - Error = '%v' Xml = '%s'", errInner, string(b))
+					}
+				}
+			}
+			return err
+		})
+	}
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an error unless the response

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -6,9 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
-	"strconv"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -48,53 +46,24 @@ func CopyAndDecode(encodedAs EncodedAs, r io.Reader, v interface{}) (bytes.Buffe
 	return b, NewDecoder(encodedAs, io.TeeReader(r, &b)).Decode(v)
 }
 
-func readBool(r io.Reader) (bool, error) {
-	s, err := readString(r)
-	if err == nil {
-		return strconv.ParseBool(s)
-	}
-	return false, err
+// TeeReadCloser returns a ReadCloser that writes to w what it reads from rc.
+// It utilizes io.TeeReader to copy the data read and has the same behavior when reading.
+// Further, when it is closed, it ensures that rc is closed as well.
+func TeeReadCloser(rc io.ReadCloser, w io.Writer) io.ReadCloser {
+	return &teeReadCloser{rc, io.TeeReader(rc, w)}
 }
 
-func readFloat32(r io.Reader) (float32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 32)
-		return float32(v), err
-	}
-	return float32(0), err
+type teeReadCloser struct {
+	rc io.ReadCloser
+	r  io.Reader
 }
 
-func readFloat64(r io.Reader) (float64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 64)
-		return v, err
-	}
-	return float64(0), err
+func (t *teeReadCloser) Read(p []byte) (int, error) {
+	return t.r.Read(p)
 }
 
-func readInt32(r io.Reader) (int32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 32)
-		return int32(v), err
-	}
-	return int32(0), err
-}
-
-func readInt64(r io.Reader) (int64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 64)
-		return v, err
-	}
-	return int64(0), err
-}
-
-func readString(r io.Reader) (string, error) {
-	b, err := ioutil.ReadAll(r)
-	return string(b), err
+func (t *teeReadCloser) Close() error {
+	return t.rc.Close()
 }
 
 func containsInt(ints []int, n int) bool {

--- a/vendor/github.com/Azure/go-autorest/autorest/version.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	major        = "6"
+	major        = "7"
 	minor        = "0"
 	patch        = "0"
 	tag          = ""


### PR DESCRIPTION
Making Azure operation polling intervals more frequent to
detect completions faster (and thus making machine creations
faster).

Reduce one Azure API call for each machine command by caching
the discovered Azure Active Directory tenant ID of the user’s
Azure subscription into a local file. This also makes Azure
driver commands faster.

Removing the hacky polling around `azureutil.go#createStorageAccount`
by fixing it in Azure Go SDK.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
