### PR TITLE
Remove coverage-send (buggy) from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: bash
 services: docker
 env:
   matrix:
-    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="build validate coverage-send"
+    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="build validate"
     - TARGET_OS=darwin TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=windows TARGET_ARCH=amd64 TARGETS="build-x"
 script:


### PR DESCRIPTION
@dgageot @dmp42 @jeanlaurent  FYI

Twice this week so far I've gotten emails from Travis telling me that master build is failing because 

```
Bad response status from coveralls: 422 - {"message":"Couldn't find a repository matching this job.","error":true}

make: *** [coverage-send] Error 1

mk/coverage.mk:21: recipe for target 'coverage-send' failed

make: *** [build validate coverage-send] Error 2
```

I have seen this so many times.  I'm not sure what could be causing it other than coveralls being flaky, but it confuses contributors and forces us to re-run the build when their PRs turn up red for no reason.  I'd like to remove it.  I don't find that the coverage check provides us much value, historically we have been much more likely to be successful at enforcing requiring unit tests by hand.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>