### PR TITLE
Dialer TLS timeout is too short, 2 -> 20 seconds

### DIFF
--- a/libmachine/cert/cert.go
+++ b/libmachine/cert/cert.go
@@ -257,7 +257,7 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 	}
 
 	dialer := &net.Dialer{
-		Timeout: time.Second * 2,
+		Timeout: time.Second * 20,
 	}
 
 	_, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)


### PR DESCRIPTION
Fixes #3479 