### PR TITLE
coreos: better docker integration with existing systemd unit

### DIFF
--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
 	"github.com/docker/machine/libmachine/swarm"
 )
 
@@ -64,22 +65,11 @@ func (provisioner *CoreOSProvisioner) GenerateDockerOptions(dockerPort int) (*Do
 	driverNameLabel := fmt.Sprintf("provider=%s", provisioner.Driver.DriverName())
 	provisioner.EngineOptions.Labels = append(provisioner.EngineOptions.Labels, driverNameLabel)
 
-	engineConfigTmpl := `[Unit]
-Description=Docker Socket for the API
-After=docker.socket early-docker.target network.target
-Requires=docker.socket early-docker.target
-
-[Service]
-Environment=TMPDIR=/var/tmp
-EnvironmentFile=-/run/flannel_docker_opts.env
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
-ExecStart=/usr/lib/coreos/dockerd daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }} \$DOCKER_OPTS \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPT_IPMASQ
-Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
+	engineConfigTmpl := `[Service]
+Environment='DOCKER_OPTS=--host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }}'
+{{range .EngineOptions.Env}}
+{{ printf "Environment=%q" . }}
+{{end}}
 `
 
 	t, err := template.New("engineConfig").Parse(engineConfigTmpl)
@@ -97,7 +87,7 @@ WantedBy=multi-user.target
 
 	return &DockerOptions{
 		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: provisioner.DaemonOptionsFile,
+		EngineOptionsPath: "/etc/systemd/system/docker.service.d/machine.conf",
 	}, nil
 }
 
@@ -128,6 +118,11 @@ func (provisioner *CoreOSProvisioner) Provision(swarmOptions swarm.Options, auth
 
 	log.Debug("Configuring swarm")
 	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
+		return err
+	}
+
+	log.Debug("enabling docker in systemd")
+	if err := provisioner.Service("docker", serviceaction.Enable); err != nil {
 		return err
 	}
 

--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -87,7 +87,7 @@ Environment='DOCKER_OPTS=--host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlsc
 
 	return &DockerOptions{
 		EngineOptions:     engineCfg.String(),
-		EngineOptionsPath: "/etc/systemd/system/docker.service.d/machine.conf",
+		EngineOptionsPath: provisioner.DaemonOptionsFile,
 	}, nil
 }
 

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -179,7 +179,9 @@ func ConfigureAuth(p Provisioner) error {
 
 	log.Info("Setting Docker configuration on the remote daemon...")
 
-	if _, err = p.SSHCommand(fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	if _, err = p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s",
+		path.Dir(dkrcfg.EngineOptionsPath),
+		dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
CoreOS is shipping a systemd unit starting Docker through socket
activation. The content of the file is the following (CoreOS 899):

```
[Unit]
Description=Docker Socket for the API
PartOf=docker.service

[Socket]
ListenStream=/var/run/docker.sock
SocketMode=0660
SocketUser=docker
SocketGroup=docker

[Install]
WantedBy=sockets.target
```

The service file provided by CoreOS is the following:

```
[Unit]
Description=Docker Application Container Engine
Documentation=http://docs.docker.com
After=docker.socket early-docker.target network.target
Requires=docker.socket early-docker.target

[Service]
EnvironmentFile=-/run/flannel_docker_opts.env
MountFlags=slave
LimitNOFILE=1048576
LimitNPROC=1048576
ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ

[Install]
WantedBy=multi-user.target
```

Docker Machine is setting up a regular systemd unit service file. The
content is the following:

```
[Unit]
Description=Docker Socket for the API
After=docker.socket early-docker.target network.target
Requires=docker.socket early-docker.target

[Service]
Environment=TMPDIR=/var/tmp
EnvironmentFile=-/run/flannel_docker_opts.env
MountFlags=slave
LimitNOFILE=1048576
LimitNPROC=1048576
ExecStart=/usr/lib/coreos/dockerd daemon --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=exoscale $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
Environment=

[Install]
WantedBy=multi-user.target
```

It's mostly a copy/paste of the original service. There are multiple problems:
1. We have two processes listening to /var/run/docker.sock: systemd
   through socket activation and Docker itself. A few tests show that
   Docker gets all the requests but it could be luck and break at some
   point or under some conditions.
2. The unit setup by Docker Machine is not enabled on start. After a
   reboot, Docker is not started anymore. If we trigger it locally, it
   starts but blocks because it doesn't use socket activation. Further
   invocations will then work.
3. The environment is in fact empty because of the empty `Environment=`
   at the end.

Those commits integrates Docker a bit better with CoreOS by solving the
first and last point (first commit) and the middle one (last commit).
We cannot do socket activation with TLS because in
stable channels, CoreOS ships only Docker 1.9. Therefore, we keep socket
activation for the Unix socket but we use a regular socket for the TLS
one. We override the existing service to avoid repeat what's in it. We
add /etc/systemd/system/docker.service.d/machine.conf:

```
[Service]
Environment="DOCKER_OPTS=--host=tcp://0.0.0.0:2376 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem --label provider=exoscale"
```

In the future (Docker 1.10+), we could add
/etc/systemd/system/docker.socket.d/machine.conf:

```
[Socket]
ListenStream=0.0.0.0:2376
```

And only append `Environment` to the `.service` file.

Note that the way the systemd unit is passed over SSH is quite
fragile. Notably, characters need to be escaped properly and a double
quotes should not be present. This can be problematic for the
environment variables. See #3391.
