### PR TITLE
Add support for OS_CACERT in Openstack driver

### DIFF
--- a/docs/drivers/openstack.md
+++ b/docs/drivers/openstack.md
@@ -25,6 +25,7 @@ Options:
 
 -   `--openstack-active-timeout`: The timeout in seconds until the OpenStack instance must be active.
 -   `--openstack-availability-zone`: The availability zone in which to launch the server.
+-   `--openstack-cacert`: The CA certificate bundle to verify against.
 -   `--openstack-domain-name` or `--openstack-domain-id`: Domain to use for authentication (Keystone v3 only).
 -   `--openstack-endpoint-type`: Endpoint type can be `internalURL`, `adminURL` on `publicURL`. If is a helper for the driver
     to choose the right URL in the OpenStack service catalog. If not provided the default id `publicURL`
@@ -52,6 +53,7 @@ Environment variables and default values:
 | `--openstack-active-timeout`    | `OS_ACTIVE_TIMEOUT`    | `200`       |
 | `--openstack-auth-url`          | `OS_AUTH_URL`          | -           |
 | `--openstack-availability-zone` | `OS_AVAILABILITY_ZONE` | -           |
+| `--openstack-cacert`            | `OS_CACERT             | -           |
 | `--openstack-domain-id`         | `OS_DOMAIN_ID`         | -           |
 | `--openstack-domain-name`       | `OS_DOMAIN_NAME`       | -           |
 | `--openstack-endpoint-type`     | `OS_ENDPOINT_TYPE`     | `publicURL` |

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -20,6 +20,7 @@ type Driver struct {
 	AuthUrl          string
 	ActiveTimeout    int
 	Insecure         bool
+	CaCert           string
 	DomainID         string
 	DomainName       string
 	Username         string
@@ -65,6 +66,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "OS_INSECURE",
 			Name:   "openstack-insecure",
 			Usage:  "Disable TLS credential checking.",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "OS_CACERT",
+			Name:   "openstack-cacert",
+			Usage:  "CA certificate bundle to verify against",
+			Value:  "",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "OS_DOMAIN_ID",
@@ -252,6 +259,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.AuthUrl = flags.String("openstack-auth-url")
 	d.ActiveTimeout = flags.Int("openstack-active-timeout")
 	d.Insecure = flags.Bool("openstack-insecure")
+	d.CaCert = flags.String("openstack-cacert")
 	d.DomainID = flags.String("openstack-domain-id")
 	d.DomainName = flags.String("openstack-domain-name")
 	d.Username = flags.String("openstack-username")


### PR DESCRIPTION
This enables using docker-machine's openstack driver without having to
resort to using the --insecure flag.