### PR TITLE
azure: do not reuse service principal accounts for other machines

### DIFF
--- a/drivers/azure/azureutil/auth.go
+++ b/drivers/azure/azureutil/auth.go
@@ -44,34 +44,21 @@ var (
 	}
 )
 
-// Authenticate fetches a token from the local file cache or initiates a consent
-// flow and waits for token to be obtained.
-func Authenticate(env azure.Environment, subscriptionID string, getToken AuthFunc) (*azure.ServicePrincipalToken, error) {
-	appID, ok := appIDs[env.Name]
-	if !ok {
-		return nil, fmt.Errorf("docker-machine application not set up for Azure environment %q", env.Name)
-	}
-
+// AuthenticateDeviceFlow fetches a token from the local file cache or initiates a consent
+// flow and waits for token to be obtained. Obtained token is stored in a file cache for
+// future use and refreshing.
+func AuthenticateDeviceFlow(env azure.Environment, subscriptionID string) (*azure.ServicePrincipalToken, error) {
 	// First we locate the tenant ID of the subscription as we store tokens per
 	// tenant (which could have multiple subscriptions)
-	log.Debug("Looking up AAD Tenant ID.", logutil.Fields{
-		"subs": subscriptionID})
 	tenantID, err := loadOrFindTenantID(env, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("Found AAD Tenant ID.", logutil.Fields{
-		"tenant": tenantID,
-		"subs":   subscriptionID})
-
 	oauthCfg, err := env.OAuthConfigForTenant(tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to obtain oauth config for azure environment: %v", err)
 	}
 
-	// for AzurePublicCloud (https://management.core.windows.net/), this old
-	// Service Management scope covers both ASM and ARM.
-	apiScope := env.ServiceManagementEndpoint
 	tokenPath := tokenCachePath(tenantID)
 	saveToken := mkTokenCallback(tokenPath)
 	saveTokenCallback := func(t azure.Token) error {
@@ -80,8 +67,14 @@ func Authenticate(env azure.Environment, subscriptionID string, getToken AuthFun
 	}
 	f := logutil.Fields{"path": tokenPath}
 
+	appID, ok := appIDs[env.Name]
+	if !ok {
+		return nil, fmt.Errorf("docker-machine application not set up for Azure environment %q", env.Name)
+	}
+	scope := getScope(env)
+
 	// Lookup the token cache file for an existing token.
-	spt, err := tokenFromFile(*oauthCfg, tokenPath, appID, apiScope, saveTokenCallback)
+	spt, err := tokenFromFile(*oauthCfg, tokenPath, appID, scope, saveTokenCallback)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +107,7 @@ func Authenticate(env azure.Environment, subscriptionID string, getToken AuthFun
 	}
 
 	log.Debug("Obtaining a token.", f)
-	spt, err = getToken(*oauthCfg, appID, apiScope)
+	spt, err = deviceFlowAuth(*oauthCfg, appID, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +115,25 @@ func Authenticate(env azure.Environment, subscriptionID string, getToken AuthFun
 	if err := saveToken(spt.Token); err != nil {
 		log.Error("Error occurred saving token to cache file.")
 		return nil, err
+	}
+	return spt, nil
+}
+
+// AuthenticateServicePrincipal uses given service principal credentials to return a
+// service principal token. Generated token is not stored in a cache file or refreshed.
+func AuthenticateServicePrincipal(env azure.Environment, subscriptionID, spID, spPassword string) (*azure.ServicePrincipalToken, error) {
+	tenantID, err := loadOrFindTenantID(env, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	oauthCfg, err := env.OAuthConfigForTenant(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to obtain oauth config for azure environment: %v", err)
+	}
+
+	spt, err := azure.NewServicePrincipalToken(*oauthCfg, spID, spPassword, getScope(env))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create service principal token: %+v", err)
 	}
 	return spt, nil
 }
@@ -150,14 +162,11 @@ func tokenFromFile(oauthCfg azure.OAuthConfig, tokenPath, clientID, resource str
 	return spt, nil
 }
 
-// AuthFunc determines the authentication flow to retrieve a token from Azure.
-type AuthFunc func(oauthCfg azure.OAuthConfig, clientID, resource string) (*azure.ServicePrincipalToken, error)
-
-// DeviceFlowAuth prints a message to the screen for user to take action to
+// deviceFlowAuth prints a message to the screen for user to take action to
 // consent application on a browser and in the meanwhile the authentication
 // endpoint is polled until user gives consent, denies or the flow times out.
 // Returned token must be saved.
-func DeviceFlowAuth(oauthCfg azure.OAuthConfig, clientID, resource string) (*azure.ServicePrincipalToken, error) {
+func deviceFlowAuth(oauthCfg azure.OAuthConfig, clientID, resource string) (*azure.ServicePrincipalToken, error) {
 	cl := oauthClient()
 	deviceCode, err := azure.InitiateDeviceAuth(&cl, oauthCfg, clientID, resource)
 	if err != nil {
@@ -184,23 +193,6 @@ func DeviceFlowAuth(oauthCfg azure.OAuthConfig, clientID, resource string) (*azu
 	return spt, nil
 }
 
-// ServicePrincipalAuth creates a new AuthFunc that authenticates to Azure
-// using the provided Service Principal Account credentials (client_id and
-// client_secret).
-func ServicePrincipalAuth(spID, spPassword string) AuthFunc {
-	return func(oauthCfg azure.OAuthConfig, _, resource string) (*azure.ServicePrincipalToken, error) {
-		spt, err := azure.NewServicePrincipalToken(oauthCfg, spID, spPassword, resource)
-		if err != nil {
-			return nil, err
-		}
-		// force Refresh() to get a token to be stored.
-		if err := spt.Refresh(); err != nil {
-			return nil, fmt.Errorf("Failed to get a token with service principal: %v", err)
-		}
-		return spt, nil
-	}
-}
-
 // azureCredsPath returns the directory the azure credentials are stored in.
 func azureCredsPath() string {
 	return filepath.Join(mcnutils.GetHomeDir(), ".docker", "machine", "credentials", "azure")
@@ -213,7 +205,7 @@ func tokenCachePath(tenantID string) string {
 }
 
 // tenantIDPath returns the full path the tenant ID for the given subscription
-// should be saved at.
+// should be saved at.f
 func tenantIDPath(subscriptionID string) string {
 	return filepath.Join(azureCredsPath(), fmt.Sprintf("%s.tenantid", subscriptionID))
 }
@@ -243,4 +235,11 @@ func validateToken(env azure.Environment, token *azure.ServicePrincipalToken) er
 		return fmt.Errorf("Token validity check failed: %v", err)
 	}
 	return nil
+}
+
+// getScope returns the API scope for authnetication tokens.
+func getScope(env azure.Environment) string {
+	// for AzurePublicCloud (https://management.core.windows.net/), this old
+	// Service Management scope covers both ASM and ARM.
+	return env.ServiceManagementEndpoint
 }

--- a/drivers/azure/azureutil/tenantid.go
+++ b/drivers/azure/azureutil/tenantid.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docker/machine/drivers/azure/logutil"
 	"github.com/docker/machine/libmachine/log"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -19,6 +20,9 @@ import (
 // cache it for future use.
 func loadOrFindTenantID(env azure.Environment, subscriptionID string) (string, error) {
 	var tenantID string
+
+	log.Debug("Looking up AAD Tenant ID.", logutil.Fields{
+		"subs": subscriptionID})
 
 	// Load from cache
 	fp := tenantIDPath(subscriptionID)
@@ -47,6 +51,9 @@ func loadOrFindTenantID(env azure.Environment, subscriptionID string) (string, e
 		}
 		log.Debugf("Cached tenant ID to file: %s", fp)
 	}
+	log.Debug("Found AAD Tenant ID.", logutil.Fields{
+		"tenant": tenantID,
+		"subs":   subscriptionID})
 	return tenantID, nil
 }
 

--- a/drivers/azure/util.go
+++ b/drivers/azure/util.go
@@ -42,20 +42,24 @@ func (d *Driver) newAzureClient() (*azureutil.AzureClient, error) {
 		return nil, fmt.Errorf("Invalid Azure environment: %q", d.Environment)
 	}
 
-	var auth azureutil.AuthFunc
+	var (
+		token *azure.ServicePrincipalToken
+		err   error
+	)
 	if d.ClientID != "" && d.ClientSecret != "" { // use Service Principal auth
 		log.Debug("Using Azure service principal authentication.")
-		auth = azureutil.ServicePrincipalAuth(d.ClientID, d.ClientSecret)
+		token, err = azureutil.AuthenticateServicePrincipal(env, d.SubscriptionID, d.ClientID, d.ClientSecret)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to authenticate using service principal credentials: %+v", err)
+		}
 	} else { // use browser-based device auth
 		log.Debug("Using Azure device flow authentication.")
-		auth = azureutil.DeviceFlowAuth
+		token, err = azureutil.AuthenticateDeviceFlow(env, d.SubscriptionID)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating Azure client: %v", err)
+		}
 	}
-
-	servicePrincipalToken, err := azureutil.Authenticate(env, d.SubscriptionID, auth)
-	if err != nil {
-		return nil, fmt.Errorf("Error creating Azure client: %v", err)
-	}
-	return azureutil.New(env, d.SubscriptionID, servicePrincipalToken), nil
+	return azureutil.New(env, d.SubscriptionID, token), nil
 }
 
 // generateSSHKey creates a ssh key pair locally and saves the public key file


### PR DESCRIPTION
This prevents --azure-client-id/--azure-client-secret pair provided for a machine to be stored and then reused by other machines created in the same subscription.

Fixes #3782.

@vincent99 @nathanleclaire  PTAL