### PR TITLE
Fix improper use of IP in generateLocationArg

### DIFF
--- a/commands/scp.go
+++ b/commands/scp.go
@@ -27,7 +27,7 @@ var (
 type HostInfo interface {
 	GetMachineName() string
 
-	GetIP() (string, error)
+	GetSSHHostname() (string, error)
 
 	GetSSHPort() (int, error)
 
@@ -167,12 +167,12 @@ func generateLocationArg(hostInfo HostInfo, path string) (string, error) {
 		return path, nil
 	}
 
-	ip, err := hostInfo.GetIP()
+	hostname, err := hostInfo.GetSSHHostname()
 	if err != nil {
 		return "", err
 	}
 
-	location := fmt.Sprintf("%s@%s:%s", hostInfo.GetSSHUsername(), ip, path)
+	location := fmt.Sprintf("%s@%s:%s", hostInfo.GetSSHUsername(), hostname, path)
 	return location, nil
 }
 

--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -19,7 +19,7 @@ func (h *MockHostInfo) GetMachineName() string {
 	return h.name
 }
 
-func (h *MockHostInfo) GetIP() (string, error) {
+func (h *MockHostInfo) GetSSHHostname() (string, error) {
 	return h.ip, nil
 }
 


### PR DESCRIPTION
Closes issue when IP is different than intended SSH hostname, e.g., `localhost` in VBox's case

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>