### PR TITLE
Run Swarm containers without --net host

### DIFF
--- a/libmachine/provision/configure_swarm.go
+++ b/libmachine/provision/configure_swarm.go
@@ -93,7 +93,6 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 					},
 				},
 			},
-			NetworkMode: "host",
 		}
 
 		swarmMasterConfig := &dockerclient.ContainerConfig{
@@ -118,7 +117,6 @@ func configureSwarm(p Provisioner, swarmOptions swarm.Options, authOptions auth.
 			Name:              "always",
 			MaximumRetryCount: 0,
 		},
-		NetworkMode: "host",
 	}
 
 	swarmWorkerConfig := &dockerclient.ContainerConfig{


### PR DESCRIPTION
There's no reason to run these with `--net host` and it leads to confusion.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>