### PR TITLE
azure: Service principal authentication

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -21,7 +21,7 @@ You will need an Azure Subscription to use this Docker Machine driver.
 [azure]: http://azure.microsoft.com/
 [trial]: https://azure.microsoft.com/free/
 
-## Authentication
+## Authentication (browser-based)
 
 The first time you try to create a machine, Azure driver will ask you to
 authenticate:
@@ -31,15 +31,27 @@ authenticate:
     Microsoft Azure: To sign in, use a web browser to open the page https://aka.ms/devicelogin.
     Enter the code [...] to authenticate.
 
-After authenticating, the driver will remember your credentials up to two weeks.
+- Browser based authentication **credentials expire in 2 weeks**.
+- Once your credentials expire, you will be prompted to log in again.
+- This is practical for daily use; but not recommended for headless applications.
 
-> **KNOWN ISSUE:** There is a known issue with Azure Active Directory causing stored
-> credentials to expire within hours rather than 14 days when the user logs in with
-> personal Microsoft Account (formerly _Live ID_) instead of an Active Directory account.
-> Currently, there is no ETA for resolution, however in the meanwhile you can
-> [create an AAD account][aad-docs] and login with that as a workaround.
+## Authentication (service principal account)
 
-[aad-docs]: https://azure.microsoft.com/documentation/articles/virtual-machines-windows-create-aad-work-id/
+1. Create an Azure Service Principal account ([described here][sp]) to get a
+   `client_id` and `client_secret`
+2. Use `azure role assignment create` command to give your service account
+   `Owner` or `Contributor` roles on your subscription (see article above).
+3. Pass `--azure-client-id` and `--azure-client-secret` arguments (or
+   environment variables) to to `docker-machine`.
+
+Azure Service Principal Account credentials are recommended for headless
+applications (such as CI/CD systems).
+
+The Service Principal Account password created through the `azure ad app create`
+command is valid for 1 year by default, you can use `--end-date` argument to
+specify accounts that last longer.
+
+[sp]: https://www.packer.io/docs/builders/azure-setup.html
 
 ## Options
 
@@ -52,6 +64,8 @@ Required:
 
 Optional:
 
+- `--azure-client-id`: Azure Service Principal Account ID (for headless authentication)
+- `--azure-client-secret`: Azure Service Principal Account password (for headless authentication)
 - `--azure-image`: Azure virtual machine image in the format of Publisher:Offer:Sku:Version [[?][vm-image]]
 - `--azure-location`: Azure region to create the virtual machine. [[?][location]]
 - `--azure-resource-group`: Azure Resource Group name to create the resources in.
@@ -82,6 +96,8 @@ Environment variables and default values:
 | CLI option                      | Environment variable          | Default            |
 | ------------------------------- | ----------------------------- | ------------------ |
 | **`--azure-subscription-id`**   | `AZURE_SUBSCRIPTION_ID`       | -                  |
+| `--azure-client-id`             | `AZURE_CLIENT_ID`             | -                  |
+| `--azure-client-secret`         | `AZURE_CLIENT_SECRET`         | -                  |
 | `--azure-environment`           | `AZURE_ENVIRONMENT`           | `AzurePublicCloud` |
 | `--azure-image`                 | `AZURE_IMAGE`                 | `canonical:UbuntuServer:15.10:latest` |
 | `--azure-location`              | `AZURE_LOCATION`              | `westus`           |

--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -37,12 +37,16 @@ authenticate:
 
 ## Authentication (service principal account)
 
-1. Create an Azure Service Principal account ([described here][sp]) to get a
+1. Create an Azure Service Principal account ([described here][sp-1] or [here][sp-2]) to get a
    `client_id` and `client_secret`
 2. Use `azure role assignment create` command to give your service account
    `Owner` or `Contributor` roles on your subscription (see article above).
 3. Pass `--azure-client-id` and `--azure-client-secret` arguments (or
-   environment variables) to to `docker-machine`.
+   environment variables) to `docker-machine create`.
+
+    $ docker-machine create --driver azure --azure-subscription-id <subs-id> \
+        --azure-client-id <client-id> --azure-client-secret <client-secret> \
+        <machine-name>
 
 Azure Service Principal Account credentials are recommended for headless
 applications (such as CI/CD systems).
@@ -51,7 +55,8 @@ The Service Principal Account password created through the `azure ad app create`
 command is valid for 1 year by default, you can use `--end-date` argument to
 specify accounts that last longer.
 
-[sp]: https://www.packer.io/docs/builders/azure-setup.html
+[sp-1]: https://azure.microsoft.com/documentation/articles/resource-group-authenticate-service-principal-cli/
+[sp-2]: https://www.packer.io/docs/builders/azure-setup.html
 
 ## Options
 

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -53,6 +53,8 @@ const (
 	flAzureNoPublicIP      = "azure-no-public-ip"
 	flAzureStorageType     = "azure-storage-type"
 	flAzureCustomData      = "azure-custom-data"
+	flAzureClientID        = "azure-client-id"
+	flAzureClientSecret    = "azure-client-secret"
 )
 
 const (
@@ -63,6 +65,9 @@ const (
 // Driver represents Azure Docker Machine Driver.
 type Driver struct {
 	*drivers.BaseDriver
+
+	ClientID     string // service principal account name
+	ClientSecret string // service principal account password
 
 	Environment    string
 	SubscriptionID string
@@ -83,7 +88,6 @@ type Driver struct {
 	UsePrivateIP   bool
 	NoPublicIP     bool
 	StaticPublicIP bool
-
 	CustomDataFile string
 
 	// Ephemeral fields
@@ -212,6 +216,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  flAzurePorts,
 			Usage: "Make the specified port number accessible from the Internet",
 		},
+		mcnflag.StringFlag{
+			Name:   flAzureClientID,
+			Usage:  "Azure Service Principal Account ID (optional, browser auth is used if not specified)",
+			EnvVar: "AZURE_CLIENT_ID",
+		},
+		mcnflag.StringFlag{
+			Name:   flAzureClientSecret,
+			Usage:  "Azure Service Principal Account password (optional, browser auth is used if not specified)",
+			EnvVar: "AZURE_CLIENT_SECRET",
+		},
 	}
 }
 
@@ -254,6 +268,9 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.StaticPublicIP = fl.Bool(flAzureStaticPublicIP)
 	d.DockerPort = fl.Int(flAzureDockerPort)
 	d.CustomDataFile = fl.String(flAzureCustomData)
+
+	d.ClientID = fl.String(flAzureClientID)
+	d.ClientSecret = fl.String(flAzureClientSecret)
 
 	// Set flags on the BaseDriver
 	d.BaseDriver.SSHPort = sshPort


### PR DESCRIPTION
This adds a new authentication mode for Azure driver using arguments `--azure-client-id` & `--azure-client-secret`, that works like API key credentials in other drivers (called “Service Principal Account” in Azure).

- allow users to authenticate clients without browser window
  (recommended for headless applications) (fixes #3201, fixes #3493, fixes #3199)
- allow clients to have long-lived credentials (as opposed to current
  model that expires every 2 weeks and requires interactive auth again)
