### PR TITLE
Update base images for AWS to 16.04.1

### DIFF
--- a/docs/drivers/aws.md
+++ b/docs/drivers/aws.md
@@ -83,7 +83,7 @@ Environment variables and default values:
 | `--amazonec2-access-key`                 | `AWS_ACCESS_KEY_ID`     | -                |
 | `--amazonec2-secret-key`                 | `AWS_SECRET_ACCESS_KEY` | -                |
 | `--amazonec2-session-token`              | `AWS_SESSION_TOKEN`     | -                |
-| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-13be557e`   |
+| `--amazonec2-ami`                        | `AWS_AMI`               | `ami-c60b90d1`   |
 | `--amazonec2-region`                     | `AWS_DEFAULT_REGION`    | `us-east-1`      |
 | `--amazonec2-vpc-id`                     | `AWS_VPC_ID`            | -                |
 | `--amazonec2-zone`                       | `AWS_ZONE`              | `a`              |
@@ -109,23 +109,23 @@ Environment variables and default values:
 
 ## Default AMIs
 
-By default, the Amazon EC2 driver will use a daily image of Ubuntu 16.04 LTS (Ubuntu 15.10 for cn-north-1).
+By default, the Amazon EC2 driver will use a daily image of Ubuntu 16.04 LTS.
 
 | Region         | AMI ID       |
 | -------------- | ------------ |
-| ap-northeast-1 | ami-5d38d93c |
+| ap-northeast-1 | ami-51f13330 |
 | ap-northeast-2 | ami-a3915acd |
-| ap-southeast-1 | ami-a35284c0 |
-| ap-southeast-2 | ami-f4361997 |
-| ap-south-1     | ami-f7513b98 |
-| cn-north-1     | ami-79eb2214 |
-| eu-west-1      | ami-7a138709 |
-| eu-central-1   | ami-f9e30f96 |
-| sa-east-1      | ami-0d5dd561 |
-| us-east-1      | ami-13be557e |
-| us-west-1      | ami-84423ae4 |
-| us-west-2      | ami-06b94666 |
-| us-gov-west-1  | ami-8f4df2ee |
+| ap-southeast-1 | ami-fec51c9d |
+| ap-southeast-2 | ami-a78ebac4 |
+| ap-south-1     | ami-7e94fe11 |
+| cn-north-1     | ami-2c3bf141 |
+| eu-central-1   | ami-004abc6f |
+| eu-west-1      | ami-c06b1eb3 |
+| sa-east-1      | ami-a674e2ca |
+| us-east-1      | ami-c60b90d1 |
+| us-west-1      | ami-1bf0b37b |
+| us-west-2      | ami-f701cb97 |
+| us-gov-west-1  | ami-76f34a17 |
 
 ## Security Group
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -29,7 +29,7 @@ const (
 	driverName               = "amazonec2"
 	ipRange                  = "0.0.0.0/0"
 	machineSecurityGroupName = "docker-machine"
-	defaultAmiId             = "ami-13be557e"
+	defaultAmiId             = "ami-c60b90d1"
 	defaultRegion            = "us-east-1"
 	defaultInstanceType      = "t2.micro"
 	defaultDeviceName        = "/dev/sda1"

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -8,22 +8,22 @@ type region struct {
 	AmiId string
 }
 
-// Release 16.04 LTS 20160516.1
+// Release 16.04 LTS 20160815
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1":  {"ami-5d38d93c"},
-	"ap-northeast-2":  {"ami-a3915acd"},
-	"ap-southeast-1":  {"ami-a35284c0"},
-	"ap-southeast-2":  {"ami-f4361997"},
-	"ap-south-1":      {"ami-f7513b98"},
-	"cn-north-1":      {"ami-79eb2214"}, // 15.10 20151116.1
-	"eu-west-1":       {"ami-7a138709"},
-	"eu-central-1":    {"ami-f9e30f96"},
-	"sa-east-1":       {"ami-0d5dd561"},
-	"us-east-1":       {"ami-13be557e"},
-	"us-west-1":       {"ami-84423ae4"},
-	"us-west-2":       {"ami-06b94666"},
-	"us-gov-west-1":   {"ami-8f4df2ee"},
+	"ap-northeast-1":  {"ami-51f13330"},
+	"ap-northeast-2":  {"ami-a3915acd"}, // 20160516.1
+	"ap-southeast-1":  {"ami-fec51c9d"},
+	"ap-southeast-2":  {"ami-a78ebac4"},
+	"ap-south-1":      {"ami-7e94fe11"}, // 20160627
+	"cn-north-1":      {"ami-2c3bf141"}, // 20160610
+	"eu-central-1":    {"ami-004abc6f"},
+	"eu-west-1":       {"ami-c06b1eb3"},
+	"sa-east-1":       {"ami-a674e2ca"},
+	"us-east-1":       {"ami-c60b90d1"},
+	"us-west-1":       {"ami-1bf0b37b"},
+	"us-west-2":       {"ami-f701cb97"},
+	"us-gov-west-1":   {"ami-76f34a17"},
 	"custom-endpoint": {""},
 }
 


### PR DESCRIPTION
This PR updates configs and docs on AWS driver.

### features
- update the Ubuntu base image for AWS EC2 to 16.04.1 LTS (20160815) (except for 20160516.1 for `ap-northeast-2`, 20160627 for `ap-south-1`) from 16.04 LTS (20160516.1)
- update the image for AWS EC2 in `cn-north-1` to 16.04 LTS (20160610) from 15.04
    - cf. #3478

### minor fixes
- change the order of `eu-central-1` and `eu-west-1` to keep in alphabetical order
    - It will help save time to update the list.
    - `us-gov-west-1` is still off the grid.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>