### PR TITLE
remove LTS from Ubuntu 15.10 in aws driver docs

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -105,7 +105,7 @@ Environment variables and default values:
 
 ## Default AMIs
 
-By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10 LTS.
+By default, the Amazon EC2 driver will use a daily image of Ubuntu 15.10.
 
 | Region         | AMI ID       |
 | -------------- | ------------ |


### PR DESCRIPTION
The 14.04.x and 16.04 [release](https://wiki.ubuntu.com/Releases) are LTS., but Ubuntu 15.10 is not an LTS release, so I'd suggest removing that designation from the docs.