### PR TITLE
drivers: vmwarefusion: fix CPU count

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -44,7 +44,6 @@ type Driver struct {
 	CPU            int
 	ISO            string
 	Boot2DockerURL string
-	CPUS           int
 
 	SSHPassword    string
 	ConfigDriveISO string
@@ -56,7 +55,7 @@ const (
 	defaultSSHUser  = B2DUser
 	defaultSSHPass  = B2DPass
 	defaultDiskSize = 20000
-	defaultCpus     = 1
+	defaultCPU      = 1
 	defaultMemory   = 1024
 )
 
@@ -116,7 +115,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
-		CPUS:        defaultCpus,
+		CPU:         defaultCPU,
 		Memory:      defaultMemory,
 		DiskSize:    defaultDiskSize,
 		SSHPassword: defaultSSHPass,


### PR DESCRIPTION
The current default for CPU count is 0. At some point it looks like
someone started using CPU instead of CPUS field
(13c1006f3bc19d8db3468ffaa257c08cd25e3ace) but things got messed up
later.