### PR TITLE
Generic driver: flags to provide SSH config file

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -713,6 +713,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 func (d *Driver) Start() error {
 	_, err := d.getClient().StartInstances(&ec2.StartInstancesInput{
 		InstanceIds: []*string{&d.InstanceId},

--- a/drivers/errdriver/error.go
+++ b/drivers/errdriver/error.go
@@ -71,6 +71,10 @@ func (d *Driver) GetSSHUsername() string {
 	return ""
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	return "/dev/null"
+}
+
 func (d *Driver) GetState() (state.State, error) {
 	return state.Error, NotLoadable{d.Name}
 }

--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -128,6 +128,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "exoscale"

--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -72,6 +72,10 @@ func (d *Driver) GetSSHUsername() string {
 	return ""
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	return "/dev/null"
+}
+
 func (d *Driver) GetState() (state.State, error) {
 	return d.MockState, nil
 }

--- a/drivers/generic/generic_test.go
+++ b/drivers/generic/generic_test.go
@@ -12,9 +12,10 @@ func TestSetConfigFromFlags(t *testing.T) {
 
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
-			"generic-engine-port": "3000",
-			"generic-ip-address":  "localhost",
-			"generic-ssh-key":     "path",
+			"generic-engine-port":     "3000",
+			"generic-ip-address":      "localhost",
+			"generic-ssh-key":         "path",
+			"generic-ssh-config-file": "config_file",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -155,6 +155,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "google"

--- a/drivers/none/driver.go
+++ b/drivers/none/driver.go
@@ -67,6 +67,10 @@ func (d *Driver) GetSSHUsername() string {
 	return ""
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	return "/dev/null"
+}
+
 func (d *Driver) GetURL() (string, error) {
 	return d.URL, nil
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -188,6 +188,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "virtualbox"

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -140,6 +140,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "vmwarefusion"

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -175,6 +175,13 @@ func (d *Driver) GetSSHUsername() string {
 	return d.SSHUser
 }
 
+func (d *Driver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
+}
+
 // DriverName returns the name of the driver
 func (d *Driver) DriverName() string {
 	return "vmwarevsphere"

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -19,6 +19,7 @@ type BaseDriver struct {
 	SSHUser        string
 	SSHPort        int
 	SSHKeyPath     string
+	SSHConfigFile  string
 	StorePath      string
 	SwarmMaster    bool
 	SwarmHost      string
@@ -49,6 +50,14 @@ func (d *BaseDriver) GetSSHKeyPath() string {
 		d.SSHKeyPath = d.ResolveStorePath("id_rsa")
 	}
 	return d.SSHKeyPath
+}
+
+// GetSSHConfigFile returns the ssh config file; default is /dev/null
+func (d *BaseDriver) GetSSHConfigFile() string {
+	if d.SSHConfigFile == "" {
+		d.SSHConfigFile = "/dev/null"
+	}
+	return d.SSHConfigFile
 }
 
 // GetSSHPort returns the ssh port, 22 if not specified

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -41,6 +41,9 @@ type Driver interface {
 	// GetSSHUsername returns username for use with ssh
 	GetSSHUsername() string
 
+	// GetSSHConfigFile returns the ssh config file
+	GetSSHConfigFile() string
+
 	// GetURL returns a Docker compatible host URL for connecting to this host
 	// e.g. tcp://1.2.3.4:2376
 	GetURL() (string, error)

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -74,6 +74,7 @@ const (
 	GetSSHKeyPathMethod      = `.GetSSHKeyPath`
 	GetSSHPortMethod         = `.GetSSHPort`
 	GetSSHUsernameMethod     = `.GetSSHUsername`
+	GetSSHConfigFileMethod   = `.GetSSHConfigFile`
 	GetStateMethod           = `.GetState`
 	PreCreateCheckMethod     = `.PreCreateCheck`
 	CreateMethod             = `.Create`
@@ -318,6 +319,15 @@ func (c *RPCClientDriver) GetSSHUsername() string {
 	}
 
 	return username
+}
+
+func (c *RPCClientDriver) GetSSHConfigFile() string {
+	configFile, err := c.rpcStringCall(GetSSHConfigFileMethod)
+	if err != nil {
+		log.Warnf("Error attempting call to get SSH config file: %s", err)
+	}
+
+	return configFile
 }
 
 func (c *RPCClientDriver) GetState() (state.State, error) {

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -181,6 +181,11 @@ func (r *RPCServerDriver) GetSSHUsername(_ *struct{}, reply *string) error {
 	return nil
 }
 
+func (r *RPCServerDriver) GetSSHConfigFile(_ *struct{}, reply *string) error {
+	*reply = r.ActualDriver.GetSSHConfigFile()
+	return nil
+}
+
 func (r *RPCServerDriver) GetURL(_ *struct{}, reply *string) error {
 	info, err := r.ActualDriver.GetURL()
 	*reply = info

--- a/libmachine/drivers/serial.go
+++ b/libmachine/drivers/serial.go
@@ -101,6 +101,12 @@ func (d *SerialDriver) GetSSHUsername() string {
 	return d.Driver.GetSSHUsername()
 }
 
+func (d *SerialDriver) GetSSHConfigFile() string {
+	d.Lock()
+	defer d.Unlock()
+	return d.Driver.GetSSHConfigFile()
+}
+
 // GetURL returns a Docker compatible host URL for connecting to this host
 // e.g. tcp://1.2.3.4:2376
 func (d *SerialDriver) GetURL() (string, error) {

--- a/libmachine/drivers/serial_test.go
+++ b/libmachine/drivers/serial_test.go
@@ -29,17 +29,18 @@ func (l *MockLocker) Unlock() {
 }
 
 type MockDriver struct {
-	calls       *CallRecorder
-	driverName  string
-	flags       []mcnflag.Flag
-	ip          string
-	machineName string
-	sshHostname string
-	sshKeyPath  string
-	sshPort     int
-	sshUsername string
-	url         string
-	state       state.State
+	calls         *CallRecorder
+	driverName    string
+	flags         []mcnflag.Flag
+	ip            string
+	machineName   string
+	sshHostname   string
+	sshKeyPath    string
+	sshPort       int
+	sshUsername   string
+	sshConfigFile string
+	url           string
+	state         state.State
 }
 
 func (d *MockDriver) Create() error {
@@ -85,6 +86,11 @@ func (d *MockDriver) GetSSHPort() (int, error) {
 func (d *MockDriver) GetSSHUsername() string {
 	d.calls.record("GetSSHUsername")
 	return d.sshUsername
+}
+
+func (d *MockDriver) GetSSHConfigFile() string {
+	d.calls.record("GetSSHConfigFile")
+	return d.sshConfigFile
 }
 
 func (d *MockDriver) GetURL() (string, error) {

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -19,16 +19,14 @@ func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
 		return nil, err
 	}
 
-	var auth *ssh.Auth
-	if d.GetSSHKeyPath() == "" {
-		auth = &ssh.Auth{}
-	} else {
-		auth = &ssh.Auth{
-			Keys: []string{d.GetSSHKeyPath()},
-		}
+	options := &ssh.Options{
+		ConfigFile: d.GetSSHConfigFile(),
+	}
+	if d.GetSSHKeyPath() != "" {
+		options.Keys = []string{d.GetSSHKeyPath()}
 	}
 
-	client, err := ssh.NewClient(d.GetSSHUsername(), address, port, auth)
+	client, err := ssh.NewClient(d.GetSSHUsername(), address, port, options)
 	return client, err
 
 }

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -83,12 +83,12 @@ func (creator *StandardSSHClientCreator) CreateSSHClient(d drivers.Driver) (ssh.
 		return &ssh.ExternalClient{}, err
 	}
 
-	auth := &ssh.Auth{}
+	options := &ssh.Options{}
 	if d.GetSSHKeyPath() != "" {
-		auth.Keys = []string{d.GetSSHKeyPath()}
+		options.Keys = []string{d.GetSSHKeyPath()}
 	}
 
-	return ssh.NewClient(d.GetSSHUsername(), addr, port, auth)
+	return ssh.NewClient(d.GetSSHUsername(), addr, port, options)
 }
 
 func (h *Host) runActionForState(action func() error, desiredState state.State) error {

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -46,9 +46,10 @@ type NativeClient struct {
 	openSession *ssh.Session
 }
 
-type Auth struct {
-	Passwords []string
-	Keys      []string
+type Options struct {
+	Passwords  []string
+	Keys       []string
+	ConfigFile string
 }
 
 type ClientType string
@@ -64,7 +65,6 @@ const (
 
 var (
 	baseSSHArgs = []string{
-		"-F", "/dev/null",
 		"-o", "BatchMode=yes",
 		"-o", "PasswordAuthentication=no",
 		"-o", "StrictHostKeyChecking=no",
@@ -90,30 +90,30 @@ func SetDefaultClient(clientType ClientType) {
 	}
 }
 
-func NewClient(user string, host string, port int, auth *Auth) (Client, error) {
+func NewClient(user string, host string, port int, options *Options) (Client, error) {
 	sshBinaryPath, err := exec.LookPath("ssh")
 	if err != nil {
 		log.Debug("SSH binary not found, using native Go implementation")
-		client, err := NewNativeClient(user, host, port, auth)
+		client, err := NewNativeClient(user, host, port, options)
 		log.Debug(client)
 		return client, err
 	}
 
 	if defaultClientType == Native {
 		log.Debug("Using SSH client type: native")
-		client, err := NewNativeClient(user, host, port, auth)
+		client, err := NewNativeClient(user, host, port, options)
 		log.Debug(client)
 		return client, err
 	}
 
 	log.Debug("Using SSH client type: external")
-	client, err := NewExternalClient(sshBinaryPath, user, host, port, auth)
+	client, err := NewExternalClient(sshBinaryPath, user, host, port, options)
 	log.Debug(client)
 	return client, err
 }
 
-func NewNativeClient(user, host string, port int, auth *Auth) (Client, error) {
-	config, err := NewNativeConfig(user, auth)
+func NewNativeClient(user, host string, port int, options *Options) (Client, error) {
+	config, err := NewNativeConfig(user, options)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting config for native Go SSH: %s", err)
 	}
@@ -125,12 +125,12 @@ func NewNativeClient(user, host string, port int, auth *Auth) (Client, error) {
 	}, nil
 }
 
-func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
+func NewNativeConfig(user string, options *Options) (ssh.ClientConfig, error) {
 	var (
 		authMethods []ssh.AuthMethod
 	)
 
-	for _, k := range auth.Keys {
+	for _, k := range options.Keys {
 		key, err := ioutil.ReadFile(k)
 		if err != nil {
 			return ssh.ClientConfig{}, err
@@ -144,7 +144,7 @@ func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
 		authMethods = append(authMethods, ssh.PublicKeys(privateKey))
 	}
 
-	for _, p := range auth.Passwords {
+	for _, p := range options.Passwords {
 		authMethods = append(authMethods, ssh.Password(p))
 	}
 
@@ -307,21 +307,26 @@ func (client *NativeClient) Shell(args ...string) error {
 	return nil
 }
 
-func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (*ExternalClient, error) {
+func NewExternalClient(sshBinaryPath, user, host string, port int, options *Options) (*ExternalClient, error) {
 	client := &ExternalClient{
 		BinaryPath: sshBinaryPath,
 	}
 
-	args := append(baseSSHArgs, fmt.Sprintf("%s@%s", user, host))
+	args := append(baseSSHArgs, "-F", options.ConfigFile)
+	if _, err := os.Stat(options.ConfigFile); err != nil {
+		// Abort if config file not accessible
+		return nil, err
+	}
+	args = append(args, fmt.Sprintf("%s@%s", user, host))
 
 	// If no identities are explicitly provided, also look at the identities
 	// offered by ssh-agent
-	if len(auth.Keys) > 0 {
+	if len(options.Keys) > 0 {
 		args = append(args, "-o", "IdentitiesOnly=yes")
 	}
 
 	// Specify which private keys to use to authorize the SSH request.
-	for _, privateKeyPath := range auth.Keys {
+	for _, privateKeyPath := range options.Keys {
 		if privateKeyPath != "" {
 			// Check each private key before use it
 			fi, err := os.Stat(privateKeyPath)

--- a/vendor/github.com/samalba/dockerclient/utils.go
+++ b/vendor/github.com/samalba/dockerclient/utils.go
@@ -10,6 +10,7 @@ import (
 
 func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration) *http.Client {
 	httpTransport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 


### PR DESCRIPTION
This adds two flags to the `generic` driver:

    --generic-ssh-config-file <path/to/config>

        Use the provided config file with the external SSH client (-F)

    --generic-use-user-ssh-config

        Use ~/.ssh/config as the config file

The flags are mutually exclusive in order to avoid ambiguity.

This also adds the SSHConfigFile parameter to BaseDriver and a
GetSSHConfigFile method to all drivers. It seems like there should
be a way to reduce this duplication, since most of the implementations
are identical (return "/dev/null"). I'm a golang noob, though, so if
you know of a better way to accomplish this, please let me know.

Tried this out in my environment, which requires a `ProxyCommand` to
access a remote site via SSH. Before, the issue described in #3310
occurred, preventing me from using `docker-machine` to configure this
host. With this, the `--generic-use-user-ssh-config` option adds
the config file in place of the previous-default `/dev/null` and all
seems well.

Also added a couple unit test cases.