### PR TITLE
Use net.JoinHostPort in ssh.Dial commands to allow for ipv6 addresses to work properly.

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/term"
@@ -154,7 +156,7 @@ func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
 }
 
 func (client *NativeClient) dialSuccess() bool {
-	if _, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", client.Hostname, client.Port), &client.Config); err != nil {
+	if _, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config); err != nil {
 		log.Debugf("Error dialing TCP: %s", err)
 		return false
 	}
@@ -166,7 +168,7 @@ func (client *NativeClient) session(command string) (*ssh.Session, error) {
 		return nil, fmt.Errorf("Error attempting SSH client dial: %s", err)
 	}
 
-	conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", client.Hostname, client.Port), &client.Config)
+	conn, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config)
 	if err != nil {
 		return nil, fmt.Errorf("Mysterious error dialing TCP for SSH (we already succeeded at least once) : %s", err)
 	}
@@ -250,7 +252,7 @@ func (client *NativeClient) Shell(args ...string) error {
 	var (
 		termWidth, termHeight int
 	)
-	conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", client.Hostname, client.Port), &client.Config)
+	conn, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There was an issue encountered in Windows where when using Powershell/cmd (which did not have an ssh command by default), calls using ssh.Dial would use the native go ssh binary which had an error handling ipv6 addresses (which Hyper V uses by default).  This fix puts the hostname:port in a format that allows it to work properly.  