### PR TITLE
Remove "open : no such file or directory" message during crash report

### DIFF
--- a/libmachine/crashreport/crash_report.go
+++ b/libmachine/crashreport/crash_report.go
@@ -112,6 +112,9 @@ func (r *BugsnagCrashReporter) noReportFileExist() bool {
 }
 
 func addFile(path string, metaData *bugsnag.MetaData) {
+	if path == "" {
+		return
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		log.Debug(err)


### PR DESCRIPTION
Add an empty string check to the path argument of addFile(). Send()
method of BugsnagCrashReporter calls addFile() passing err.LogFilePath
as the path argument, which is an empty string if the driver is not
virtualbox.

Fixes #3559

Signed-off-by: KOBAYASHI Shinji <koba@jp.fujitsu.com>