### PR TITLE
Update AWS Credentials lookup to use AWS default provider chain.

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -296,7 +296,7 @@ func (d *Driver) buildClient() Ec2Client {
 }
 
 func (d *Driver) buildCredentials() awsCredentials {
-	return NewAWSCredentials(d.AccessKey, d.SecretKey, d.SessionToken, "", "")
+	return NewAWSCredentials(d.AccessKey, d.SecretKey, d.SessionToken)
 }
 
 func (d *Driver) getClient() Ec2Client {

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -50,23 +50,22 @@ var (
 	dockerPort                           = 2376
 	swarmPort                            = 3376
 	errorNoPrivateSSHKey                 = errors.New("using --amazonec2-keypair-name also requires --amazonec2-ssh-keypath")
-	errorMissingAccessKeyOption          = errors.New("amazonec2 driver requires the --amazonec2-access-key option or proper credentials in ~/.aws/credentials")
-	errorMissingSecretKeyOption          = errors.New("amazonec2 driver requires the --amazonec2-secret-key option or proper credentials in ~/.aws/credentials")
+	errorMissingCredentials              = errors.New("amazonec2 driver requires AWS credentials configured with the --amazonec2-access-key and --amazonec2-secret-key options, environment variables, ~/.aws/credentials, or an instance role")
 	errorNoVPCIdFound                    = errors.New("amazonec2 driver requires either the --amazonec2-subnet-id or --amazonec2-vpc-id option or an AWS Account with a default vpc-id")
 	errorDisableSSLWithoutCustomEndpoint = errors.New("using --amazonec2-insecure-transport also requires --amazonec2-endpoint")
 )
 
 type Driver struct {
 	*drivers.BaseDriver
-	clientFactory  func() Ec2Client
-	awsCredentials awsCredentials
-	Id             string
-	AccessKey      string
-	SecretKey      string
-	SessionToken   string
-	Region         string
-	AMI            string
-	SSHKeyID       int
+	clientFactory         func() Ec2Client
+	awsCredentialsFactory func() awsCredentials
+	Id                    string
+	AccessKey             string
+	SecretKey             string
+	SessionToken          string
+	Region                string
+	AMI                   string
+	SSHKeyID              int
 	// ExistingKey keeps track of whether the key was created by us or we used an existing one. If an existing one was used, we shouldn't delete it when the machine is deleted.
 	ExistingKey      bool
 	KeyName          string
@@ -273,10 +272,10 @@ func NewDriver(hostName, storePath string) *Driver {
 			MachineName: hostName,
 			StorePath:   storePath,
 		},
-		awsCredentials: &defaultAWSCredentials{},
 	}
 
 	driver.clientFactory = driver.buildClient
+	driver.awsCredentialsFactory = driver.buildCredentials
 
 	return driver
 }
@@ -285,7 +284,7 @@ func (d *Driver) buildClient() Ec2Client {
 	config := aws.NewConfig()
 	alogger := AwsLogger()
 	config = config.WithRegion(d.Region)
-	config = config.WithCredentials(d.awsCredentials.NewStaticCredentials(d.AccessKey, d.SecretKey, d.SessionToken))
+	config = config.WithCredentials(d.awsCredentialsFactory().Credentials())
 	config = config.WithLogger(alogger)
 	config = config.WithLogLevel(aws.LogDebugWithHTTPBody)
 	config = config.WithMaxRetries(d.RetryCount)
@@ -294,6 +293,10 @@ func (d *Driver) buildClient() Ec2Client {
 		config = config.WithDisableSSL(d.DisableSSL)
 	}
 	return ec2.New(session.New(config))
+}
+
+func (d *Driver) buildCredentials() awsCredentials {
+	return NewAWSCredentials(d.AccessKey, d.SecretKey, d.SessionToken, "", "")
 }
 
 func (d *Driver) getClient() Ec2Client {
@@ -354,24 +357,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		return errorNoPrivateSSHKey
 	}
 
