### PR TITLE
azure: create temporary file next to destination

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -96,23 +96,23 @@
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.4-6-gec603a8",
+			"Rev": "ec603a8ea5ffc45df35c7d948d9acfd6cbc07b46"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/azure",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.4-6-gec603a8",
+			"Rev": "ec603a8ea5ffc45df35c7d948d9acfd6cbc07b46"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/date",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.4-6-gec603a8",
+			"Rev": "ec603a8ea5ffc45df35c7d948d9acfd6cbc07b46"
 		},
 		{
 			"ImportPath": "github.com/Azure/go-autorest/autorest/to",
-			"Comment": "v7.0.4",
-			"Rev": "b01ec2b60f95678fa759f796bac3c6b9bceaead4"
+			"Comment": "v7.0.4-6-gec603a8",
+			"Rev": "ec603a8ea5ffc45df35c7d948d9acfd6cbc07b46"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/persist.go
@@ -34,13 +34,13 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 		return fmt.Errorf("failed to create directory (%s) to store token in: %v", dir, err)
 	}
 
-	newFile, err := ioutil.TempFile(os.TempDir(), "token")
+	newFile, err := ioutil.TempFile(dir, "token")
 	if err != nil {
 		return fmt.Errorf("failed to create the temp file to write the token: %v", err)
 	}
 	tempPath := newFile.Name()
 
-	if json.NewEncoder(newFile).Encode(token); err != nil {
+	if err := json.NewEncoder(newFile).Encode(token); err != nil {
 		return fmt.Errorf("failed to encode token to file (%s) while saving token: %v", tempPath, err)
 	}
 	if err := newFile.Close(); err != nil {
@@ -49,7 +49,7 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 
 	// Atomic replace to avoid multi-writer file corruptions
 	if err := os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("failed to move temporary token to desired output location. source=(%s). destination=(%s). error = %v", tempPath, path, err)
+		return fmt.Errorf("failed to move temporary token to desired output location. src=%s dst=%s: %v", tempPath, path, err)
 	}
 	if err := os.Chmod(path, mode); err != nil {
 		return fmt.Errorf("failed to chmod the token file %s: %v", path, err)

--- a/vendor/github.com/Azure/go-autorest/autorest/client.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/client.go
@@ -2,6 +2,7 @@ package autorest
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -53,7 +54,9 @@ func (li LoggingInspector) WithInspection() PrepareDecorator {
 			defer r.Body.Close()
 
 			r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &body))
-			r.Write(&b)
+			if err := r.Write(&b); err != nil {
+				return nil, fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(requestFormat, b.String())
 
@@ -76,7 +79,9 @@ func (li LoggingInspector) ByInspecting() RespondDecorator {
 			defer resp.Body.Close()
 
 			resp.Body = ioutil.NopCloser(io.TeeReader(resp.Body, &body))
-			resp.Write(&b)
+			if err := resp.Write(&b); err != nil {
+				return fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(responseFormat, b.String())
 

--- a/vendor/github.com/Azure/go-autorest/autorest/responder.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/responder.go
@@ -95,7 +95,9 @@ func ByClosing() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})
@@ -109,7 +111,9 @@ func ByClosingIfError() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err != nil && resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})


### PR DESCRIPTION
We were doing atomic file writes by writing to /tmp
and moving to the actual destination, however some filesystems
do not support copying from /tmpfs.

Bumping the `go-autorest` dependency version to latest which fixes this.

Fixes #3313.