### PR TITLE
azure: add flag for static dns label

### DIFF
--- a/docs/drivers/azure.md
+++ b/docs/drivers/azure.md
@@ -86,6 +86,7 @@ Optional:
 - `--azure-use-private-ip`: Use private IP address of the machine to connect. It's useful for managing Docker machines from another machine on the same network e.g. while deploying Swarm.
 - `--azure-no-public-ip`: Do not create a public IP address for the machine (implies `--azure-use-private-ip`). Should be used only when creating machines from an Azure VM within the same subnet.
 - `--azure-static-public-ip`: Assign a static public IP address to the machine.
+- `--azure-dns`: A unique DNS label for the public IP adddress.
 - `--azure-docker-port`: Port number for Docker engine.
 - `--azure-environment`: Azure environment (e.g. `AzurePublicCloud`, `AzureChinaCloud`).
 - `--azure-storage-type`: Type of Azure Storage account hosting the OS disk of the machine (e.g. `Standard_LRS`, `Premium_LRS`).
@@ -116,6 +117,7 @@ Environment variables and default values:
 | `--azure-availability-set`      | `AZURE_AVAILABILITY_SET`      | `docker-machine`   |
 | `--azure-storage-type`          | `AZURE_STORAGE_TYPE`          | `Standard_LRS`     |
 | `--azure-custom-data`           | `AZURE_CUSTOM_DATA_FILE`      | -                  |
+| `--azure-dns`                   | `AZURE_DNS_LABEL`             | -                  |
 | `--azure-open-port`             | -                             | -                  |
 | `--azure-private-ip-address`    | -                             | -                  |
 | `--azure-use-private-ip`        | -                             | -                  |

--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -51,6 +51,7 @@ const (
 	flAzureUsePrivateIP    = "azure-use-private-ip"
 	flAzureStaticPublicIP  = "azure-static-public-ip"
 	flAzureNoPublicIP      = "azure-no-public-ip"
+	flAzureDNSLabel        = "azure-dns"
 	flAzureStorageType     = "azure-storage-type"
 	flAzureCustomData      = "azure-custom-data"
 	flAzureClientID        = "azure-client-id"
@@ -87,6 +88,7 @@ type Driver struct {
 	PrivateIPAddr  string
 	UsePrivateIP   bool
 	NoPublicIP     bool
+	DNSLabel       string
 	StaticPublicIP bool
 	CustomDataFile string
 
@@ -212,6 +214,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:  flAzureStaticPublicIP,
 			Usage: "Assign a static public IP address to the machine",
 		},
+		mcnflag.StringFlag{
+			Name:   flAzureDNSLabel,
+			Usage:  "A unique DNS label for the public IP adddress",
+			EnvVar: "AZURE_DNS_LABEL",
+		},
 		mcnflag.StringSliceFlag{
 			Name:  flAzurePorts,
 			Usage: "Make the specified port number accessible from the Internet",
@@ -267,6 +274,7 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	d.NoPublicIP = fl.Bool(flAzureNoPublicIP)
 	d.StaticPublicIP = fl.Bool(flAzureStaticPublicIP)
 	d.DockerPort = fl.Int(flAzureDockerPort)
+	d.DNSLabel = fl.String(flAzureDNSLabel)
 	d.CustomDataFile = fl.String(flAzureCustomData)
 
 	d.ClientID = fl.String(flAzureClientID)
@@ -368,7 +376,7 @@ func (d *Driver) Create() error {
 	if d.NoPublicIP {
 		log.Info("Not creating a public IP address.")
 	} else {
-		if err := c.CreatePublicIPAddress(d.ctx, d.ResourceGroup, d.naming().IP(), d.Location, d.StaticPublicIP); err != nil {
+		if err := c.CreatePublicIPAddress(d.ctx, d.ResourceGroup, d.naming().IP(), d.Location, d.StaticPublicIP, d.DNSLabel); err != nil {
 			return err
 		}
 	}

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -159,7 +159,9 @@ func (d *Driver) ipAddress() (ip string, err error) {
 		ip, err = c.GetPrivateIPAddress(d.ResourceGroup, d.naming().NIC())
 	} else {
 		ipType = "Public"
-		ip, err = c.GetPublicIPAddress(d.ResourceGroup, d.naming().IP())
+		ip, err = c.GetPublicIPAddress(d.ResourceGroup,
+			d.naming().IP(),
+			d.DNSLabel != "")
 	}
 
 	log.Debugf("Retrieving %s IP address...", ipType)


### PR DESCRIPTION
Introducing `--azure-dns` argument which creates a FQDN to the
created public IP resource for the VM. This way, users don't have to
pay for a static IP address.

e.g. a value like `foo` will be later used as IP `foo.westus.azure.cloudapp.net`.

Also modifying `ip` subcommand to operate on FQDN, where possible so that
the generated certs etc do not require re-generation when IP of the VM changes.

