### PR TITLE
Add support for --swarm-opt to agent nodes

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -119,15 +119,20 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 		},
 	}
 
+	cmdWorker := []string{
+		"join",
+		"--advertise",
+		advertiseInfo,
+	}
+	for _, option := range swarmOptions.ArbitraryFlags {
+		cmdWorker = append(cmdWorker, "--"+option)
+	}
+	cmdWorker = append(cmdWorker, swarmOptions.Discovery)
+
 	swarmWorkerConfig := &dockerclient.ContainerConfig{
-		Image: swarmOptions.Image,
-		Env:   swarmOptions.Env,
-		Cmd: []string{
-			"join",
-			"--advertise",
-			advertiseInfo,
-			swarmOptions.Discovery,
-		},
+		Image:      swarmOptions.Image,
+		Env:        swarmOptions.Env,
+		Cmd:        cmdWorker,
 		HostConfig: workerHostConfig,
 	}
 	if swarmOptions.IsExperimental {


### PR DESCRIPTION
Closes #3285 

This modification permits the swarm-agent created by docker-machine to take into account the `—swarm-opt `arguments.

Signed-off-by: Lucien Gougerot lucien.gougerot@gmail.com