### PR TITLE
Add support to install Docker on raspbian/jessie

### DIFF
--- a/libmachine/provision/os_release_test.go
+++ b/libmachine/provision/os_release_test.go
@@ -58,6 +58,16 @@ ANSI_COLOR="0;34"
 HOME_URL="https://fedoraproject.org/"
 BUG_REPORT_URL="https://bugzilla.redhat.com/"
 `)
+		raspbian = []byte(`PRETTY_NAME="Raspbian GNU/Linux 8 (jessie)"
+NAME="Raspbian GNU/Linux"
+VERSION_ID="8"
+VERSION="8 (jessie)"
+ID=raspbian
+ID_LIKE=debian
+HOME_URL="http://www.raspbian.org/"
+SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
+BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
+`)
 	)
 
 	osr, err := NewOsRelease(ubuntuTrusty)
@@ -167,6 +177,27 @@ BUG_REPORT_URL="https://bugzilla.redhat.com/"
 
 	if !reflect.DeepEqual(*osr, expectedOsr) {
 		t.Fatal("Error with fedora osr parsing: structs do not match")
+	}
+
+	osr, err = NewOsRelease(raspbian)
+	if err != nil {
+		t.Fatalf("Unexpected error parsing os release: %s", err)
+	}
+
+	expectedOsr = OsRelease{
+		PrettyName:   "Raspbian GNU/Linux 8 (jessie)",
+		Name:         "Raspbian GNU/Linux",
+		VersionID:    "8",
+		Version:      "8 (jessie)",
+		ID:           "raspbian",
+		IDLike:       "debian",
+		HomeURL:      "http://www.raspbian.org/",
+		SupportURL:   "http://www.raspbian.org/RaspbianForums",
+		BugReportURL: "http://www.raspbian.org/RaspbianBugs",
+	}
+
+	if !reflect.DeepEqual(*osr, expectedOsr) {
+		t.Fatal("Error with raspbian osr parsing: structs do not match")
 	}
 }
 

--- a/libmachine/provision/raspbian.go
+++ b/libmachine/provision/raspbian.go
@@ -1,0 +1,137 @@
+package provision
+
+import (
+	"fmt"
+
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnutils"
+	"github.com/docker/machine/libmachine/provision/pkgaction"
+	"github.com/docker/machine/libmachine/provision/serviceaction"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func init() {
+	Register("Raspbian", &RegisteredProvisioner{
+		New: NewRaspbianProvisioner,
+	})
+}
+
+func NewRaspbianProvisioner(d drivers.Driver) Provisioner {
+	return &RaspbianProvisioner{
+		NewSystemdProvisioner("raspbian", d),
+	}
+}
+
+type RaspbianProvisioner struct {
+	SystemdProvisioner
+}
+
+func (provisioner *RaspbianProvisioner) String() string {
+	return "raspbian"
+}
+
+func (provisioner *RaspbianProvisioner) Package(name string, action pkgaction.PackageAction) error {
+	var packageAction string
+
+	updateMetadata := true
+
+	switch action {
+	case pkgaction.Install, pkgaction.Upgrade:
+		packageAction = "install"
+	case pkgaction.Remove:
+		packageAction = "remove"
+		updateMetadata = false
+	}
+
+	switch name {
+	case "docker":
+		name = "docker-engine"
+	}
+
+	if updateMetadata {
+		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
+			return err
+		}
+	}
+
+	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)
+
+	log.Debugf("package: action=%s name=%s", action.String(), name)
+
+	if _, err := provisioner.SSHCommand(command); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (provisioner *RaspbianProvisioner) dockerDaemonResponding() bool {
+	log.Debug("checking docker daemon")
+
+	if out, err := provisioner.SSHCommand("sudo docker version"); err != nil {
+		log.Warnf("Error getting SSH command to check if the daemon is up: %s", err)
+		log.Debugf("'sudo docker version' output:\n%s", out)
+		return false
+	}
+
+	// The daemon is up if the command worked.  Carry on.
+	return true
+}
+
+func (provisioner *RaspbianProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	provisioner.SwarmOptions = swarmOptions
+	provisioner.AuthOptions = authOptions
+	provisioner.EngineOptions = engineOptions
+	swarmOptions.Env = engineOptions.Env
+
+	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)
+	if err != nil {
+		return err
+	}
+	provisioner.EngineOptions.StorageDriver = storageDriver
+
+	log.Debug("setting hostname")
+	if err := provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {
+		return err
+	}
+
+	log.Debug("installing base packages")
+	for _, pkg := range provisioner.Packages {
+		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
+			return err
+		}
+	}
+
+	log.Debug("installing docker")
+	if err := installDockerGeneric(provisioner, engineOptions.InstallURL); err != nil {
+		return err
+	}
+
+	log.Debug("waiting for docker daemon")
+	if err := mcnutils.WaitFor(provisioner.dockerDaemonResponding); err != nil {
+		return err
+	}
+
+	provisioner.AuthOptions = setRemoteAuthOptions(provisioner)
+
+	log.Debug("configuring auth")
+	if err := ConfigureAuth(provisioner); err != nil {
+		return err
+	}
+
+	log.Debug("configuring swarm")
+	if err := configureSwarm(provisioner, swarmOptions, provisioner.AuthOptions); err != nil {
+		return err
+	}
+
+	// enable in systemd
+	log.Debug("enabling docker in systemd")
+	if err := provisioner.Service("docker", serviceaction.Enable); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/libmachine/provision/raspbian_test.go
+++ b/libmachine/provision/raspbian_test.go
@@ -1,0 +1,20 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/provision/provisiontest"
+	"github.com/docker/machine/libmachine/swarm"
+)
+
+func TestRaspbianDefaultStorageDriver(t *testing.T) {
+	p := NewRaspbianProvisioner(&fakedriver.Driver{}).(*RaspbianProvisioner)
+	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
+	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
+	if p.EngineOptions.StorageDriver != "overlay" {
+		t.Fatal("Default storage driver should be overlay")
+	}
+}


### PR DESCRIPTION
**\- What I did**
Adding support to provision the Docker Engine on a standard Raspberry Pi running a raspbian/jessie OS. Refers to https://github.com/docker/docker/issues/24561 and https://github.com/docker/docker/issues/24815.

**\- How I did it**
As Raspbian is just a fork of Debian and is compiled for ARMv6, I just cloned the Debian provisioner and modified it to use Raspbian and use "overlay" as the default storage driver.

**\- How to verify it**
Flash a standard SD card image with latest RASPBIAN JESSIE or RASPBIAN JESSIE LITE, boot the Raspberry Pi and configure the SSH access via SSH keys. A `ssh pi@<ipaddress>` should work correctly without requiring an interactive password.

Next, use `docker-machine` to provision the Docker Engine to the Raspberry Pi with the following commands or shell script:

```
#!/bin/sh
set -x

# access the Raspberry Pi running Raspbian/Jessie
IPADDRESS=192.168.2.115
PI_USERNAME=pi
PI_PASSWORD=raspberry

# deploy a Docker 1.12.0-rc4 on ARMv6
docker-machine --debug create \
  --driver=generic \
  --generic-ip-address=$IPADDRESS \
  --generic-ssh-user=$PI_USERNAME \
  --engine-install-url=https://github.com/DieterReuter/docker/raw/430bf992d933a1a41d7e61e23ca8fa051e98659e/hack/install.sh \
  pi
```

As soon as the PR https://github.com/docker/docker/issues/24815 is merged and a docker-engine .deb package for raspbian/jessie is in the official Docker APT repository, we can use `--engine-install-url=https://test.docker.com`.

Signed-off-by: Dieter Reuter dieter.reuter@me.com
