### PR TITLE
[SSH] Allow private keys with 0400 permissions (fixes #3359)

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -332,9 +332,12 @@ func NewExternalClient(sshBinaryPath, user, host string, port int, auth *Auth) (
 				mode := fi.Mode()
 				log.Debugf("Using SSH private key: %s (%s)", privateKeyPath, mode)
 				// Private key file should have strict permissions
-				if mode != 0600 {
-					// Abort with correct message
-					return nil, fmt.Errorf("Permissions %#o for '%s' are too open.", mode, privateKeyPath)
+				perm := mode.Perm()
+				if perm&0400 == 0 {
+					return nil, fmt.Errorf("'%s' is not readable", privateKeyPath)
+				}
+				if perm&0077 != 0 {
+					return nil, fmt.Errorf("permissions %#o for '%s' are too open", perm, privateKeyPath)
 				}
 			}
 			args = append(args, "-i", privateKeyPath)


### PR DESCRIPTION
Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>

I'm wondering if https://github.com/docker/machine/commit/be8f469a828ffd6ad8ca0baaef017c49e3bab713 shouldn't be reverted instead of merging my PR. It caused a few false positives and kind of "duplicates" the ssh binary behaviour. If the original intention was to have more helpful error messages, maybe the default could be to print the output when an SSH command is failing?