### PR TITLE
drivers/azure: fix security rule naming

### DIFF
--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -133,7 +133,9 @@ func (d *Driver) getSecurityRules(extraPorts []string) (*[]network.SecurityRule,
 			return nil, fmt.Errorf("cannot parse security rule protocol: %v", err)
 		}
 		log.Debugf("User-requested port to be opened on NSG: %v/%s", port, proto)
-		r := mkRule(basePri+i, fmt.Sprintf("Port%s%sAllowAny", port, proto), "User requested port to be accessible from Internet via docker-machine", "*", port, proto)
+		name := fmt.Sprintf("Port%s-%sAllowAny", port, proto)
+		name = strings.Replace(name, "*", "Asterisk", -1)
+		r := mkRule(basePri+i, name, "User requested port to be accessible from Internet via docker-machine", "*", port, proto)
 		rl = append(rl, r)
 	}
 	log.Debugf("Total NSG rules: %d", len(rl))


### PR DESCRIPTION
This removes forbidden characters from the security rule naming,
which prevents the user from creating security rules using
custom protocols.

Tested running: `docker-machine create -d azure --azure-open-port 5000/udp --azure-open-port 2326/* --azure-open-port 8080 --azure-image 'coreos:coreos:stable:latest' azure5`

Which yields the following rules:

![image](https://cloud.githubusercontent.com/assets/2944739/18812333/2f011f1c-82a7-11e6-9ccc-acf0730fe811.png)

Fixes #3777 

Signed-off-by: André Carvalho <andre.carvalho@corp.globo.com>