### PR TITLE
Support building a Linux ARMv6 binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="build validate"
     - TARGET_OS=darwin TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=windows TARGET_ARCH=amd64 TARGETS="build-x"
+    - TARGET_OS=linux TARGET_ARCH=arm TARGETS="build-x"
 script:
     - USE_CONTAINER=true make "$TARGETS"
     - "[[ \"$(find bin -type f -name docker-machine*)\" != \"\" ]]"

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -22,7 +22,7 @@ ifeq ($(TARGET_OS),)
 endif
 
 ifeq ($(TARGET_ARCH),)
-  TARGET_ARCH := amd64 386
+  TARGET_ARCH := amd64 arm 386
 endif
 
 # Output prefix, defaults to local directory if not specified

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,13 +1,14 @@
 extension = $(patsubst windows,.exe,$(filter windows,$(1)))
 
 # Valid target combinations
-VALID_OS_ARCH := "[darwin/amd64][linux/amd64][windows/amd64][windows/386]"
+VALID_OS_ARCH := "[darwin/amd64][linux/amd64][linux/arm][windows/amd64][windows/386]"
 
 os.darwin := Darwin
 os.linux := Linux
 os.windows := Windows
 
 arch.amd64 := x86_64
+arch.arm := armhf
 arch.386 := i386
 
 define gocross


### PR DESCRIPTION
In order to support building for Linux on ARM (32bit) we could easily cross compile Docker Machine. As Go defaults to GOARM=6 the compiled binary supports running on ARMv6 and ARMv7 machines which are typically called "armhf" for the Debian distro.

Testing a build locally within Docker and only compile an ARM binary is easy with this command:
```
USE_CONTAINER=true TARGET_OS=linux TARGET_ARCH=arm make build-x
```
It builds the binary `./bin/docker-machine-Linux-armhf`.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>