### PR TITLE
[EC2 driver] Only open SSH, docker and swarm ports for the first security group 

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -1034,21 +1034,22 @@ func (d *Driver) configureSecurityGroups(groupNames []string) error {
 			}
 		}
 		d.SecurityGroupIds = append(d.SecurityGroupIds, *group.GroupId)
+	}
 
-		perms, err := d.configureSecurityGroupPermissions(group)
+	var mainGroup = groupsByName[groupNames[0]]
+	perms, err := d.configureSecurityGroupPermissions(mainGroup)
+	if err != nil {
+		return err
+	}
+
+	if len(perms) != 0 {
+		log.Debugf("authorizing group %s with permissions: %v", groupNames, perms)
+		_, err := d.getClient().AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       mainGroup.GroupId,
+			IpPermissions: perms,
+		})
 		if err != nil {
 			return err
-		}
-
-		if len(perms) != 0 {
-			log.Debugf("authorizing group %s with permissions: %v", groupNames, perms)
-			_, err := d.getClient().AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-				GroupId:       group.GroupId,
-				IpPermissions: perms,
-			})
-			if err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
Hi,

PR #3111 enabled the EC2 driver to handle setting multiple security groups on EC2 instances. Yet, this also opens SSH, docker and swarm ports for each security group set using `--amazonec2-security-group` flag which (I think) is useless and unexpected. Setting the rule on one security group only would be sufficient, proper and safer.

This PR opens the required ports on the first security group provided only. Therefore, this makes the CLI options order-sensitive (I don't know if it is already). Maybe that's not what is expected either.
If this is problematic, another solution I could implement could be to set the main security group using the `--amazonec2-security-group docker-sg` flag and set extra security groups using some kind of `--amazonec2-extra-security-group some-extra-sg` flag. This would mean that only one `--amazonec2-security-group` flag could be accepted, but multiple `--amazonec2-extra-security-group` flags could be provided (with no order consideration).
Another (less intrusive) solution that would address my issue as a side-effect would be to add a flag that would make the driver trust the security groups provided and not try to update them. You'd have to pre-configure them using the AWS CLI.

Please, let me know what is acceptable to you, and tell me where and how I can document this if I ever it's needed.

Thank you.