### PR TITLE
[DigitalOcean] Fix missing identity file error

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -347,6 +347,14 @@ func (d *Driver) getClient() *godo.Client {
 	return godo.NewClient(client)
 }
 
+func (d *Driver) GetSSHKeyPath() string {
+	// don't set SSHKeyPath when using an existing key fingerprint
+	if d.SSHKeyPath == "" && d.SSHKeyFingerprint == "" {
+		d.SSHKeyPath = d.ResolveStorePath("id_rsa")
+	}
+	return d.SSHKeyPath
+}
+
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
 }

--- a/drivers/digitalocean/digitalocean_test.go
+++ b/drivers/digitalocean/digitalocean_test.go
@@ -21,6 +21,8 @@ func TestSetConfigFromFlags(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Empty(t, checkFlags.InvalidFlags)
+
+	assert.Equal(t, driver.ResolveStorePath("id_rsa"), driver.GetSSHKeyPath())
 }
 
 func TestDefaultSSHUserAndPort(t *testing.T) {
@@ -61,4 +63,22 @@ func TestCustomSSHUserAndPort(t *testing.T) {
 	assert.Equal(t, "user", driver.GetSSHUsername())
 	assert.Equal(t, 2222, sshPort)
 	assert.NoError(t, err)
+}
+
+func TestSSHKeyFingerprint(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"digitalocean-access-token":        "TOKEN",
+			"digitalocean-ssh-key-fingerprint": "64:51:2b:9b:8b:f0:95:3c:f9:36:4d:8b:80:a8:8f:1e",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "64:51:2b:9b:8b:f0:95:3c:f9:36:4d:8b:80:a8:8f:1e", driver.SSHKeyFingerprint)
+	assert.Equal(t, "", driver.GetSSHKeyPath())
 }


### PR DESCRIPTION
When using the --digitalocean-ssh-key-fingerprint flag, no SSH key pair
is generated. Keeping the driver's SSHKeyPath option empty makes sure
the ssh client won't perform any validation on the private key.

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>