### PR TITLE
drivers/azure: adds test to getSecurityRules

### DIFF
--- a/drivers/azure/util_test.go
+++ b/drivers/azure/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/docker/machine/libmachine/drivers"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,5 +28,26 @@ func TestParseSecurityRuleProtocol(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
+	}
+}
+
+func TestGetSecurityRules(t *testing.T) {
+	d := Driver{BaseDriver: &drivers.BaseDriver{SSHPort: 22}, DockerPort: 2376}
+	expected := []struct {
+		name     string
+		protocol network.SecurityRuleProtocol
+		port     string
+	}{
+		{"SSHAllowAny", network.TCP, "22"},
+		{"DockerAllowAny", network.TCP, "2376"},
+		{"Port123TcpAllowAny", network.TCP, "123"},
+		{"Port123UdpAllowAny", network.UDP, "123"},
+	}
+	rules, err := d.getSecurityRules([]string{"123/tcp", "123/udp"})
+	assert.Nil(t, err)
+	for i, r := range *rules {
+		assert.EqualValues(t, expected[i].name, *r.Name)
+		assert.EqualValues(t, expected[i].protocol, r.Properties.Protocol)
+		assert.EqualValues(t, expected[i].port, *r.Properties.DestinationPortRange)
 	}
 }


### PR DESCRIPTION
This adds a test to the getSecurityRules driver method, and is related to #3777.

@ahmetalpbalkan, I was not able to reproduce the issue reported on #3777, I tried with the test on this PR, the rules are not being created with `/` in their name. 

I will try to dig in a little more, but since I don't have an Azure account, I can't try to reproduce it with a manual test to get more insight

Signed-off-by: André Carvalho <andre.carvalho@corp.globo.com>