### PR TITLE
[Generic] Copy the public key to machine directory (fixes #3268)

### DIFF
--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -87,13 +88,6 @@ func (d *Driver) GetSSHUsername() string {
 }
 
 func (d *Driver) GetSSHKeyPath() string {
-	if d.SSHKey == "" {
-		return ""
-	}
-
-	if d.SSHKeyPath == "" {
-		d.SSHKeyPath = d.ResolveStorePath("id_rsa")
-	}
 	return d.SSHKeyPath
 }
 
@@ -114,8 +108,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 func (d *Driver) PreCreateCheck() error {
 	if d.SSHKey != "" {
 		if _, err := os.Stat(d.SSHKey); os.IsNotExist(err) {
-			return fmt.Errorf("Ssh key does not exist: %q", d.SSHKey)
+			return fmt.Errorf("SSH key does not exist: %q", d.SSHKey)
 		}
+
+		// TODO: validate the key is a valid key
 	}
 
 	return nil
@@ -127,13 +123,14 @@ func (d *Driver) Create() error {
 			" future will require the ssh agent to contain the appropriate key.")
 	} else {
 		log.Info("Importing SSH key...")
-		// TODO: validate the key is a valid key
-		if err := mcnutils.CopyFile(d.SSHKey, d.GetSSHKeyPath()); err != nil {
-			return fmt.Errorf("unable to copy ssh key: %s", err)
+
+		d.SSHKeyPath = d.ResolveStorePath(path.Base(d.SSHKey))
+		if err := copySSHKey(d.SSHKey, d.SSHKeyPath); err != nil {
+			return err
 		}
 
-		if err := os.Chmod(d.GetSSHKeyPath(), 0600); err != nil {
-			return fmt.Errorf("unable to set permissions on the ssh key: %s", err)
+		if err := copySSHKey(d.SSHKey+".pub", d.SSHKeyPath+".pub"); err != nil {
+			log.Infof("Couldn't copy SSH public key : %s", err)
 		}
 	}
 
@@ -184,5 +181,17 @@ func (d *Driver) Kill() error {
 }
 
 func (d *Driver) Remove() error {
+	return nil
+}
+
+func copySSHKey(src, dst string) error {
+	if err := mcnutils.CopyFile(src, dst); err != nil {
+		return fmt.Errorf("unable to copy ssh key: %s", err)
+	}
+
+	if err := os.Chmod(dst, 0600); err != nil {
+		return fmt.Errorf("unable to set permissions on the ssh key: %s", err)
+	}
+
 	return nil
 }

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -63,11 +63,7 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 
-	if err := os.Chmod(dst, fi.Mode()); err != nil {
-		return err
-	}
-
-	return nil
+	return os.Chmod(dst, fi.Mode())
 }
 
 func WaitForSpecificOrError(f func() (bool, error), maxAttempts int, waitInterval time.Duration) error {


### PR DESCRIPTION
It should be possible to use the specified location directly. Copying
the private key can also have some drawbacks :

http://apple.stackexchange.com/questions/18458/password-dialog-appears-when-ssh-private-key-permissions-are-set-to-0600/26252#26252

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>