### PR TITLE
New option for virtualbox driver to set custom shared folder

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -193,8 +193,8 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		},
 		mcnflag.StringFlag{
 			EnvVar: "VIRTUALBOX_SHARE_FOLDER",
-			Name: "virtualbox-share-folder",
-			Usage: "Mount the specified directory instead of the default home location. Format: dir:name",
+			Name:   "virtualbox-share-folder",
+			Usage:  "Mount the specified directory instead of the default home location. Format: dir:name",
 		},
 	}
 }

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -69,6 +69,7 @@ type Driver struct {
 	NoShare             bool
 	DNSProxy            bool
 	NoVTXCheck          bool
+	ShareFolder         string
 }
 
 // NewDriver creates a new VirtualBox driver with default settings.
@@ -190,6 +191,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Disable checking for the availability of hardware virtualization before the vm is started",
 			EnvVar: "VIRTUALBOX_NO_VTX_CHECK",
 		},
+		mcnflag.StringFlag{
+			EnvVar: "VIRTUALBOX_SHARE_FOLDER",
+			Name: "virtualbox-share-folder",
+			Usage: "Mount the specified directory instead of the default home location. Format: dir:name",
+		},
 	}
 }
 
@@ -242,6 +248,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.NoShare = flags.Bool("virtualbox-no-share")
 	d.DNSProxy = !flags.Bool("virtualbox-no-dns-proxy")
 	d.NoVTXCheck = flags.Bool("virtualbox-no-vtx-check")
+	d.ShareFolder = flags.String("virtualbox-share-folder")
 
 	return nil
 }
@@ -447,6 +454,11 @@ func (d *Driver) CreateVM() error {
 	}
 
 	shareName, shareDir := getShareDriveAndName()
+
+	if d.ShareFolder != "" {
+		split := strings.Split(d.ShareFolder, ":")
+		shareDir, shareName = split[0], split[1]
+	}
 
 	if shareDir != "" && !d.NoShare {
 		log.Debugf("setting up shareDir")


### PR DESCRIPTION
I'm an OSX user, who has his $HOME outside /Users. It was moved to a secondary hard drive.

With this setup, I had difficulties using docker volumes, so I've added a new parameter to docker-machine's virtualbox driver that I can use to specify the location of my alternative /Users directory.

The format is --virtualbox-share-folder /path/to/folder:sharename. Automatic mounting currently only works with sharename == Users, for custom sharenames some work is needed on the boot2docker side1.

(My previous pull request #2100 was successfully ruined by sourcetree and me together...)
