### PR TITLE
Fix missing '--driver none' from get-start-cloud.md docs

### DIFF
--- a/docs/get-started-cloud.md
+++ b/docs/get-started-cloud.md
@@ -65,7 +65,7 @@ See <a href="../drivers/" target="_blank">Docker Machine driver reference</a> fo
 
 You can add a host to Docker which only has a URL and no driver. Then you can use the machine name you provide here for an existing host so you don’t have to type out the URL every time you run a Docker command.
 
-    $ docker-machine create --url=tcp://50.134.234.20:2376 custombox
+    $ docker-machine create --driver none --url=tcp://50.134.234.20:2376 custombox
     $ docker-machine ls
     NAME        ACTIVE   DRIVER    STATE     URL
     custombox   *        none      Running   tcp://50.134.234.20:2376


### PR DESCRIPTION
Fixes #3652

Signed-off-by: Tao Wang <twang2218@gmail.com>