### PR TITLE
Revert "Correct error handling for external SSH client"

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -321,19 +321,6 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 	// Specify which private keys to use to authorize the SSH request.
 	for _, privateKeyPath := range auth.Keys {
 		if privateKeyPath != "" {
-			// Check each private key before use it
-			fi, err := os.Stat(privateKeyPath)
-			if err != nil {
-				// Abort if key not accessible
-				return nil, err
-			}
-			mode := fi.Mode()
-			log.Debugf("Using SSH private key: %s (%s)", privateKeyPath, mode)
-			// Private key file should have strict permissions
-			if mode != 0600 {
-				// Abort with correct message
-				return nil, fmt.Errorf("Permissions %#o for '%s' are too open.", mode, privateKeyPath)
-			}
 			args = append(args, "-i", privateKeyPath)
 		}
 	}

--- a/libmachine/ssh/client_test.go
+++ b/libmachine/ssh/client_test.go
@@ -43,36 +43,3 @@ func TestGetSSHCmdArgs(t *testing.T) {
 		assert.Equal(t, cmd.Args, c.expectedArgs)
 	}
 }
-
-func TestNewExternalClient(t *testing.T) {
-	cases := []struct {
-		sshBinaryPath string
-		user          string
-		host          string
-		port          int
-		auth          *Auth
-		expectedError string
-	}{
-		{
-			sshBinaryPath: "/usr/local/bin/ssh",
-			user:          "docker",
-			host:          "localhost",
-			port:          22,
-			auth:          &Auth{Keys: []string{"/tmp/private-key-not-exist"}},
-			expectedError: "stat /tmp/private-key-not-exist: no such file or directory",
-		},
-		{
-			sshBinaryPath: "/usr/local/bin/ssh",
-			user:          "docker",
-			host:          "localhost",
-			port:          22,
-			auth:          &Auth{Keys: []string{"/dev/null"}},
-			expectedError: "Permissions 0410000666 for '/dev/null' are too open.",
-		},
-	}
-
-	for _, c := range cases {
-		_, err := NewExternalClient(c.sshBinaryPath, c.user, c.host, c.port, c.auth)
-		assert.EqualError(t, err, c.expectedError)
-	}
-}


### PR DESCRIPTION
This reverts commit f2acfa9492d9352edeb722ba625adaf86bcdee7e due to https://github.com/docker/machine/issues/3292 breaking Windows machines.

I'm happy to add it back in later once the regression is fixed, but we're getting down to the wire on the release, so I'm erring on the side of caution.