-	if d.AccessKey == "" && d.SecretKey == "" {
-		credentials, err := d.awsCredentials.NewSharedCredentials("", "").Get()
-		if err != nil {
-			log.Debug("Could not load credentials from ~/.aws/credentials")
-		} else {
-			log.Debug("Successfully loaded credentials from ~/.aws/credentials")
-			d.AccessKey = credentials.AccessKeyID
-			d.SecretKey = credentials.SecretAccessKey
-			d.SessionToken = credentials.SessionToken
-		}
-	}
-
-	if d.AccessKey == "" {
-		return errorMissingAccessKeyOption
-	}
-
-	if d.SecretKey == "" {
-		return errorMissingSecretKeyOption
+	_, err = d.awsCredentialsFactory().Credentials().Get()
+	if err != nil {
+		return errorMissingCredentials
 	}
 
 	if d.VpcId == "" {

--- a/drivers/amazonec2/awscredentials.go
+++ b/drivers/amazonec2/awscredentials.go
@@ -1,19 +1,79 @@
 package amazonec2
 
-import "github.com/aws/aws-sdk-go/aws/credentials"
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
 
 type awsCredentials interface {
-	NewStaticCredentials(id, secret, token string) *credentials.Credentials
-
-	NewSharedCredentials(filename, profile string) *credentials.Credentials
+	Credentials() *credentials.Credentials
 }
 
-type defaultAWSCredentials struct{}
+type ProviderFactory interface {
+	NewStaticProvider(id, secret, token string) credentials.Provider
 
-func (c *defaultAWSCredentials) NewStaticCredentials(id, secret, token string) *credentials.Credentials {
-	return credentials.NewStaticCredentials(id, secret, token)
+	NewSharedProvider(filename, profile string) credentials.Provider
 }
 
-func (c *defaultAWSCredentials) NewSharedCredentials(filename, profile string) *credentials.Credentials {
-	return credentials.NewSharedCredentials(filename, profile)
+type defaultAWSCredentials struct {
+	AccessKey        string
+	SecretKey        string
+	SessionToken     string
+	Filename         string
+	Profile          string
+	providerFactory  ProviderFactory
+	fallbackProvider awsCredentials
+}
+
+func NewAWSCredentials(id, secret, token, filename, profile string) *defaultAWSCredentials {
+	creds := defaultAWSCredentials{
+		AccessKey:        id,
+		SecretKey:        secret,
+		SessionToken:     token,
+		Filename:         filename,
+		Profile:          profile,
+		fallbackProvider: &AwsDefaultCredentialsProvider{},
+		providerFactory:  &defaultProviderFactory{},
+	}
+	return &creds
+}
+
+func (c *defaultAWSCredentials) Credentials() *credentials.Credentials {
+	providers := []credentials.Provider{}
+	if c.AccessKey != "" && c.SecretKey != "" {
+		providers = append(providers, c.providerFactory.NewStaticProvider(c.AccessKey, c.SecretKey, c.SessionToken))
+	}
+	if c.Filename != "" || c.Profile != "" {
+		providers = append(providers, c.providerFactory.NewSharedProvider(c.Filename, c.Profile))
+	}
+	if c.fallbackProvider != nil {
+		fallbackCreds, err := c.fallbackProvider.Credentials().Get()
+		if err == nil {
+			providers = append(providers, &credentials.StaticProvider{Value: fallbackCreds})
+		}
+	}
+	return credentials.NewChainCredentials(providers)
+}
+
+type AwsDefaultCredentialsProvider struct{}
+
+func (c *AwsDefaultCredentialsProvider) Credentials() *credentials.Credentials {
+	return session.New().Config.Credentials
+}
+
+type defaultProviderFactory struct{}
+
+func (c *defaultProviderFactory) NewStaticProvider(id, secret, token string) credentials.Provider {
+	return &credentials.StaticProvider{Value: credentials.Value{
+		AccessKeyID:     id,
+		SecretAccessKey: secret,
+		SessionToken:    token,
+	}}
+}
+
+func (c *defaultProviderFactory) NewSharedProvider(filename, profile string) credentials.Provider {
+	return &credentials.SharedCredentialsProvider{
+		Filename: filename,
+		Profile:  profile,
+	}
 }

--- a/drivers/amazonec2/awscredentials.go
+++ b/drivers/amazonec2/awscredentials.go
@@ -11,27 +11,21 @@ type awsCredentials interface {
 
 type ProviderFactory interface {
 	NewStaticProvider(id, secret, token string) credentials.Provider
-
-	NewSharedProvider(filename, profile string) credentials.Provider
 }
 
 type defaultAWSCredentials struct {
 	AccessKey        string
 	SecretKey        string
 	SessionToken     string
-	Filename         string
-	Profile          string
 	providerFactory  ProviderFactory
 	fallbackProvider awsCredentials
 }
 
-func NewAWSCredentials(id, secret, token, filename, profile string) *defaultAWSCredentials {
+func NewAWSCredentials(id, secret, token string) *defaultAWSCredentials {
 	creds := defaultAWSCredentials{
 		AccessKey:        id,
 		SecretKey:        secret,
 		SessionToken:     token,
-		Filename:         filename,
-		Profile:          profile,
 		fallbackProvider: &AwsDefaultCredentialsProvider{},
 		providerFactory:  &defaultProviderFactory{},
 	}
@@ -42,9 +36,6 @@ func (c *defaultAWSCredentials) Credentials() *credentials.Credentials {
 	providers := []credentials.Provider{}
 	if c.AccessKey != "" && c.SecretKey != "" {
 		providers = append(providers, c.providerFactory.NewStaticProvider(c.AccessKey, c.SecretKey, c.SessionToken))
-	}
-	if c.Filename != "" || c.Profile != "" {
-		providers = append(providers, c.providerFactory.NewSharedProvider(c.Filename, c.Profile))
 	}
 	if c.fallbackProvider != nil {
 		fallbackCreds, err := c.fallbackProvider.Credentials().Get()
@@ -69,11 +60,4 @@ func (c *defaultProviderFactory) NewStaticProvider(id, secret, token string) cre
 		SecretAccessKey: secret,
 		SessionToken:    token,
 	}}
-}
-
-func (c *defaultProviderFactory) NewSharedProvider(filename, profile string) credentials.Provider {
-	return &credentials.SharedCredentialsProvider{
-		Filename: filename,
-		Profile:  profile,
-	}
 }

--- a/drivers/amazonec2/awscredentials_test.go
+++ b/drivers/amazonec2/awscredentials_test.go
@@ -1,0 +1,165 @@
+package amazonec2
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAccessKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "", "", "", "")
+	awsCreds.fallbackProvider = nil
+
+	_, err := awsCreds.Credentials().Get()
+	assert.Error(t, err)
+}
+
+func TestAccessKeyIsMandatoryEvenIfSecretKeyIsPassedWhenSystemCredentialsAreNotPresent(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "secret", "", "", "")
+	awsCreds.fallbackProvider = nil
+
+	_, err := awsCreds.Credentials().Get()
+	assert.Error(t, err)
+}
+
+func TestSecretKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "", "", "", "")
+	awsCreds.fallbackProvider = nil
+
+	_, err := awsCreds.Credentials().Get()
+	assert.Error(t, err)
+}
+
+func TestFallbackCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreMissing(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "", "", "", "")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback_access", creds.AccessKeyID)
+	assert.Equal(t, "fallback_secret", creds.SecretAccessKey)
+	assert.Equal(t, "fallback_token", creds.SessionToken)
+}
+
+func TestFallbackCredentialsAreLoadedWhenAccessKeyIsMissing(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "secret", "", "", "")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback_access", creds.AccessKeyID)
+	assert.Equal(t, "fallback_secret", creds.SecretAccessKey)
+	assert.Equal(t, "fallback_token", creds.SessionToken)
+}
+
+func TestFallbackCredentialsAreLoadedWhenSecretKeyIsMissing(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "", "", "", "")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback_access", creds.AccessKeyID)
+	assert.Equal(t, "fallback_secret", creds.SecretAccessKey)
+	assert.Equal(t, "fallback_token", creds.SessionToken)
+}
+
+func TestOptionCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreProvided(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "secret", "", "", "")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "", creds.SessionToken)
+}
+
+func TestCredentialsAreLoadedFromFileWhenFilenameIsProvided(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "", "", "my/aws/credentials", "")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "", creds.SessionToken)
+}
+
+func TestCredentialsAreLoadedFromFileWhenProfileIsProvided(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "", "", "", "non-default-profile")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "", creds.SessionToken)
+}
+
+func TestCredentialsAreLoadedFromFileWhenFilenameAndProfileAreProvided(t *testing.T) {
+	awsCreds := NewAWSCredentials("", "", "", "my/aws/credentials", "non-default-profile")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "", creds.SessionToken)
+}
+
+func TestOptionCredentialsAreLoadedEvenIfFilenameAndProfileAreProvided(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = NewTestFileCredentialsProvider("foo", "bar", "")
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "token", creds.SessionToken)
+}
+
+func TestCredentialsAreLoadedFromFileIfStaticCredentialsGenerateError(t *testing.T) {
+	awsCreds := NewAWSCredentials("foo", "bar", "", "my/aws/credentials", "non-default-profile")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = NewTestFileCredentialsProviderWithStaticError("access", "secret", "")
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "access", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "", creds.SessionToken)
+}
+
+func TestFallbackCredentialsAreLoadedIfBothStaticAndSharedCredentialsGenerateError(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
+	awsCreds.fallbackProvider = &fallbackCredentials{}
+	awsCreds.providerFactory = &errorCredentialsProvider{}
+
+	creds, err := awsCreds.Credentials().Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback_access", creds.AccessKeyID)
+	assert.Equal(t, "fallback_secret", creds.SecretAccessKey)
+	assert.Equal(t, "fallback_token", creds.SessionToken)
+}
+
+func TestErrorGeneratedWhenAllProvidersGenerateErrors(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
+	awsCreds.fallbackProvider = &errorFallbackCredentials{}
+	awsCreds.providerFactory = &errorCredentialsProvider{}
+
+	_, err := awsCreds.Credentials().Get()
+	assert.Error(t, err)
+}

