### PR TITLE
libmachine: initiliaze core drivers as slice instead of array

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -17,7 +17,7 @@ var (
 	// plugin server.
 	defaultTimeout               = 10 * time.Second
 	CurrentBinaryIsDockerMachine = false
-	CoreDrivers                  = [...]string{"amazonec2", "azure", "digitalocean",
+	CoreDrivers                  = []string{"amazonec2", "azure", "digitalocean",
 		"exoscale", "generic", "google", "hyperv", "none", "openstack",
 		"rackspace", "softlayer", "virtualbox", "vmwarefusion",
 		"vmwarevcloudair", "vmwarevsphere"}


### PR DESCRIPTION
This PR changes the `CoreDrivers` variable to a slice instead of an array.

I'm currently using docker-machine as a library, shipping it inside an executable and I would like to support some additional drivers as core drivers. This change makes it possible to address this kind of usage of docker-machine, since I can just append a new driver to the `CoreDrivers` and handle it's registering on the process main.

I think there are other changes that we could discuss to make this kind of use case better (people using `libmachine` outside of the `docker-machine` binary), I'm open to help on this since we are heavily using it on [tsuru](https://github.com/tsuru/tsuru/tree/master/iaas/dockermachine) (if this is a valid use case that `docker-machine` was to address in the future).