### PR TITLE
Add affinity group support in exoscale driver

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -295,7 +295,7 @@
 		},
 		{
 			"ImportPath": "github.com/pyr/egoscale/src/egoscale",
-			"Rev": "347f81398d2ea1f3eebf1cd27ee3183669e34819"
+			"Rev": "906e88e3bb9cf8c559e45e248db1d09578acf47f"
 		},
 		{
 			"ImportPath": "github.com/rackspace/gophercloud",

--- a/docs/drivers/exoscale.md
+++ b/docs/drivers/exoscale.md
@@ -28,6 +28,7 @@ Options:
 -   `--exoscale-availability-zone`: Exoscale availability zone.
 -   `--exoscale-ssh-user`: SSH username, which must match the default SSH user for the used image.
 -   `--exoscale-userdata`: Path to file containing user data for cloud-init.
+-   `--exoscale-affinity-group`: Affinity group the machine will be started in.
 
 If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.
 
@@ -45,3 +46,4 @@ Environment variables and default values:
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-gva-2`                        |
 | `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | `ubuntu`                          |
 | `--exoscale-userdata`           | `EXOSCALE_USERDATA`          | -                                 |
+| `--exoscale-affinity-group`     | `EXOSCALE_AFFINITY_GROUP`    | `docker-machine`                  |


### PR DESCRIPTION
This improves the exoscale drivers and adds support for affinity groups.

Signed-off-by: Sebastien Goasguen <runseb@gmail.com>