--- a/drivers/amazonec2/awscredentials_test.go
+++ b/drivers/amazonec2/awscredentials_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestAccessKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "", "", "", "")
+	awsCreds := NewAWSCredentials("", "", "")
 	awsCreds.fallbackProvider = nil
 
 	_, err := awsCreds.Credentials().Get()
@@ -14,7 +14,7 @@ func TestAccessKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
 }
 
 func TestAccessKeyIsMandatoryEvenIfSecretKeyIsPassedWhenSystemCredentialsAreNotPresent(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "secret", "", "", "")
+	awsCreds := NewAWSCredentials("", "secret", "")
 	awsCreds.fallbackProvider = nil
 
 	_, err := awsCreds.Credentials().Get()
@@ -22,7 +22,7 @@ func TestAccessKeyIsMandatoryEvenIfSecretKeyIsPassedWhenSystemCredentialsAreNotP
 }
 
 func TestSecretKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "", "", "", "")
+	awsCreds := NewAWSCredentials("access", "", "")
 	awsCreds.fallbackProvider = nil
 
 	_, err := awsCreds.Credentials().Get()
@@ -30,7 +30,7 @@ func TestSecretKeyIsMandatoryWhenSystemCredentialsAreNotPresent(t *testing.T) {
 }
 
 func TestFallbackCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreMissing(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "", "", "", "")
