### PR TITLE
Fix for on-premise EC2 endpoints

### DIFF
--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -11,19 +11,20 @@ type region struct {
 // Release 16.04 LTS 20160516.1
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1": {"ami-5d38d93c"},
-	"ap-northeast-2": {"ami-a3915acd"},
-	"ap-southeast-1": {"ami-a35284c0"},
-	"ap-southeast-2": {"ami-f4361997"},
-	"ap-south-1":     {"ami-f7513b98"},
-	"cn-north-1":     {"ami-79eb2214"}, // 15.10 20151116.1
-	"eu-west-1":      {"ami-7a138709"},
-	"eu-central-1":   {"ami-f9e30f96"},
-	"sa-east-1":      {"ami-0d5dd561"},
-	"us-east-1":      {"ami-13be557e"},
-	"us-west-1":      {"ami-84423ae4"},
-	"us-west-2":      {"ami-06b94666"},
-	"us-gov-west-1":  {"ami-8f4df2ee"},
+	"ap-northeast-1":  {"ami-5d38d93c"},
+	"ap-northeast-2":  {"ami-a3915acd"},
+	"ap-southeast-1":  {"ami-a35284c0"},
+	"ap-southeast-2":  {"ami-f4361997"},
+	"ap-south-1":      {"ami-f7513b98"},
+	"cn-north-1":      {"ami-79eb2214"}, // 15.10 20151116.1
+	"eu-west-1":       {"ami-7a138709"},
+	"eu-central-1":    {"ami-f9e30f96"},
+	"sa-east-1":       {"ami-0d5dd561"},
+	"us-east-1":       {"ami-13be557e"},
+	"us-west-1":       {"ami-84423ae4"},
+	"us-west-2":       {"ami-06b94666"},
+	"us-gov-west-1":   {"ami-8f4df2ee"},
+	"custom-endpoint": {""},
 }
 
 func awsRegionsList() []string {


### PR DESCRIPTION
Added option to select amazonec2-endpoint and amazonec2-insecure-endpoint.

- Disabled region checking when custom endpoint used.

Signed-off-by: Berk Gokden <berkgokden@gmail.com>

This is re based version of pull request 2535 : 
Fixes for on-premise EC2 endpoints #2535 https://github.com/docker/machine/pull/2535
