### PR TITLE
AWS: Add new ap-south-1 region.

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -112,6 +112,7 @@ By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10 LTS.
 | ap-northeast-1 | ami-b36d4edd |
 | ap-southeast-1 | ami-1069af73 |
 | ap-southeast-2 | ami-1d336a7e |
+| ap-south-1     | ami-845e34eb |
 | cn-north-1     | ami-79eb2214 |
 | eu-west-1      | ami-8aa67cf9 |
 | eu-central-1   | ami-ab0210c7 |

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -15,6 +15,7 @@ var regionDetails map[string]*region = map[string]*region{
 	"ap-northeast-2": {"ami-09dc1267"},
 	"ap-southeast-1": {"ami-1069af73"},
 	"ap-southeast-2": {"ami-1d336a7e"},
+	"ap-south-1":     {"ami-845e34eb"},
 	"cn-north-1":     {"ami-79eb2214"},
 	"eu-west-1":      {"ami-8aa67cf9"},
 	"eu-central-1":   {"ami-ab0210c7"},

--- a/vendor/github.com/aws/aws-sdk-go/private/endpoints/endpoints.json
+++ b/vendor/github.com/aws/aws-sdk-go/private/endpoints/endpoints.json
@@ -75,6 +75,9 @@
     "ap-southeast-2/s3": {
       "endpoint": "s3-{region}.amazonaws.com"
     },
+    "ap-south-1/s3": {
+      "endpoint": "s3-{region}.amazonaws.com"
+    },
     "ap-northeast-1/s3": {
       "endpoint": "s3-{region}.amazonaws.com"
     },

--- a/vendor/github.com/aws/aws-sdk-go/private/endpoints/endpoints_map.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/endpoints/endpoints_map.go
@@ -63,6 +63,9 @@ var endpointsMap = endpointStruct{
 		"ap-southeast-2/s3": {
 			Endpoint: "s3-{region}.amazonaws.com",
 		},
+		"ap-south-1/s3": {
+			Endpoint: "s3-{region}.amazonaws.com",
+		},
 		"cn-north-1/*": {
 			Endpoint: "{service}.{region}.amazonaws.com.cn",
 		},


### PR DESCRIPTION
I went to setup things in the new AWS region "ap-south-1", and after getting everything setup on the AWS site, i went to go launch a server with docker-machine and was told "Invalid region specified".

I checked the AWS marketplace and found the AMI for the new region that matches the same version of ubuntu that the other regions are using.