### PR TITLE
readme: fix available driver plugins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ In addition to the core driver plugins bundled alongside Docker Machine, users
 can make and distribute their own plugin for any virtualization technology or
 cloud provider.  To browse the list of known Docker Machine plugins, please [see
 this document in our
-repo](https://github.com/docker/machine/blob/master/docs/AVAILABLE_DRIVER_PLUGINS.md).
+docs repo](https://github.com/docker/docker.github.io/blob/master/machine/AVAILABLE_DRIVER_PLUGINS.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR fixes a broken link on the readme that used to point to a list of 3rd party drivers plugins. This depends on docker/docker.github.io#250 being merged.