### PR TITLE
Remove incorrect hard-coded "fish" shell identification.

### DIFF
--- a/libmachine/shell/shell.go
+++ b/libmachine/shell/shell.go
@@ -22,9 +22,5 @@ func Detect() (string, error) {
 		return "", ErrUnknownShell
 	}
 
-	if os.Getenv("__fish_bin_dir") != "" {
-		return "fish", nil
-	}
-
 	return filepath.Base(shell), nil
 }


### PR DESCRIPTION
Fixes #3496 

The lines I removed cause the shell to be identified as `fish` if the `__fish_bin_dir` environment variable is set, even when `$SHELL` is explicitly set to something else.

This causes a fish user to get the `fish` env when running a non-fish sub-shell.  Until fixed all bash scripts that use `docker-machine env` will fail for `fish` users.