### PR TITLE
amazonec2: add support for additional open ports

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -57,6 +57,7 @@ You can use environment variables:
 -   `--amazonec2-zone`: The AWS zone to launch the instance in (i.e. one of a,b,c,d,e).
 -   `--amazonec2-subnet-id`: AWS VPC subnet id.
 -   `--amazonec2-security-group`: AWS VPC security group name.
+-   `--amazonec2-open-port`: Make additional port number(s) accessible from the Internet.
 -   `--amazonec2-tags`: AWS extra tag key-value pairs (comma-separated, e.g. key1,value1,key2,value2).
 -   `--amazonec2-instance-type`: The instance type to run.
 -   `--amazonec2-keypair-name`: AWS keypair to use; requires --amazonec2-ssh-keypath
@@ -88,6 +89,7 @@ Environment variables and default values:
 | `--amazonec2-zone`                       | `AWS_ZONE`              | `a`              |
 | `--amazonec2-subnet-id`                  | `AWS_SUBNET_ID`         | -                |
 | `--amazonec2-security-group`             | `AWS_SECURITY_GROUP`    | `docker-machine` |
+| `--amazonec2-open-port`                  | -                       | -                |
 | `--amazonec2-tags`                       | `AWS_TAGS`              | -                |
 | `--amazonec2-instance-type`              | `AWS_INSTANCE_TYPE`     | `t2.micro`       |
 | `--amazonec2-keypair-name`               | `AWS_KEYPAIR_NAME`      | -                |
@@ -134,7 +136,8 @@ Note that a security group will be created and associated to the host. This secu
 -   swarm (3376/tcp), only if the node is a swarm master
 
 If you specify a security group yourself using the `--amazonec2-security-group` flag, the above ports will be checked and opened and the security group modified.
-If you want more ports to be opened, like application specific ports, use the aws console and modify the configuration manually.
+If you want more ports to be opened, like application specific ports, you can use the `--amazonec2-open-port` flag to
+pass a list of port numbers to be opened or use the aws console and modify the configuration manually.
 
 ## VPC ID
 
