### PR TITLE
Several additions in support of google cloud engine:

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -261,6 +261,44 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		instance.NetworkInterfaces[0].AccessConfigs = append(instance.NetworkInterfaces[0].AccessConfigs, cfg)
 	}
 
+	if d.LocalSsdNum > 0 {
+		for i := 0; i < d.LocalSsdNum; i++ {
+			localSsd := &raw.AttachedDisk{
+				AutoDelete: true,      // Cannot create local SSD without autoDelete
+				Type:       "SCRATCH", // Again, necessary for local SSD
+				Mode:       "READ_WRITE",
+				Interface:  d.LocalSsdInterface,
+				InitializeParams: &raw.AttachedDiskInitializeParams{
+					DiskType: c.zoneURL + "/diskTypes/local-ssd",
+					// DiskSize - is a default 370 GB on gcloud
+					// DiskName - use the default local-ssd-N
+				},
+			}
+			instance.Disks = append(instance.Disks, localSsd)
+		}
+	}
+	if d.MetadataSpec != "" {
+		metadataPairs := strings.Split(d.MetadataSpec, ",")
+		metadataItems := []*raw.MetadataItems{}
+		for _, metadataPair := range metadataPairs {
+			var keyFilePair = strings.Split(metadataPair, "=")
+			if len(keyFilePair) != 2 {
+				return errors.New("Invalid metadata pair specified: " + metadataPair)
+			}
+			content, err := ioutil.ReadFile(keyFilePair[1])
+			if err != nil {
+				return err
+			}
+			contentStr := string(content[:])
+			metadataItems = append(metadataItems, &raw.MetadataItems{
+				Key:   keyFilePair[0],
+				Value: &contentStr,
+			})
+		}
+		instance.Metadata = &raw.Metadata{
+			Items: metadataItems,
+		}
+	}
 	if c.address != "" {
 		staticAddress, err := c.staticAddress()
 		if err != nil {
@@ -348,15 +386,14 @@ func (c *ComputeUtil) uploadSSHKey(instance *raw.Instance, sshKeyPath string) er
 	}
 
 	metaDataValue := fmt.Sprintf("%s:%s %s\n", c.userName, strings.TrimSpace(string(sshKey)), c.userName)
-
+	items := instance.Metadata.Items
+	items = append(items, &raw.MetadataItems{
+		Key:   "sshKeys",
+		Value: &metaDataValue,
+	})
 	op, err := c.service.Instances.SetMetadata(c.project, c.zone, c.instanceName, &raw.Metadata{
 		Fingerprint: instance.Metadata.Fingerprint,
-		Items: []*raw.MetadataItems{
-			{
-				Key:   "sshKeys",
-				Value: &metaDataValue,
-			},
-		},
+		Items:       items,
 	}).Do()
 
 	return c.waitForRegionalOp(op.Name)

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -28,16 +28,20 @@ type Driver struct {
 	Project           string
 	Tags              string
 	UseExisting       bool
+	LocalSsdNum       int
+	LocalSsdInterface string
+	MetadataSpec      string
 }
 
 const (
-	defaultZone        = "us-central1-a"
-	defaultUser        = "docker-user"
-	defaultMachineType = "n1-standard-1"
-	defaultImageName   = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20151114"
-	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write"
-	defaultDiskType    = "pd-standard"
-	defaultDiskSize    = 10
+	defaultZone              = "us-central1-a"
+	defaultUser              = "docker-user"
+	defaultMachineType       = "n1-standard-1"
+	defaultImageName         = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20151114"
+	defaultScopes            = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write"
+	defaultDiskType          = "pd-standard"
+	defaultDiskSize          = 10
+	defaultLocalSsdInterface = "SCSI"
 )
 
 // GetCreateFlags registers the flags this driver adds to
@@ -122,6 +126,24 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Don't create a new VM, use an existing one",
 			EnvVar: "GOOGLE_USE_EXISTING",
 		},
+		mcnflag.IntFlag{
+			Name:   "google-local-ssd-num",
+			Usage:  "GCE Local SSD number of disks.",
+			Value:  0,
+			EnvVar: "GOOGLE_LOCAL_SSD_NUM",
+		},
+		mcnflag.StringFlag{
+			Name:   "google-local-ssd-interface",
+			Usage:  "GCE Local SSD Interface type (SCSI or NVME)",
+			Value:  defaultLocalSsdInterface,
+			EnvVar: "GOOGLE_LOCAL_SSD_INTERFACE",
+		},
+		mcnflag.StringFlag{
+			Name:   "google-metadata",
+			Usage:  "GCE Machine Metadata <key>=<filename w/ val>[,<key>=<filename w/ val>]*",
+			EnvVar: "GOOGLE_METADATA",
+			Value:  "",
+		},
 	}
 }
 
