### PR TITLE
Disable user-defined ssh_config configurations

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -63,6 +63,7 @@ const (
 
 var (
 	baseSSHArgs = []string{
+		"-F", "/dev/null",
 		"-o", "BatchMode=yes",
 		"-o", "PasswordAuthentication=no",
 		"-o", "StrictHostKeyChecking=no",


### PR DESCRIPTION
Using the user-defined ssh_config configurations bring more problems
instead of enchancements.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>