+	awsCreds := NewAWSCredentials("", "", "")
 	awsCreds.fallbackProvider = &fallbackCredentials{}
 
 	creds, err := awsCreds.Credentials().Get()
@@ -42,7 +42,7 @@ func TestFallbackCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreMissing(t *test
 }
 
 func TestFallbackCredentialsAreLoadedWhenAccessKeyIsMissing(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "secret", "", "", "")
+	awsCreds := NewAWSCredentials("", "secret", "")
 	awsCreds.fallbackProvider = &fallbackCredentials{}
 
 	creds, err := awsCreds.Credentials().Get()
@@ -54,7 +54,7 @@ func TestFallbackCredentialsAreLoadedWhenAccessKeyIsMissing(t *testing.T) {
 }
 
 func TestFallbackCredentialsAreLoadedWhenSecretKeyIsMissing(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "", "", "", "")
+	awsCreds := NewAWSCredentials("access", "", "")
 	awsCreds.fallbackProvider = &fallbackCredentials{}
 
 	creds, err := awsCreds.Credentials().Get()
@@ -66,7 +66,7 @@ func TestFallbackCredentialsAreLoadedWhenSecretKeyIsMissing(t *testing.T) {
 }
 
 func TestOptionCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreProvided(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "secret", "", "", "")
+	awsCreds := NewAWSCredentials("access", "secret", "")
 	awsCreds.fallbackProvider = &fallbackCredentials{}
 
 	creds, err := awsCreds.Credentials().Get()
@@ -77,73 +77,8 @@ func TestOptionCredentialsAreLoadedWhenAccessKeyAndSecretKeyAreProvided(t *testi
 	assert.Equal(t, "", creds.SessionToken)
 }
 
