### PR TITLE
exoscale: fix cloud-init file to be compatible with CoreOS

### DIFF
--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -459,6 +459,6 @@ func (d *Driver) getCloudInit() (string, error) {
 	}
 
 	return `#cloud-config
-manage_etc_hosts: true
+manage_etc_hosts: localhost
 `, nil
 }


### PR DESCRIPTION
The cloud-init implementation in CoreOS is quite limited and will choke
on `manage_etc_hosts: true`. Use `manage_etc_hosts: localhost` instead
which is supported. This is also supported by the classic Python
cloud-init implementation and the result is quite similar.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>