### PR TITLE
Add the monitoring scope to the default scopes for GCE instances created by docker-machine

### DIFF
--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -35,7 +35,7 @@ const (
 	defaultUser        = "docker-user"
 	defaultMachineType = "n1-standard-1"
 	defaultImageName   = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20151114"
-	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write"
+	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write"
 	defaultDiskType    = "pd-standard"
 	defaultDiskSize    = 10
 )


### PR DESCRIPTION
This allows sending metrics using application-default-credentials from the GCE VM
to the Google Cloud Monitoring API

Signed-off-by: Jeremy Katz <jekatz@google.com>