### PR TITLE
SSH - don't enable BatchMode (fixes #3306)

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -65,7 +65,6 @@ const (
 var (
 	baseSSHArgs = []string{
 		"-F", "/dev/null",
-		"-o", "BatchMode=yes",
 		"-o", "PasswordAuthentication=no",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",


### PR DESCRIPTION
When a passphrase protected key is not yet in ssh-agent, it gives a
chance to the user to fill a prompt instead of silently failing.

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>