### PR TITLE
azure: add --azure-storage-type flag

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -68,6 +68,7 @@ Optional:
 - `--azure-static-public-ip`: Assign a static public IP address to the machine.
 - `--azure-docker-port`: Port number for Docker engine [$AZURE_DOCKER_PORT]
 - `--azure-environment`: Azure environment (e.g. `AzurePublicCloud`, `AzureChinaCloud`).
+- `--azure-storage-type`: Type of Azure Storage account hosting the OS disk of the machine (e.g. `Standard_LRS`, `Premium_LRS`).
 
 [vm-image]: https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/
 [location]: https://azure.microsoft.com/en-us/regions/
@@ -90,6 +91,7 @@ Environment variables and default values:
 | `--azure-subnet`                | `AZURE_SUBNET`                | `docker-machine`   |
 | `--azure-subnet-prefix`         | `AZURE_SUBNET_PREFIX`         | `192.168.0.0/16`   |
 | `--azure-availability-set`      | `AZURE_AVAILABILITY_SET`      | `docker-machine`   |
+| `--azure-storage-type`          | `AZURE_STORAGE_TYPE`          | `Standard_LRS`     |
 | `--azure-open-port`             | -                             | -                  |
 | `--azure-private-ip-address`    | -                             | -                  |
 | `--azure-use-private-ip`        | -                             | -                  |

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -357,7 +357,9 @@ func (a AzureClient) createStorageAccount(resourceGroup, location string, storag
 	name := randomAzureStorageAccountName() // if it's not random enough, then you're unlucky
 	f := logutil.Fields{
 		"name":     name,
-		"location": location}
+		"location": location,
+		"type":     storageType,
+	}
 
 	log.Info("Creating storage account.", f)
 	_, err := a.storageAccountsClient().Create(resourceGroup, name,


### PR DESCRIPTION
This allows users to specify type of Azure Storage account
to be used to run the machine’s disk and enables users to create
SSD-backed machines.

Fixes #3542.

Signed-off-by: Ahmet Alp Balkan