@@ -159,7 +162,7 @@ This example assumes the VPC ID was found in the `a` availability zone. Use the`
 ## VPC Connectivity
 Machine uses SSH to complete the set up of instances in EC2 and requires the ability to access the instance directly.  
 
-If you use the flag `--amazonec2-private-address-only`, you will need to ensure that you have some method of accessing the new instance from within the internal network of the VPC (e.g. a corporate VPN to the VPC, a VPN instance inside the VPC or using Docker-machine from an instance within your VPC). 
+If you use the flag `--amazonec2-private-address-only`, you will need to ensure that you have some method of accessing the new instance from within the internal network of the VPC (e.g. a corporate VPN to the VPC, a VPN instance inside the VPC or using Docker-machine from an instance within your VPC).
 
 Configuration of VPCs is beyond the scope of this guide, however the first step in troubleshooting is ensuring if you are using private subnets that you follow the design guidance in the [AWS VPC User Guide](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html) and have some form of NAT available so that the set up process can access the internet to complete set up.
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -80,6 +80,7 @@ type Driver struct {
 	SecurityGroupName  string
 	SecurityGroupNames []string
 
+	OpenPorts               []string
 	Tags                    string
 	ReservationId           string
 	DeviceName              string
@@ -153,6 +154,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "AWS VPC security group",
 			Value:  []string{defaultSecurityGroup},
 			EnvVar: "AWS_SECURITY_GROUP",
+		},
+		mcnflag.StringSliceFlag{
+			Name:  "amazonec2-open-port",
+			Usage: "Make the specified port number accessible from the Internet",
 		},
 		mcnflag.StringFlag{
 			Name:   "amazonec2-tags",
@@ -316,6 +321,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.ExistingKey = flags.String("amazonec2-keypair-name") != ""
 	d.SetSwarmConfigFromFlags(flags)
 	d.RetryCount = flags.Int("amazonec2-retries")
+	d.OpenPorts = flags.StringSlice("amazonec2-open-port")
 
 	if d.KeyName != "" && d.SSHPrivateKeyPath == "" {
 		return errorNoPrivateSSHKey
@@ -1000,7 +1006,10 @@ func (d *Driver) configureSecurityGroups(groupNames []string) error {
 		}
 		d.SecurityGroupIds = append(d.SecurityGroupIds, *group.GroupId)
 
-		perms := d.configureSecurityGroupPermissions(group)
+		perms, err := d.configureSecurityGroupPermissions(group)
+		if err != nil {
+			return err
+		}
 
 		if len(perms) != 0 {
 			log.Debugf("authorizing group %s with permissions: %v", groupNames, perms)
@@ -1017,7 +1026,7 @@ func (d *Driver) configureSecurityGroups(groupNames []string) error {
 	return nil
 }
 
-func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) []*ec2.IpPermission {
+func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) ([]*ec2.IpPermission, error) {
 	hasSshPort := false
 	hasDockerPort := false
 	hasSwarmPort := false
@@ -1063,9 +1072,22 @@ func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) []*
 		})
 	}
 
+	for _, port := range d.OpenPorts {
+		n, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, fmt.Errorf("invalid port number %s: %s", port, err)
+		}
+		perms = append(perms, &ec2.IpPermission{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int64(int64(n)),
+			ToPort:     aws.Int64(int64(n)),
+			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(ipRange)}},
+		})
+	}
+
 	log.Debugf("configuring security group authorization for %s", ipRange)
 
-	return perms
+	return perms, nil
 }
 
 func (d *Driver) deleteKeyPair() error {

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -1072,15 +1072,15 @@ func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) ([]
 		})
 	}
 
-	for _, port := range d.OpenPorts {
-		n, err := strconv.Atoi(port)
+	for _, p := range d.OpenPorts {
+		port, protocol, err := splitPortProto(p)
 		if err != nil {
-			return nil, fmt.Errorf("invalid port number %s: %s", port, err)
+			return nil, err
 		}
 		perms = append(perms, &ec2.IpPermission{
-			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int64(int64(n)),
-			ToPort:     aws.Int64(int64(n)),
+			IpProtocol: aws.String(protocol),
+			FromPort:   aws.Int64(int64(port)),
+			ToPort:     aws.Int64(int64(port)),
 			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(ipRange)}},
 		})
 	}
@@ -1088,6 +1088,20 @@ func (d *Driver) configureSecurityGroupPermissions(group *ec2.SecurityGroup) ([]
 	log.Debugf("configuring security group authorization for %s", ipRange)
 
 	return perms, nil
+}
+
+func splitPortProto(raw string) (port int, protocol string, err error) {
+	parts := strings.Split(raw, "/")
+	if len(parts) == 1 {
+		protocol = "tcp"
+	} else {
+		protocol = parts[1]
+	}
+	port, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid port number %s: %s", parts[0], err)
+	}
+	return port, protocol, nil
 }
 
 func (d *Driver) deleteKeyPair() error {

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -96,18 +96,22 @@ func TestConfigureSecurityGroupPermissionsDockerAndSsh(t *testing.T) {
 
 func TestConfigureSecurityGroupPermissionsOpenPorts(t *testing.T) {
 	driver := NewTestDriver()
-	driver.OpenPorts = []string{"8888", "8080"}
+	driver.OpenPorts = []string{"8888/tcp", "8080/udp", "9090"}
 	perms, err := driver.configureSecurityGroupPermissions(&ec2.SecurityGroup{})
 
 	assert.NoError(t, err)
-	assert.Len(t, perms, 4)
+	assert.Len(t, perms, 5)
 	assert.Equal(t, aws.Int64(int64(8888)), perms[2].ToPort)
+	assert.Equal(t, aws.String("tcp"), perms[2].IpProtocol)
 	assert.Equal(t, aws.Int64(int64(8080)), perms[3].ToPort)
+	assert.Equal(t, aws.String("udp"), perms[3].IpProtocol)
+	assert.Equal(t, aws.Int64(int64(9090)), perms[4].ToPort)
+	assert.Equal(t, aws.String("tcp"), perms[4].IpProtocol)
 }
 
 func TestConfigureSecurityGroupPermissionsInvalidOpenPorts(t *testing.T) {
 	driver := NewTestDriver()
-	driver.OpenPorts = []string{"2222", "abc1"}
+	driver.OpenPorts = []string{"2222/tcp", "abc1"}
 	perms, err := driver.configureSecurityGroupPermissions(&ec2.SecurityGroup{})
 
 	assert.Error(t, err)

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -30,8 +30,9 @@ var (
 func TestConfigureSecurityGroupPermissionsEmpty(t *testing.T) {
 	driver := NewTestDriver()
 
-	perms := driver.configureSecurityGroupPermissions(securityGroup)
+	perms, err := driver.configureSecurityGroupPermissions(securityGroup)
 
+	assert.Nil(t, err)
 	assert.Len(t, perms, 2)
 }
 
@@ -46,8 +47,9 @@ func TestConfigureSecurityGroupPermissionsSshOnly(t *testing.T) {
 		},
 	}
 
-	perms := driver.configureSecurityGroupPermissions(group)
+	perms, err := driver.configureSecurityGroupPermissions(group)
 
+	assert.Nil(t, err)
 	assert.Len(t, perms, 1)
 	assert.Equal(t, testDockerPort, *perms[0].FromPort)
 }
@@ -63,8 +65,9 @@ func TestConfigureSecurityGroupPermissionsDockerOnly(t *testing.T) {
 		},
 	}
 
-	perms := driver.configureSecurityGroupPermissions(group)
+	perms, err := driver.configureSecurityGroupPermissions(group)
 
+	assert.Nil(t, err)
 	assert.Len(t, perms, 1)
 	assert.Equal(t, testSSHPort, *perms[0].FromPort)
 }
@@ -85,9 +88,30 @@ func TestConfigureSecurityGroupPermissionsDockerAndSsh(t *testing.T) {
 		},
 	}
 
-	perms := driver.configureSecurityGroupPermissions(group)
+	perms, err := driver.configureSecurityGroupPermissions(group)
 
+	assert.Nil(t, err)
 	assert.Empty(t, perms)
+}
+
+func TestConfigureSecurityGroupPermissionsOpenPorts(t *testing.T) {
+	driver := NewTestDriver()
+	driver.OpenPorts = []string{"8888", "8080"}
+	perms, err := driver.configureSecurityGroupPermissions(&ec2.SecurityGroup{})
+
+	assert.NoError(t, err)
+	assert.Len(t, perms, 4)
+	assert.Equal(t, aws.Int64(int64(8888)), perms[2].ToPort)
+	assert.Equal(t, aws.Int64(int64(8080)), perms[3].ToPort)
+}
+
+func TestConfigureSecurityGroupPermissionsInvalidOpenPorts(t *testing.T) {
+	driver := NewTestDriver()
+	driver.OpenPorts = []string{"2222", "abc1"}
+	perms, err := driver.configureSecurityGroupPermissions(&ec2.SecurityGroup{})
+
+	assert.Error(t, err)
+	assert.Nil(t, perms)
 }
 
 func TestConfigureSecurityGroupPermissionsWithSwarm(t *testing.T) {
@@ -107,8 +131,9 @@ func TestConfigureSecurityGroupPermissionsWithSwarm(t *testing.T) {
 		},
 	}
 
-	perms := driver.configureSecurityGroupPermissions(group)
+	perms, err := driver.configureSecurityGroupPermissions(group)
 
+	assert.Nil(t, err)
 	assert.Len(t, perms, 1)
 	assert.Equal(t, testSwarmPort, *perms[0].FromPort)
 }


### PR DESCRIPTION
This PR adds a flag to the `amazonec2` driver to enable opening custom ports on the host.
This is a step to add this support for every core driver(where applied) as discussed in #3642(the azure driver already support this flag). 

I kept the same behavior as the azure driver, but I was thinking about supporting the format `port/protocol`(eg `8888/tcp`, `9200/udp`), defaulting the protocol to `tcp` if not set by the user. I decided to open the PR like this because I think the behavior should be the same across all core drivers. If we go for this behavior, I can update this PR and them move on to the other drivers.

cc @nathanleclaire, @ahmetalpbalkan 

Signed-off-by: André Carvalho <andre.carvalho@corp.globo.com>