### PR TITLE
fix repo install on redhat provisioner

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -170,9 +170,20 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 		}
 	}
 
+	// configure dockers rpm repo
+        if err := provisioner.ConfigurePackageList(); err != nil {
+                return err
+        }
+
 	// update OS -- this is needed for libdevicemapper and the docker install
 	if _, err := provisioner.SSHCommand("sudo -E yum -y update"); err != nil {
 		return err
+	}
+
+        // try to install docker rpms via repo that provisioner.ConfigurePackageList created 
+        // if that does not succed, installDocker will install generic or skip install if docker exists
+        if _, err := provisioner.SSHCommand("sudo -E yum -y -q install docker-engine"); err != nil {
+                return err
 	}
 
 	// install docker

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -171,19 +171,19 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	}
 
 	// configure dockers rpm repo
-        if err := provisioner.ConfigurePackageList(); err != nil {
-                return err
-        }
+	if err := provisioner.ConfigurePackageList(); err != nil {
+		return err
+	}
 
 	// update OS -- this is needed for libdevicemapper and the docker install
 	if _, err := provisioner.SSHCommand("sudo -E yum -y update"); err != nil {
 		return err
 	}
 
-        // try to install docker rpms via repo that provisioner.ConfigurePackageList created 
-        // if that does not succed, installDocker will install generic or skip install if docker exists
-        if _, err := provisioner.SSHCommand("sudo -E yum -y -q install docker-engine"); err != nil {
-                return err
+	// try to install docker rpms via repo that provisioner.ConfigurePackageList created
+	// if that does not succed, installDocker will install generic or skip install if docker exists
+	if _, err := provisioner.SSHCommand("sudo -E yum -y -q install docker-engine"); err != nil {
+		return err
 	}
 
 	// install docker


### PR DESCRIPTION
redhat provisioner
* added repo config (found in older version)
* try to install redhat/fedora rpm from docker
before generic get.docker.com tries to config & install (and fails at the moment)

Signed-off-by: Stefan Sels <tronicum@gmail.com>