-func TestCredentialsAreLoadedFromFileWhenFilenameIsProvided(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "", "", "my/aws/credentials", "")
-	awsCreds.fallbackProvider = &fallbackCredentials{}
-	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
-
-	creds, err := awsCreds.Credentials().Get()
-
-	assert.NoError(t, err)
-	assert.Equal(t, "access", creds.AccessKeyID)
-	assert.Equal(t, "secret", creds.SecretAccessKey)
-	assert.Equal(t, "", creds.SessionToken)
-}
-
-func TestCredentialsAreLoadedFromFileWhenProfileIsProvided(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "", "", "", "non-default-profile")
-	awsCreds.fallbackProvider = &fallbackCredentials{}
-	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
-
-	creds, err := awsCreds.Credentials().Get()
-
-	assert.NoError(t, err)
-	assert.Equal(t, "access", creds.AccessKeyID)
-	assert.Equal(t, "secret", creds.SecretAccessKey)
-	assert.Equal(t, "", creds.SessionToken)
-}
-
-func TestCredentialsAreLoadedFromFileWhenFilenameAndProfileAreProvided(t *testing.T) {
-	awsCreds := NewAWSCredentials("", "", "", "my/aws/credentials", "non-default-profile")
-	awsCreds.fallbackProvider = &fallbackCredentials{}
-	awsCreds.providerFactory = NewTestFileCredentialsProvider("access", "secret", "")
-
-	creds, err := awsCreds.Credentials().Get()
-
-	assert.NoError(t, err)
-	assert.Equal(t, "access", creds.AccessKeyID)
-	assert.Equal(t, "secret", creds.SecretAccessKey)
-	assert.Equal(t, "", creds.SessionToken)
-}
-
-func TestOptionCredentialsAreLoadedEvenIfFilenameAndProfileAreProvided(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
-	awsCreds.fallbackProvider = &fallbackCredentials{}
-	awsCreds.providerFactory = NewTestFileCredentialsProvider("foo", "bar", "")
-
-	creds, err := awsCreds.Credentials().Get()
-
-	assert.NoError(t, err)
-	assert.Equal(t, "access", creds.AccessKeyID)
-	assert.Equal(t, "secret", creds.SecretAccessKey)
-	assert.Equal(t, "token", creds.SessionToken)
-}
-
-func TestCredentialsAreLoadedFromFileIfStaticCredentialsGenerateError(t *testing.T) {
-	awsCreds := NewAWSCredentials("foo", "bar", "", "my/aws/credentials", "non-default-profile")
-	awsCreds.fallbackProvider = &fallbackCredentials{}
-	awsCreds.providerFactory = NewTestFileCredentialsProviderWithStaticError("access", "secret", "")
-
-	creds, err := awsCreds.Credentials().Get()
-
-	assert.NoError(t, err)
-	assert.Equal(t, "access", creds.AccessKeyID)
-	assert.Equal(t, "secret", creds.SecretAccessKey)
-	assert.Equal(t, "", creds.SessionToken)
-}
-
-func TestFallbackCredentialsAreLoadedIfBothStaticAndSharedCredentialsGenerateError(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
+func TestFallbackCredentialsAreLoadedIfStaticCredentialsGenerateError(t *testing.T) {
+	awsCreds := NewAWSCredentials("access", "secret", "token")
 	awsCreds.fallbackProvider = &fallbackCredentials{}
 	awsCreds.providerFactory = &errorCredentialsProvider{}
 
@@ -156,7 +91,7 @@ func TestFallbackCredentialsAreLoadedIfBothStaticAndSharedCredentialsGenerateErr
 }
 
 func TestErrorGeneratedWhenAllProvidersGenerateErrors(t *testing.T) {
-	awsCreds := NewAWSCredentials("access", "secret", "token", "my/aws/credentials", "non-default-profile")
+	awsCreds := NewAWSCredentials("access", "secret", "token")
 	awsCreds.fallbackProvider = &errorFallbackCredentials{}
 	awsCreds.providerFactory = &errorCredentialsProvider{}
 

--- a/drivers/amazonec2/stub_test.go
+++ b/drivers/amazonec2/stub_test.go
@@ -61,44 +61,40 @@ func NewErrorAwsCredentials() awsCredentials {
 	return &errorFallbackCredentials{}
 }
 
-type testFileCredentialsProvider struct {
-	fileProvider credentials.Provider
-	staticError  bool
-}
-
-func NewTestFileCredentialsProvider(id, secret, token string) *testFileCredentialsProvider {
-	return &testFileCredentialsProvider{
-		fileProvider: &okProvider{id, secret, token},
-		staticError:  false,
-	}
-}
-
-func NewTestFileCredentialsProviderWithStaticError(id, secret, token string) *testFileCredentialsProvider {
-	return &testFileCredentialsProvider{
-		fileProvider: &okProvider{id, secret, token},
-		staticError:  true,
-	}
-}
-
-func (c *testFileCredentialsProvider) NewStaticProvider(id, secret, token string) credentials.Provider {
-	if c.staticError {
-		return &errorProvider{}
-	} else {
-		return &okProvider{id, secret, token}
-	}
-}
-
-func (c *testFileCredentialsProvider) NewSharedProvider(filename, profile string) credentials.Provider {
-	return c.fileProvider
-}
+//type testFileCredentialsProvider struct {
+//	fileProvider credentials.Provider
+//	staticError  bool
+//}
+//
+//func NewTestFileCredentialsProvider(id, secret, token string) *testFileCredentialsProvider {
+//	return &testFileCredentialsProvider{
+//		fileProvider: &okProvider{id, secret, token},
+//		staticError:  false,
+//	}
+//}
+//
+//func NewTestFileCredentialsProviderWithStaticError(id, secret, token string) *testFileCredentialsProvider {
+//	return &testFileCredentialsProvider{
+//		fileProvider: &okProvider{id, secret, token},
+//		staticError:  true,
+//	}
+//}
+//
+//func (c *testFileCredentialsProvider) NewStaticProvider(id, secret, token string) credentials.Provider {
+//	if c.staticError {
+//		return &errorProvider{}
+//	} else {
+//		return &okProvider{id, secret, token}
+//	}
+//}
+//
+//func (c *testFileCredentialsProvider) NewSharedProvider(filename, profile string) credentials.Provider {
+//	return c.fileProvider
+//}
 
 type errorCredentialsProvider struct{}
 
 func (c *errorCredentialsProvider) NewStaticProvider(id, secret, token string) credentials.Provider {
-	return &errorProvider{}
-}
-
-func (c *errorCredentialsProvider) NewSharedProvider(filename, profile string) credentials.Provider {
 	return &errorProvider{}
 }
 

--- a/drivers/amazonec2/stub_test.go
+++ b/drivers/amazonec2/stub_test.go
@@ -61,37 +61,6 @@ func NewErrorAwsCredentials() awsCredentials {
 	return &errorFallbackCredentials{}
 }
 
-//type testFileCredentialsProvider struct {
-//	fileProvider credentials.Provider
-//	staticError  bool
-//}
-//
-//func NewTestFileCredentialsProvider(id, secret, token string) *testFileCredentialsProvider {
-//	return &testFileCredentialsProvider{
-//		fileProvider: &okProvider{id, secret, token},
-//		staticError:  false,
-//	}
-//}
-//
-//func NewTestFileCredentialsProviderWithStaticError(id, secret, token string) *testFileCredentialsProvider {
-//	return &testFileCredentialsProvider{
-//		fileProvider: &okProvider{id, secret, token},
-//		staticError:  true,
-//	}
-//}
-//
-//func (c *testFileCredentialsProvider) NewStaticProvider(id, secret, token string) credentials.Provider {
-//	if c.staticError {
-//		return &errorProvider{}
-//	} else {
-//		return &okProvider{id, secret, token}
-//	}
-//}
-//
-//func (c *testFileCredentialsProvider) NewSharedProvider(filename, profile string) credentials.Provider {
-//	return c.fileProvider
-//}
-
 type errorCredentialsProvider struct{}
 
 func (c *errorCredentialsProvider) NewStaticProvider(id, secret, token string) credentials.Provider {


### PR DESCRIPTION
This PR replaces #3790.

Fixes #3748 
Fixes #533 

This change adds support for automatic configuration of AWS credentials from Instance Roles when running `docker-machine` from an EC2 server or ECS container. It replaces the original credential lookup code with an Amazon ChainProvider that retrieves credentials from the first valid source in this list:
1. Static credentials from the `--amazonec2-access-key`, `--amazonec2-secret-key`, and `--amazonec2-session-token`command line options
2. Amazon's default credential chain: (at time of submission)
   a.  Environment Variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
   b.  Default profile in `~/.aws/credentials`
   b.  IAM Role (on supported AWS infrastructure)
