### PR TITLE
Update certificates error message

### DIFF
--- a/libmachine/check/check.go
+++ b/libmachine/check/check.go
@@ -29,7 +29,7 @@ type ErrCertInvalid struct {
 func (e ErrCertInvalid) Error() string {
 	return fmt.Sprintf(`There was an error validating certificates for host %q: %s
 You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
-Be advised that this will trigger a Docker daemon restart which will stop running containers.
+Be advised that this will trigger a Docker daemon restart which might stop running containers.
 `, e.hostURL, e.wrappedErr)
 }
 


### PR DESCRIPTION
Which is not necessarily true since live-restore was introduced
(https://docs.docker.com/engine/admin/live-restore/).

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>