### PR TITLE
Fix ssh keyfile permissions on FreeBSD

### DIFF
--- a/libmachine/ssh/keys.go
+++ b/libmachine/ssh/keys.go
@@ -82,7 +82,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 
 		// windows does not support chmod
 		switch runtime.GOOS {
-		case "darwin", "linux":
+		case "darwin", "linux", "freebsd":
 			if err := f.Chmod(0600); err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, the permissions would be left open which results in a broken SSH setup between the client and the docker machine host.