### PR TITLE
Use default AWS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Provisioners
 - Fix issue with generated systemd service file on RedHat family distros
 Drivers
+- `amazonec2`
+    - In case no credentials are stored in `config.json`, use defaults as per [AWS SDK](http://github.com/aws/aws-sdk/go)
 - `azure`
     - Bump Ubuntu image to 16.04
     - Update docs with updated default parameters


### PR DESCRIPTION
If AWS credentials are not stored in machines `config.json`, use [AWS SDK](http://github.com/aws/aws-sdk-go) default. First step to fixing #533.