### PR TITLE
Added check if subnet.DefaultForAz is not nil

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -490,7 +490,7 @@ func (d *Driver) checkPrereqs() error {
 		// try to find default
 		if len(subnets.Subnets) > 1 {
 			for _, subnet := range subnets.Subnets {
-				if *subnet.DefaultForAz {
+				if subnet.DefaultForAz != nil && *subnet.DefaultForAz {
 					d.SubnetId = *subnet.SubnetId
 					break
 				}


### PR DESCRIPTION
Added check if subnet.DefaultForAz is not nil

- subnet.DefaultForAz is an optional parameter and can be empty.
- if subnet.DefaultForAz is empty, it is considered as false.

Reference: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html