### PR TITLE
Add VARIANT and VARIANT_ID to os-release

### DIFF
--- a/libmachine/provision/os_release.go
+++ b/libmachine/provision/os_release.go
@@ -20,6 +20,8 @@ type OsRelease struct {
 	AnsiColor    string `osr:"ANSI_COLOR"`
 	Name         string `osr:"NAME"`
 	Version      string `osr:"VERSION"`
+	Variant      string `osr:"VARIANT"`
+	VariantID    string `osr:"VARIANT_ID"`
 	ID           string `osr:"ID"`
 	IDLike       string `osr:"ID_LIKE"`
 	PrettyName   string `osr:"PRETTY_NAME"`

--- a/libmachine/provision/os_release_test.go
+++ b/libmachine/provision/os_release_test.go
@@ -46,7 +46,17 @@ PRETTY_NAME="CentOS Linux 7 (Core)"
 ANSI_COLOR="0;31"
 HOME_URL="https://www.centos.org/"
 BUG_REPORT_URL="https://bugs.centos.org/"
-
+`)
+		fedora = []byte(`NAME=Fedora
+VERSION="23 (Twenty Three)"
+ID=fedora
+VERSION_ID=23
+VARIANT="Server Edition"
+VARIANT_ID=server
+PRETTY_NAME="Fedora 23 (Twenty Three)"
+ANSI_COLOR="0;34"
+HOME_URL="https://fedoraproject.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
 `)
 	)
 
@@ -135,6 +145,28 @@ BUG_REPORT_URL="https://bugs.centos.org/"
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {
 		t.Fatal("Error with centos osr parsing: structs do not match")
+	}
+
+	osr, err = NewOsRelease(fedora)
+	if err != nil {
+		t.Fatalf("Unexpected error parsing os release: %s", err)
+	}
+
+	expectedOsr = OsRelease{
+		Name:         "Fedora",
+		Version:      "23 (Twenty Three)",
+		ID:           "fedora",
+		PrettyName:   "Fedora 23 (Twenty Three)",
+		Variant:      "Server Edition",
+		VariantID:    "server",
+		AnsiColor:    "0;34",
+		VersionID:    "23",
+		HomeURL:      "https://fedoraproject.org/",
+		BugReportURL: "https://bugzilla.redhat.com/",
+	}
+
+	if !reflect.DeepEqual(*osr, expectedOsr) {
+		t.Fatal("Error with fedora osr parsing: structs do not match")
 	}
 }
 


### PR DESCRIPTION
In order to provision different variant types such as embedded and
server releases, it's required to grep the VARIANT and VARIANT_ID
variables of os-release.

Specifically from this commit:
https://pagure.io/fork/sgallagh/fedora-release/c/56267336c738f80e3e7a344c740b5d02730c76c6

Which adds the VARIANT_ID="atomic.host" in order to differentiate
between Fedora Server and container-centric Atomic Host releases.

This commit adds the accessability of VARIANT and VARIANT_ID in order
for Docker Machine to successfully provision different variants of Fedora
releases.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>