### PR TITLE
Revert "Bump version for 0.8.0"

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// Version should be updated by hand at each release
-	Version = "0.8.0"
+	Version = "0.7.0"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"


### PR DESCRIPTION
This reverts commit 324f31ea4b9486a97ad928f81b6527e2fa239842.

(I forgot that our release script wants to do this automatically.)