### PR TITLE
[provision] fix replace pattern in /etc/hosts

### DIFF
--- a/libmachine/provision/generic.go
+++ b/libmachine/provision/generic.go
@@ -47,9 +47,9 @@ func (provisioner *GenericProvisioner) SetHostname(hostname string) error {
 
 	// ubuntu/debian use 127.0.1.1 for non "localhost" loopback hostnames: https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
 	if _, err := provisioner.SSHCommand(fmt.Sprintf(`
-		if ! grep -xq .*%s /etc/hosts; then
-			if grep -xq 127.0.1.1.* /etc/hosts; then 
-				sudo sed -i 's/^127.0.1.1.*/127.0.1.1 %s/g' /etc/hosts; 
+		if ! grep -xq '.*\s%s' /etc/hosts; then
+			if grep -xq '127.0.1.1\s.*' /etc/hosts; then
+				sudo sed -i 's/^127.0.1.1\s.*/127.0.1.1 %s/g' /etc/hosts;
 			else 
 				echo '127.0.1.1 %s' | sudo tee -a /etc/hosts; 
 			fi


### PR DESCRIPTION
Require a space before the hostname.

Signed-off-by: Bilal Amarni <bilal.amarni@gmail.com>

Since #2486, as we don't check for a space before the hostname, an existing one finishing by the new one wouldn't be replaced.