### PR TITLE
virtualbox: virtualbox-hostonly-no-dhcp flag

### DIFF
--- a/drivers/virtualbox/network.go
+++ b/drivers/virtualbox/network.go
@@ -286,7 +286,7 @@ func addHostOnlyDHCPServer(ifname string, d dhcpServer, vbox VBoxManager) error 
 	command := "add"
 	if dhcp, ok := dhcps[name]; ok {
 		command = "modify"
-		if (dhcp.IPv4.IP.Equal(d.IPv4.IP)) && (dhcp.IPv4.Mask.String() == d.IPv4.Mask.String()) && (dhcp.LowerIP.Equal(d.LowerIP)) && (dhcp.UpperIP.Equal(d.UpperIP)) && dhcp.Enabled {
+		if (dhcp.IPv4.IP.Equal(d.IPv4.IP)) && (dhcp.IPv4.Mask.String() == d.IPv4.Mask.String()) && (dhcp.LowerIP.Equal(d.LowerIP)) && (dhcp.UpperIP.Equal(d.UpperIP)) && (dhcp.Enabled == d.Enabled) {
 			// dhcp is up to date
 			return nil
 		}


### PR DESCRIPTION
This PR add a virtualbox-hostonly-no-dhcp flag to disable the creation of the DHCP server. This is useful in case you want to use the DHCP server of Dnsmasq to resolve the machine name. 

```
$ docker-machine create -d virtualbox --virtualbox-hostonly-no-dhcp test
Running pre-create checks...
Creating machine...
(test) Copying /Users/asiragusa/.docker/machine/cache/boot2docker.iso to /Users/asiragusa/.docker/machine/machines/test/boot2docker.iso...
(test) Creating VirtualBox VM...
(test) Creating SSH key...
(test) Starting the VM...
(test) Check network to re-create if needed...
(test) Waiting for an IP...
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with boot2docker...
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
Checking connection to Docker...
Docker is up and running!
To see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: bin/docker-machine env test
$ docker-machine restart test
Restarting "test"...
Waiting for SSH to be available...
Detecting the provisioner...
Restarted machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
```

Then you can do the following from the host and inside the vm:
```
$ ping test.vm
PING test.vm (192.168.99.100): 56 data bytes
64 bytes from 192.168.99.100: icmp_seq=0 ttl=64 time=0.337 ms
```

The `docker-machine restart` is necessary because the hostname is set up after the interface has been configured.

BTW it is not possible to have machines on the same CIDR that have use the vbox dhcp server, as it kicks in before the dnsmasq's one.

The dnsmasq.conf I use is the following:

```
interface=vboxnet0
bind-interfaces
dhcp-range=192.168.99.100,192.168.99.253,12h
dhcp-leasefile=/var/lib/dnsmasq.leases
dhcp-option=3
local=/vm/
expand-hosts
domain=vm
address=/host.vm/192.168.99.1
```

Then I configure my host's resolver to use dnsmaqs for the domain vm this way:

```
$ echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/vm
```

Signed-off-by: Alessandro Siragusa <alessandro.siragusa@gmail.com>