### PR TITLE
Change VirtualBox on Windows base paths to use long path prefix

### DIFF
--- a/drivers/virtualbox/virtualbox_windows.go
+++ b/drivers/virtualbox/virtualbox_windows.go
@@ -91,7 +91,7 @@ func findVBoxInstallDirInRegistry() (string, error) {
 }
 
 func getShareDriveAndName() (string, string) {
-	return "c/Users", "c:\\Users"
+	return "c/Users", "\\?\c:\\Users"
 }
 
 func isHyperVInstalled() bool {

--- a/drivers/virtualbox/virtualbox_windows.go
+++ b/drivers/virtualbox/virtualbox_windows.go
@@ -91,7 +91,7 @@ func findVBoxInstallDirInRegistry() (string, error) {
 }
 
 func getShareDriveAndName() (string, string) {
-	return "c/Users", "\\?\c:\\Users"
+	return "c/Users", "\\\\?\\c:\\Users"
 }
 
 func isHyperVInstalled() bool {


### PR DESCRIPTION
*The current implementation for the Windows VirtualBox driver maps
directly to the 'c:\\Users' directory. This regularly causes exceptions
when a file is written to a volume on a Windows machine where there is a
limitation on the number of characters allowed in a file path.
*By instead using the proposed mapping of '\\\\?\\c:\\Users' the Windows
API will allow the file path to exceed the character limit and should
resolve issues and cryptic errors for many users that are using Docker
Machine to build artifacts with lengthy file paths.