### PR TITLE
Add Network options to Google Driver, shorten SourceImage URI

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -26,6 +26,7 @@ type ComputeUtil struct {
 	project           string
 	diskTypeURL       string
 	address           string
+	network           string
 	preemptible       bool
 	useInternalIP     bool
 	useInternalIPOnly bool
@@ -64,6 +65,7 @@ func newComputeUtil(driver *Driver) (*ComputeUtil, error) {
 		project:           driver.Project,
 		diskTypeURL:       driver.DiskType,
 		address:           driver.Address,
+		network:           driver.Network,
 		preemptible:       driver.Preemptible,
 		useInternalIP:     driver.UseInternalIP,
 		useInternalIPOnly: driver.UseInternalIPOnly,
@@ -170,7 +172,7 @@ func (c *ComputeUtil) portsUsed() ([]string, error) {
 }
 
 // openFirewallPorts configures the firewall to open docker and swarm ports.
-func (c *ComputeUtil) openFirewallPorts() error {
+func (c *ComputeUtil) openFirewallPorts(d *Driver) error {
 	log.Infof("Opening firewall ports")
 
 	create := false
@@ -182,6 +184,7 @@ func (c *ComputeUtil) openFirewallPorts() error {
 			Allowed:      []*raw.FirewallAllowed{},
 			SourceRanges: []string{"0.0.0.0/0"},
 			TargetTags:   []string{firewallTargetTag},
+			Network:      c.globalURL + "/networks/" + d.Network,
 		}
 	}
 
@@ -237,7 +240,7 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		},
 		NetworkInterfaces: []*raw.NetworkInterface{
 			{
-				Network: c.globalURL + "/networks/default",
+				Network: c.globalURL + "/networks/" + d.Network,
 			},
 		},
 		Tags: &raw.Tags{
@@ -274,7 +277,7 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 	if disk == nil || err != nil {
 		instance.Disks[0].InitializeParams = &raw.AttachedDiskInitializeParams{
 			DiskName:    c.diskName(),
-			SourceImage: d.MachineImage,
+			SourceImage: "https://www.googleapis.com/compute/v1/projects/" + d.MachineImage,
 			// The maximum supported disk size is 1000GB, the cast should be fine.
 			DiskSizeGb: int64(d.DiskSize),
 			DiskType:   c.diskType(),

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -20,6 +20,7 @@ type Driver struct {
 	MachineImage      string
 	DiskType          string
 	Address           string
+	Network           string
 	Preemptible       bool
 	UseInternalIP     bool
 	UseInternalIPOnly bool
@@ -34,10 +35,11 @@ const (
 	defaultZone        = "us-central1-a"
 	defaultUser        = "docker-user"
 	defaultMachineType = "n1-standard-1"
-	defaultImageName   = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20151114"
+	defaultImageName   = "ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20160627"
 	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write"
 	defaultDiskType    = "pd-standard"
 	defaultDiskSize    = 10
+	defaultNetwork     = "default"
 )
 
 // GetCreateFlags registers the flags this driver adds to
@@ -92,6 +94,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "GOOGLE_DISK_TYPE",
 		},
 		mcnflag.StringFlag{
+			Name:   "google-network",
+			Usage:  "Specify network in which to provision vm",
+			Value:  defaultNetwork,
+			EnvVar: "GOOGLE_NETWORK",
+		},
+		mcnflag.StringFlag{
 			Name:   "google-address",
 			Usage:  "GCE Instance External IP",
 			EnvVar: "GOOGLE_ADDRESS",
@@ -133,6 +141,7 @@ func NewDriver(machineName string, storePath string) *Driver {
 		DiskSize:     defaultDiskSize,
 		MachineType:  defaultMachineType,
 		MachineImage: defaultImageName,
+		Network:      defaultNetwork,
 		Scopes:       defaultScopes,
 		BaseDriver: &drivers.BaseDriver{
 			SSHUser:     defaultUser,
@@ -175,6 +184,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.DiskSize = flags.Int("google-disk-size")
 		d.DiskType = flags.String("google-disk-type")
 		d.Address = flags.String("google-address")
+		d.Network = flags.String("google-network")
 		d.Preemptible = flags.Bool("google-preemptible")
 		d.UseInternalIP = flags.Bool("google-use-internal-ip") || flags.Bool("google-use-internal-ip-only")
 		d.UseInternalIPOnly = flags.Bool("google-use-internal-ip-only")
@@ -236,7 +246,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := c.openFirewallPorts(); err != nil {
+	if err := c.openFirewallPorts(d); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* Permits specifying `--google-network=SomethingNotDefault` for a network not "default"
* Only tested with [legacy network](https://cloud.google.com/compute/docs/subnetworks#legacy_non-subnet_network)
* Shortens source-image requirements e.g. `--google-machine-image=debian-cloud/global/images/debian-8-jessie-v20160606`  (As far as I can determine) Google does not permit source images to be loaded outside its googleapis.com domain.