### PR TITLE
Align machine storage path flag name

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -113,7 +113,7 @@ func main() {
 		},
 		cli.StringFlag{
 			EnvVar: "MACHINE_STORAGE_PATH",
-			Name:   "s, storage-path",
+			Name:   "storage-path, s",
 			Value:  mcndirs.GetBaseDir(),
 			Usage:  "Configures storage path",
 		},


### PR DESCRIPTION
Signed-off-by: Ronak Banka <ronak.banka@rakuten.com>

Short form for storage path was added in https://github.com/docker/machine/commit/4e9fc9c248216496a0b4ef8d857d6144878f540d but is not aligned with other flag names.

