### PR TITLE
Add an option for configuring custom userdata script for the amazonec2 driver.

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -563,8 +563,8 @@ func (d *Driver) securityGroupIds() (ids []string) {
 
 func (d *Driver) Base64UserData() (userdata string, err error) {
 	if d.UserDataFile != "" {
-		buf, io_err := ioutil.ReadFile(d.UserDataFile)
-		if io_err != nil {
+		buf, ioerr := ioutil.ReadFile(d.UserDataFile)
+		if ioerr != nil {
 			err = errorReadingUserData
 			return
 		}

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -3,6 +3,7 @@ package amazonec2
 import (
 	"crypto/md5"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -55,6 +56,7 @@ var (
 	errorMissingSecretKeyOption          = errors.New("amazonec2 driver requires the --amazonec2-secret-key option or proper credentials in ~/.aws/credentials")
 	errorNoVPCIdFound                    = errors.New("amazonec2 driver requires either the --amazonec2-subnet-id or --amazonec2-vpc-id option or an AWS Account with a default vpc-id")
 	errorDisableSSLWithoutCustomEndpoint = errors.New("using --amazonec2-insecure-transport also requires --amazonec2-endpoint")
+	errorReadingUserData                 = errors.New("unable to read --amazonec2-userdata file")
 )
 
 type Driver struct {
@@ -105,6 +107,7 @@ type Driver struct {
 	RetryCount              int
 	Endpoint                string
 	DisableSSL              bool
+	UserDataFile            string
 }
 
 type clientFactory interface {
@@ -261,6 +264,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Disable SSL when sending requests",
 			EnvVar: "AWS_INSECURE_TRANSPORT",
 		},
+		mcnflag.StringFlag{
+			Name:   "amazonec2-userdata",
+			Usage:  "path to file with cloud-init user data",
+			EnvVar: "AWS_USERDATA",
+		},
 	}
 }
 
@@ -352,6 +360,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SetSwarmConfigFromFlags(flags)
 	d.RetryCount = flags.Int("amazonec2-retries")
 	d.OpenPorts = flags.StringSlice("amazonec2-open-port")
+	d.UserDataFile = flags.String("amazonec2-userdata")
 
 	d.DisableSSL = flags.Bool("amazonec2-insecure-transport")
 
@@ -552,6 +561,18 @@ func (d *Driver) securityGroupIds() (ids []string) {
 	return migrateStringToSlice(d.SecurityGroupId, d.SecurityGroupIds)
 }
 
+func (d *Driver) Base64UserData() (userdata string, err error) {
+	if d.UserDataFile != "" {
+		buf, io_err := ioutil.ReadFile(d.UserDataFile)
+		if io_err != nil {
+			err = errorReadingUserData
+			return
+		}
+		userdata = base64.StdEncoding.EncodeToString(buf)
+	}
+	return
+}
+
 func (d *Driver) Create() error {
 	if err := d.checkPrereqs(); err != nil {
 		return err
@@ -565,6 +586,13 @@ func (d *Driver) Create() error {
 
 	if err := d.configureSecurityGroups(d.securityGroupNames()); err != nil {
 		return err
+	}
+
+	var userdata string
+	if b64, err := d.Base64UserData(); err != nil {
+		return err
+	} else {
+		userdata = b64
 	}
 
 	bdm := &ec2.BlockDeviceMapping{
@@ -603,6 +631,7 @@ func (d *Driver) Create() error {
 				},
 				EbsOptimized:        &d.UseEbsOptimizedInstance,
 				BlockDeviceMappings: []*ec2.BlockDeviceMapping{bdm},
+				UserData:            &userdata,
 			},
 			InstanceCount: aws.Int64(1),
 			SpotPrice:     &d.SpotPrice,
@@ -674,6 +703,7 @@ func (d *Driver) Create() error {
 			},
 			EbsOptimized:        &d.UseEbsOptimizedInstance,
 			BlockDeviceMappings: []*ec2.BlockDeviceMapping{bdm},
+			UserData:            &userdata,
 		})
 
 		if err != nil {


### PR DESCRIPTION
Added --amazonec2-userdata flag that accepts the path to a file containing a custom User Data script provided to the instance when it is launched. Updated documentation

for the amazonec2 driver to reflect the new option.  Fixes #3778

Signed-off-by: Gordon Shankman gshankman@gmail.com
