### PR TITLE
azure: allow vnets from another resource group

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -57,7 +57,8 @@ Optional:
 - `--azure-resource-group`: Azure Resource Group name to create the resources in.
 - `--azure-size`: Size for Azure Virtual Machine. [[?][vm-size]]
 - `--azure-ssh-user`: Username for SSH login.
-- `--azure-vnet`: Azure Virtual Network name to connect the virtual machine. [[?][vnet]]
+- `--azure-vnet`: Azure Virtual Network name to connect the virtual machine.
+  [[?][vnet]] To specify a Virtual Network from another resource group, use `resourcegroup:vnet-name` format. 
 - `--azure-subnet`: Azure Subnet Name to be used within the Virtual Network.
 - `--azure-subnet-prefix`: Private CIDR block. Used to create subnet if it does not exist. Must match in the case that the subnet does exist.
 - `--azure-availability-set`: Azure Availability Set to place the virtual machine into. [[?][av-set]]

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -159,7 +159,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			Name:   flAzureVNet,
-			Usage:  "Azure Virtual Network name to connect the virtual machine",
+			Usage:  "Azure Virtual Network name to connect the virtual machine (in [resourcegroup:]name format)",
 			EnvVar: "AZURE_VNET",
 			Value:  defaultAzureVNet,
 		},
@@ -341,10 +341,11 @@ func (d *Driver) Create() error {
 	if err := c.CreateNetworkSecurityGroup(d.ctx, d.ResourceGroup, d.naming().NSG(), d.Location, d.ctx.FirewallRules); err != nil {
 		return err
 	}
-	if err := c.CreateVirtualNetworkIfNotExists(d.ResourceGroup, d.VirtualNetwork, d.Location); err != nil {
+	vnetResourceGroup, vNetName := parseVirtualNetwork(d.VirtualNetwork, d.ResourceGroup)
+	if err := c.CreateVirtualNetworkIfNotExists(vnetResourceGroup, vNetName, d.Location); err != nil {
 		return err
 	}
-	if err := c.CreateSubnet(d.ctx, d.ResourceGroup, d.VirtualNetwork, d.SubnetName, d.SubnetPrefix); err != nil {
+	if err := c.CreateSubnet(d.ctx, vnetResourceGroup, vNetName, d.SubnetName, d.SubnetPrefix); err != nil {
 		return err
 	}
 	if d.NoPublicIP {

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -181,7 +181,9 @@ func (a AzureClient) DeletePublicIPAddressIfExists(resourceGroup, name string) e
 func (a AzureClient) CreateVirtualNetworkIfNotExists(resourceGroup, name, location string) error {
 	f := logutil.Fields{
 		"name":     name,
-		"location": location}
+		"rg":       resourceGroup,
+		"location": location,
+	}
 
 	log.Info("Querying if virtual network already exists.", f)
 

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -172,4 +173,14 @@ func machineStateForVMPowerState(ps azureutil.VMPowerState) state.State {
 	}
 	log.Warnf("Azure PowerState %q does not map to a docker-machine state.", ps)
 	return state.None
+}
+
+// parseVirtualNetwork parses Virtual Network input format "[resourcegroup:]name"
+// into Resource Group (uses provided one if omitted) and Virtual Network Name
+func parseVirtualNetwork(name string, defaultRG string) (string, string) {
+	l := strings.SplitN(name, ":", 2)
+	if len(l) == 2 {
+		return l[0], l[1]
+	}
+	return defaultRG, name
 }


### PR DESCRIPTION
This change adds support specifying Virtual Networks from another
Resource Group. Most Azure customers already have existing resource
groups and Virtual Network resources that they attach to the new
machines they create.

`--azure-vnet` flag will automatically work with `[group:]name`
format.

Fixes #3656.

@nathanleclaire please review.