### PR TITLE
Add an option to use an EC2 instance's IAM role

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -46,6 +46,12 @@ You can use environment variables:
     $ export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
     $ docker-machine create --driver amazonec2 aws01
 
+### Instance IAM role
+
+If run on an EC2 instance with its own IAM role, you can use this by using the `--amazonec2-use-iam-role` flag on the command line:
+
+    $ docker-machine create --driver amazonec2 --amazonec2-use-iam-role aws01
+
 ## Options
 
 -   `--amazonec2-access-key`: Your access key id for the Amazon Web Services API.
@@ -72,6 +78,7 @@ You can use environment variables:
 -   `--amazonec2-use-ebs-optimized-instance`: Create an EBS Optimized Instance, instance type must support it.
 -   `--amazonec2-ssh-keypath`: Path to Private Key file to use for instance. Matching public key with .pub extension should exist
 -   `--amazonec2-retries`:  Set retry count for recoverable failures (use -1 to disable)
+-   `--amazonec2-use-iam-role`: Use the IAM role of the EC2 instance that docker-machine is run on
 
 
 Environment variables and default values:
@@ -102,6 +109,7 @@ Environment variables and default values:
 | `--amazonec2-use-ebs-optimized-instance` | -                       | `false`          |
 | `--amazonec2-ssh-keypath`                | `AWS_SSH_KEYPATH`       | -                |
 | `--amazonec2-retries`                    | -                       | `5`              |
+| `--amazonec2-use-iam-role`               | -                       | `false`          |
 
 ## Default AMIs
 

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -263,6 +263,26 @@ func TestPassingBothCLIArgWorked(t *testing.T) {
 	assert.Equal(t, "123", driver.SecretKey)
 }
 
+func TestLoadingFromRoleCredentialsWorked(t *testing.T) {
+	driver := NewCustomTestDriver(&fakeEC2WithLogin{})
+	driver.awsCredentials = &roleCredentials{}
+	options := &commandstest.FakeFlagger{
+		Data: map[string]interface{}{
+			"name":                   "test",
+			"amazonec2-region":       "us-east-1",
+			"amazonec2-zone":         "e",
+			"amazonec2-use-iam-role": true,
+		},
+	}
+
+	err := driver.SetConfigFromFlags(options)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", driver.AccessKey)
+	assert.Equal(t, "secret", driver.SecretKey)
+	assert.Equal(t, "token", driver.SessionToken)
+}
+
 var values = []string{
 	"bob",
 	"jake",

--- a/drivers/amazonec2/awscredentials.go
+++ b/drivers/amazonec2/awscredentials.go
@@ -1,11 +1,15 @@
 package amazonec2
 
 import "github.com/aws/aws-sdk-go/aws/credentials"
+import "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+import "github.com/aws/aws-sdk-go/aws/session"
 
 type awsCredentials interface {
 	NewStaticCredentials(id, secret, token string) *credentials.Credentials
 
 	NewSharedCredentials(filename, profile string) *credentials.Credentials
+
+	NewRoleCredentials() *credentials.Credentials
 }
 
 type defaultAWSCredentials struct{}
@@ -16,4 +20,8 @@ func (c *defaultAWSCredentials) NewStaticCredentials(id, secret, token string) *
 
 func (c *defaultAWSCredentials) NewSharedCredentials(filename, profile string) *credentials.Credentials {
 	return credentials.NewSharedCredentials(filename, profile)
+}
+
+func (c *defaultAWSCredentials) NewRoleCredentials() *credentials.Credentials {
+	return ec2rolecreds.NewCredentials(session.New())
 }

--- a/drivers/amazonec2/stub_test.go
+++ b/drivers/amazonec2/stub_test.go
@@ -51,6 +51,10 @@ func (c *cliCredentials) NewSharedCredentials(filename, profile string) *credent
 	return credentials.NewCredentials(&errorProvider{})
 }
 
+func (c *cliCredentials) NewRoleCredentials() *credentials.Credentials {
+	return credentials.NewCredentials(&errorProvider{})
+}
+
 type fileCredentials struct{}
 
 func (c *fileCredentials) NewStaticCredentials(id, secret, token string) *credentials.Credentials {
@@ -58,6 +62,24 @@ func (c *fileCredentials) NewStaticCredentials(id, secret, token string) *creden
 }
 
 func (c *fileCredentials) NewSharedCredentials(filename, profile string) *credentials.Credentials {
+	return credentials.NewCredentials(&okProvider{"access", "secret", "token"})
+}
+
+func (c *fileCredentials) NewRoleCredentials() *credentials.Credentials {
+	return credentials.NewCredentials(&errorProvider{})
+}
+
+type roleCredentials struct{}
+
+func (c *roleCredentials) NewStaticCredentials(id, secret, token string) *credentials.Credentials {
+	return nil
+}
+
+func (c *roleCredentials) NewSharedCredentials(filename, profile string) *credentials.Credentials {
+	return credentials.NewCredentials(&errorProvider{})
+}
+
+func (c *roleCredentials) NewRoleCredentials() *credentials.Credentials {
 	return credentials.NewCredentials(&okProvider{"access", "secret", "token"})
 }
 


### PR DESCRIPTION
Uses the AWS Go SDK's role provider to provide credentials with use of the `--amazonec2-use-iam-role` flag.

I wasn't quite sure about the flag name, so more than happy to change it if needed!

Fixes #3500 

Signed-off-by: Sean Sabbage s.sabbage@siphonnetworks.com
