### PR TITLE
[Generic] clarified doc / messages about ssh-agent

### DIFF
--- a/docs/drivers/generic.md
+++ b/docs/drivers/generic.md
@@ -33,24 +33,8 @@ to the host.
     $ docker-machine create \
       --driver generic \
       --generic-ip-address=203.0.113.81 \
-      --generic-ssh-key=~/.ssh/id_rsa \
+      --generic-ssh-key ~/.ssh/id_rsa \
       vm
-
-### Password-protected SSH keys
-
-When an SSH identity is not provided (with the `--generic-ssh-key` flag),
-the SSH agent (if running) will be consulted. This makes it possible to
-easily use password-protected SSH keys.
-
-Note that this usage is _only_ supported if you're using the external SSH client,
-which is the default behaviour when the `ssh` binary is available. If you're
-using the native client (with `--native-ssh`), using the SSH agent is not yet
-supported.
-
-    $ docker-machine create \
-      --driver generic \
-      --generic-ip-address=203.0.113.81 \
-      other
 
 ### Sudo privileges
 
@@ -76,6 +60,6 @@ Environment variables and default values:
 | -------------------------- | -------------------- | ------------------------- |
 | `--generic-engine-port`    | `GENERIC_ENGINE_PORT`| `2376`                    |
 | **`--generic-ip-address`** | `GENERIC_IP_ADDRESS` | -                         |
-| `--generic-ssh-key`        | `GENERIC_SSH_KEY`    | _(defers to `ssh-agent`)_ |
+| `--generic-ssh-key`        | `GENERIC_SSH_KEY`    | -                         |
 | `--generic-ssh-user`       | `GENERIC_SSH_USER`   | `root`                    |
 | `--generic-ssh-port`       | `GENERIC_SSH_PORT`   | `22`                      |

--- a/drivers/generic/generic.go
+++ b/drivers/generic/generic.go
@@ -49,7 +49,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   "generic-ssh-key",
-			Usage:  "SSH private key path (if not provided, identities in ssh-agent will be used)",
+			Usage:  "SSH private key path (if not provided, default SSH key will be used)",
 			Value:  "",
 			EnvVar: "GENERIC_SSH_KEY",
 		},
@@ -123,8 +123,7 @@ func (d *Driver) PreCreateCheck() error {
 
 func (d *Driver) Create() error {
 	if d.SSHKey == "" {
-		log.Info("No SSH key specified. Connecting to this machine now and in the" +
-			" future will require the ssh agent to contain the appropriate key.")
+		log.Info("No SSH key specified. Assuming an existing key at the default location.")
 	} else {
 		log.Info("Importing SSH key...")
 		// TODO: validate the key is a valid key


### PR DESCRIPTION
As the IdentitiesOnly option is set with the SSH external client,
existing identities in ssh-agent won't be used unless it's the default
location.

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>