### PR TITLE
azure: bump default image to Ubuntu 16.04.0-LTS

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -25,7 +25,7 @@ const (
 	defaultAzureLocation        = "westus"
 	defaultSSHUser              = "docker-user" // 'root' not allowed on Azure
 	defaultDockerPort           = 2376
-	defaultAzureImage           = "canonical:UbuntuServer:15.10:latest"
+	defaultAzureImage           = "canonical:UbuntuServer:16.04.0-LTS:latest"
 	defaultAzureVNet            = "docker-machine-vnet"
 	defaultAzureSubnet          = "docker-machine"
 	defaultAzureSubnetPrefix    = "192.168.0.0/16"


### PR DESCRIPTION
Ubuntu 15.10 image is EOL'd and removed from azure.
Closes #3676.

@nathanleclaire PTAL. If there's a dot release coming up soon, can we take this in?