### PR TITLE
Update base images for AWS driver

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -81,7 +81,7 @@ Environment variables and default values:
 | `--amazonec2-access-key`                 | `AWS_ACCESS_KEY_ID`     | -                |
 | `--amazonec2-secret-key`                 | `AWS_SECRET_ACCESS_KEY` | -                |
 | `--amazonec2-session-token`              | `AWS_SESSION_TOKEN`     | -                |
-| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-5f709f34`   |
+| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-13be557e`   |
 | `--amazonec2-region`                     | `AWS_DEFAULT_REGION`    | `us-east-1`      |
 | `--amazonec2-vpc-id`                     | `AWS_VPC_ID`            | -                |
 | `--amazonec2-zone`                       | `AWS_ZONE`              | `a`              |
@@ -105,21 +105,22 @@ Environment variables and default values:
 
 ## Default AMIs
 
-By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10.
+By default, the Amazon EC2 driver will use a daily image of Ubuntu 16.04 LTS (Ubuntu 15.10 for cn-north-1).
 
 | Region         | AMI ID       |
 | -------------- | ------------ |
-| ap-northeast-1 | ami-b36d4edd |
-| ap-southeast-1 | ami-1069af73 |
-| ap-southeast-2 | ami-1d336a7e |
+| ap-northeast-1 | ami-5d38d93c |
+| ap-northeast-2 | ami-a3915acd |
+| ap-southeast-1 | ami-a35284c0 |
+| ap-southeast-2 | ami-f4361997 |
 | cn-north-1     | ami-79eb2214 |
-| eu-west-1      | ami-8aa67cf9 |
-| eu-central-1   | ami-ab0210c7 |
-| sa-east-1      | ami-185de774 |
-| us-east-1      | ami-26d5af4c |
-| us-west-1      | ami-9cbcd2fc |
-| us-west-2      | ami-16b1a077 |
-| us-gov-west-1  | ami-b0bad893 |
+| eu-west-1      | ami-7a138709 |
+| eu-central-1   | ami-f9e30f96 |
+| sa-east-1      | ami-0d5dd561 |
+| us-east-1      | ami-13be557e |
+| us-west-1      | ami-84423ae4 |
+| us-west-2      | ami-06b94666 |
+| us-gov-west-1  | ami-8f4df2ee |
 
 ## Security Group
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -29,7 +29,7 @@ const (
 	driverName               = "amazonec2"
 	ipRange                  = "0.0.0.0/0"
 	machineSecurityGroupName = "docker-machine"
-	defaultAmiId             = "ami-615cb725"
+	defaultAmiId             = "ami-13be557e"
 	defaultRegion            = "us-east-1"
 	defaultInstanceType      = "t2.micro"
 	defaultDeviceName        = "/dev/sda1"

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -8,21 +8,21 @@ type region struct {
 	AmiId string
 }
 
-// Release 15.10 20151116.1
+// Release 16.04 LTS 20160516.1
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1": {"ami-b36d4edd"},
-	"ap-northeast-2": {"ami-09dc1267"},
-	"ap-southeast-1": {"ami-1069af73"},
-	"ap-southeast-2": {"ami-1d336a7e"},
-	"cn-north-1":     {"ami-79eb2214"},
-	"eu-west-1":      {"ami-8aa67cf9"},
-	"eu-central-1":   {"ami-ab0210c7"},
-	"sa-east-1":      {"ami-185de774"},
-	"us-east-1":      {"ami-26d5af4c"},
-	"us-west-1":      {"ami-9cbcd2fc"},
-	"us-west-2":      {"ami-16b1a077"},
-	"us-gov-west-1":  {"ami-b0bad893"},
+	"ap-northeast-1": {"ami-5d38d93c"},
+	"ap-northeast-2": {"ami-a3915acd"},
+	"ap-southeast-1": {"ami-a35284c0"},
+	"ap-southeast-2": {"ami-f4361997"},
+	"cn-north-1":     {"ami-79eb2214"}, // 15.10 20151116.1
+	"eu-west-1":      {"ami-7a138709"},
+	"eu-central-1":   {"ami-f9e30f96"},
+	"sa-east-1":      {"ami-0d5dd561"},
+	"us-east-1":      {"ami-13be557e"},
+	"us-west-1":      {"ami-84423ae4"},
+	"us-west-2":      {"ami-06b94666"},
+	"us-gov-west-1":  {"ami-8f4df2ee"},
 }
 
 func awsRegionsList() []string {


### PR DESCRIPTION
This PR updates configs and docs on AWS driver.

### features
- update Ubuntu base image to 16.04 LTS on AWS EC2 (except for `cn-north-1` region where there is no 16.04 LTS AMI at this moment)

### typos
- remove a typo `Ubuntu 15.10 LTS`
- remove a typo `ami-615cb725` for `us-east-1` instead of `us-west-1`

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>