@@ -180,6 +202,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.UseInternalIPOnly = flags.Bool("google-use-internal-ip-only")
 		d.Scopes = flags.String("google-scopes")
 		d.Tags = flags.String("google-tags")
+		d.LocalSsdNum = flags.Int("google-local-ssd-num")
+		d.LocalSsdInterface = flags.String("google-local-ssd-interface")
+		d.MetadataSpec = flags.String("google-metadata")
+
 	}
 	d.SSHUser = flags.String("google-username")
 	d.SSHPort = 22

--- a/libmachine/provision/debian_upstart.go
+++ b/libmachine/provision/debian_upstart.go
@@ -9,42 +9,41 @@ import (
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnutils"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
-	"github.com/docker/machine/libmachine/provision/serviceaction"
 	"github.com/docker/machine/libmachine/swarm"
 )
 
 func init() {
 	Register("Debian", &RegisteredProvisioner{
-		New: NewDebianProvisioner,
+		New: NewDebianUpstartProvisioner,
 	})
 }
 
-func NewDebianProvisioner(d drivers.Driver) Provisioner {
-	return &DebianProvisioner{
-		NewSystemdProvisioner("debian", d),
+func NewDebianUpstartProvisioner(d drivers.Driver) Provisioner {
+	return &DebianUpstartProvisioner{
+		NewUpstartProvisioner("debian", d),
 	}
 }
 
-type DebianProvisioner struct {
-	SystemdProvisioner
+type DebianUpstartProvisioner struct {
+	UpstartProvisioner
 }
 
-func (provisioner *DebianProvisioner) String() string {
-	return "debian"
+func (provisioner *DebianUpstartProvisioner) String() string {
+	return "debian(upstart)"
 }
 
-func (provisioner *DebianProvisioner) CompatibleWithHost() bool {
+func (provisioner *DebianUpstartProvisioner) CompatibleWithHost() bool {
 	isDebian := provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID
 	if !isDebian {
 		return false
 	}
 	if _, err := provisioner.SSHCommand("sudo which systemctl"); err != nil {
-		return false
+		return true
 	}
-	return true
+	return false
 }
 
-func (provisioner *DebianProvisioner) Package(name string, action pkgaction.PackageAction) error {
+func (provisioner *DebianUpstartProvisioner) Package(name string, action pkgaction.PackageAction) error {
 	var packageAction string
 
 	updateMetadata := true
@@ -98,7 +97,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	return nil
 }
 
-func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {
+func (provisioner *DebianUpstartProvisioner) dockerDaemonResponding() bool {
 	log.Debug("checking docker daemon")
 
 	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
@@ -111,7 +110,7 @@ func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {
 	return true
 }
 
-func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+func (provisioner *DebianUpstartProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
@@ -160,12 +159,6 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 
 	log.Debug("configuring swarm")
 	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
-		return err
-	}
-
-	// enable in systemd
-	log.Debug("enabling docker in systemd")
-	if err := provisioner.Service("docker", serviceaction.Enable); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/upstart.go
+++ b/libmachine/provision/upstart.go
@@ -1,0 +1,41 @@
+package provision
+
+import (
+	"fmt"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
+)
+
+type UpstartProvisioner struct {
+	GenericProvisioner
+}
+
+func (p *UpstartProvisioner) String() string {
+	return "upstart"
+}
+
+func NewUpstartProvisioner(osReleaseID string, d drivers.Driver) UpstartProvisioner {
+	return UpstartProvisioner{
+		GenericProvisioner{
+			SSHCommander:      GenericSSHCommander{Driver: d},
+			DockerOptionsDir:  "/etc/docker",
+			DaemonOptionsFile: "/etc/default/docker",
+			OsReleaseID:       osReleaseID,
+			Packages: []string{
+				"curl",
+			},
+			Driver: d,
+		},
+	}
+}
+
+func (p *UpstartProvisioner) Service(name string, action serviceaction.ServiceAction) error {
+	command := fmt.Sprintf("sudo service %s %s", name, action.String())
+
+	if _, err := p.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- added support for specifying machine metadata via a --google-metadata `<key>=<filename>[,<key>=<filename>]` flag (interesting here are the startup and shutdown scripts.
- added support for local-ssd (number of disks and interface type flags with --google-local-ssd-num and --google-local-ssd-interface)
-- added upstart based provisioner for debian + added a base upstart provisioner on the model of systemd.go. The differentiation between main debian provisioner (which is systemd based) and the debian/upstart is done in CompatibleWithHost based on the presence of systemctl
Usage case for the provisioner: this seems to be the best way to deal with some google compute engine machines (debian based w/ nvme local ssd) for which conversion to systemd is too cumbersome.

Signed-off-by: Catalin Popescu <catalin@gmail.com>