### PR TITLE
Add custom-data support to Azure driver

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -69,6 +69,7 @@ Optional:
 - `--azure-docker-port`: Port number for Docker engine.
 - `--azure-environment`: Azure environment (e.g. `AzurePublicCloud`, `AzureChinaCloud`).
 - `--azure-storage-type`: Type of Azure Storage account hosting the OS disk of the machine (e.g. `Standard_LRS`, `Premium_LRS`).
+- `--azure-custom-data`: Path to the CustomData file.
 
 [vm-image]: https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/
 [location]: https://azure.microsoft.com/en-us/regions/
@@ -92,6 +93,7 @@ Environment variables and default values:
 | `--azure-subnet-prefix`         | `AZURE_SUBNET_PREFIX`         | `192.168.0.0/16`   |
 | `--azure-availability-set`      | `AZURE_AVAILABILITY_SET`      | `docker-machine`   |
 | `--azure-storage-type`          | `AZURE_STORAGE_TYPE`          | `Standard_LRS`     |
+| `--azure-custom-data`           | `AZURE_CUSTOM_DATA_FILE`      | -                  |
 | `--azure-open-port`             | -                             | -                  |
 | `--azure-private-ip-address`    | -                             | -                  |
 | `--azure-use-private-ip`        | -                             | -                  |

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -183,7 +183,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   flAzureCustomData,
-			EnvVar: "AZURE_CUSTOM_DATA",
+			EnvVar: "AZURE_CUSTOM_DATA_FILE",
 			Usage:  "Path to file with custom-data",
 		},
 		mcnflag.StringFlag{

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -1,10 +1,13 @@
 package azure
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 
 	"github.com/docker/machine/drivers/azure/azureutil"
 	"github.com/docker/machine/libmachine/drivers"
@@ -49,6 +52,7 @@ const (
 	flAzureStaticPublicIP  = "azure-static-public-ip"
 	flAzureNoPublicIP      = "azure-no-public-ip"
 	flAzureStorageType     = "azure-storage-type"
+	flAzureCustomData      = "azure-custom-data"
 )
 
 const (
@@ -79,6 +83,8 @@ type Driver struct {
 	UsePrivateIP   bool
 	NoPublicIP     bool
 	StaticPublicIP bool
+
+	CustomDataFile string
 
 	// Ephemeral fields
 	ctx        *azureutil.DeploymentContext
@@ -176,6 +182,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  defaultAzureAvailabilitySet,
 		},
 		mcnflag.StringFlag{
+			Name:   flAzureCustomData,
+			EnvVar: "AZURE_CUSTOM_DATA",
+			Usage:  "Path to file with custom-data",
+		},
+		mcnflag.StringFlag{
 			Name:  flAzurePrivateIPAddr,
 			Usage: "Specify a static private IP address for the machine",
 		},
@@ -242,6 +253,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.NoPublicIP = fl.Bool(flAzureNoPublicIP)
 	d.StaticPublicIP = fl.Bool(flAzureStaticPublicIP)
 	d.DockerPort = fl.Int(flAzureDockerPort)
+	d.CustomDataFile = fl.String(flAzureCustomData)
 
 	// Set flags on the BaseDriver
 	d.BaseDriver.SSHPort = sshPort
@@ -256,6 +268,12 @@ func (d *Driver) DriverName() string { return driverName }
 
 // PreCreateCheck validates if driver values are valid to create the machine.
 func (d *Driver) PreCreateCheck() (err error) {
+	if d.CustomDataFile != "" {
+		if _, err := os.Stat(d.CustomDataFile); os.IsNotExist(err) {
+			return fmt.Errorf("custom-data file %s could not be found", d.CustomDataFile)
+		}
+	}
+
 	c, err := d.newAzureClient()
 	if err != nil {
 		return err
@@ -305,6 +323,15 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+	var customData string
+	if d.CustomDataFile != "" {
+		buf, err := ioutil.ReadFile(d.CustomDataFile)
+		if err != nil {
+			return err
+		}
+		customData = base64.StdEncoding.EncodeToString(buf)
+	}
+
 	if err := c.CreateResourceGroup(d.ResourceGroup, d.Location); err != nil {
 		return err
 	}
@@ -338,7 +365,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 	if err := c.CreateVirtualMachine(d.ResourceGroup, d.naming().VM(), d.Location, d.Size, d.ctx.AvailabilitySetID,
-		d.ctx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.ctx.SSHPublicKey, d.Image, d.ctx.StorageAccount); err != nil {
+		d.ctx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.ctx.SSHPublicKey, d.Image, customData, d.ctx.StorageAccount); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -469,6 +469,26 @@ func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, a
 	log.Debugf("OS disk blob will be placed at: %s", osDiskBlobURL)
 	log.Debugf("SSH key will be placed at: %s", sshKeyPath)
 
+	var osProfile = &compute.OSProfile{
+		ComputerName:  to.StringPtr(name),
+		AdminUsername: to.StringPtr(username),
+		LinuxConfiguration: &compute.LinuxConfiguration{
+			DisablePasswordAuthentication: to.BoolPtr(true),
+			SSH: &compute.SSHConfiguration{
+				PublicKeys: &[]compute.SSHPublicKey{
+					{
+						Path:    to.StringPtr(sshKeyPath),
+						KeyData: to.StringPtr(sshPublicKey),
+					},
+				},
+			},
+		},
+	}
+
+	if customData != "" {
+		osProfile.CustomData = to.StringPtr(customData)
+	}
+
 	_, err = a.virtualMachinesClient().CreateOrUpdate(resourceGroup, name,
 		compute.VirtualMachine{
 			Location: to.StringPtr(location),
@@ -486,22 +506,7 @@ func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, a
 						},
 					},
 				},
-				OsProfile: &compute.OSProfile{
-					ComputerName:  to.StringPtr(name),
-					AdminUsername: to.StringPtr(username),
-					CustomData:    to.StringPtr(customData),
-					LinuxConfiguration: &compute.LinuxConfiguration{
-						DisablePasswordAuthentication: to.BoolPtr(true),
-						SSH: &compute.SSHConfiguration{
-							PublicKeys: &[]compute.SSHPublicKey{
-								{
-									Path:    to.StringPtr(sshKeyPath),
-									KeyData: to.StringPtr(sshPublicKey),
-								},
-							},
-						},
-					},
-				},
+				OsProfile: osProfile,
 				StorageProfile: &compute.StorageProfile{
 					ImageReference: &compute.ImageReference{
 						Publisher: to.StringPtr(img.publisher),

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -448,7 +448,7 @@ func (a AzureClient) removeOSDiskBlob(resourceGroup, vmName, vhdURL string) erro
 }
 
 func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, availabilitySetID, networkInterfaceID,
-	username, sshPublicKey, imageName string, storageAccount *storage.AccountProperties) error {
+	username, sshPublicKey, imageName, customData string, storageAccount *storage.AccountProperties) error {
 	log.Info("Creating virtual machine.", logutil.Fields{
 		"name":     name,
 		"location": location,
@@ -489,6 +489,7 @@ func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, a
 				OsProfile: &compute.OSProfile{
 					ComputerName:  to.StringPtr(name),
 					AdminUsername: to.StringPtr(username),
+					CustomData:    to.StringPtr(customData),
 					LinuxConfiguration: &compute.LinuxConfiguration{
 						DisablePasswordAuthentication: to.BoolPtr(true),
 						SSH: &compute.SSHConfiguration{


### PR DESCRIPTION
This PR adds the ability to inject “Custom Data” to Azure machine at provision time. It satisfies use case of providing `cloud-config` when provisioning CoreOS machines among possibly other use cases.