### PR TITLE
Update digitalocean driver image defaults

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -35,7 +35,7 @@ type Driver struct {
 const (
 	defaultSSHPort = 22
 	defaultSSHUser = "root"
-	defaultImage   = "15621816" // Ubuntu 15.10 x86_64
+	defaultImage   = "ubuntu-16-04-x64"
 	defaultRegion  = "nyc3"
 	defaultSize    = "512mb"
 )


### PR DESCRIPTION
Ubuntu 15.10 image is no longer available on DigitalOcean since it is EOL, We recommend utilizing 16.04.1 LTS as the new default image.

