### PR TITLE
Remove lxc-docker to docker-engine migration code

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -57,25 +57,6 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 		}
 	}
 
-	// handle the new docker-engine package; we can probably remove this
-	// after we have a few versions
-	if action == pkgaction.Upgrade && name == "docker-engine" {
-		// run the force remove on the existing lxc-docker package
-		// and remove the existing apt source list
-
-		commands := []string{
-			"rm /etc/apt/sources.list.d/docker.list || true",
-			"apt-get remove -y lxc-docker || true",
-		}
-
-		for _, cmd := range commands {
-			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
-			if _, err := provisioner.SSHCommand(command); err != nil {
-				return err
-			}
-		}
-	}
-
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -73,25 +73,6 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 		}
 	}
 
-	// handle the new docker-engine package; we can probably remove this
-	// after we have a few versions
-	if action == pkgaction.Upgrade && name == "docker-engine" {
-		// run the force remove on the existing lxc-docker package
-		// and remove the existing apt source list
-
-		commands := []string{
-			"rm /etc/apt/sources.list.d/docker.list || true",
-			"apt-get remove -y lxc-docker || true",
-		}
-
-		for _, cmd := range commands {
-			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
-			if _, err := provisioner.SSHCommand(command); err != nil {
-				return err
-			}
-		}
-	}
-
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -92,25 +92,6 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 		}
 	}
 
-	// handle the new docker-engine package; we can probably remove this
-	// after we have a few versions
-	if action == pkgaction.Upgrade && name == "docker-engine" {
-		// run the force remove on the existing lxc-docker package
-		// and remove the existing apt source list
-
-		commands := []string{
-			"rm /etc/apt/sources.list.d/docker.list || true",
-			"apt-get remove -y lxc-docker || true",
-		}
-
-		for _, cmd := range commands {
-			command := fmt.Sprintf("sudo DEBIAN_FRONTEND=noninteractive %s", cmd)
-			if _, err := provisioner.SSHCommand(command); err != nil {
-				return err
-			}
-		}
-	}
-
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y -o Dpkg::Options::=\"--force-confnew\" %s", packageAction, name)
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)


### PR DESCRIPTION
The `rm /etc/apt/sources.list.d/docker.list || true` bit totally hosed upgrade.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>