### PR TITLE
Close plugin binary even when driver server fails

### DIFF
--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -213,10 +213,11 @@ func (c *RPCClientDriver) close() error {
 	log.Debug("Making call to close driver server")
 
 	if err := c.Client.Call(CloseMethod, struct{}{}, nil); err != nil {
-		return err
+		log.Debugf("Failed to make call to close driver server: %s", err)
+	} else {
+		log.Debug("Successfully made call to close driver server")
 	}
 
-	log.Debug("Successfully made call to close driver server")
 	log.Debug("Making call to close connection to plugin binary")
 
 	return c.plugin.Close()


### PR DESCRIPTION
When running `libmachine` inside a long lived process, I noticed some child processes being left in `<defunct>` state. This was happening whenever an operation like creating or removing a machine failed. Tracking this down, I figured sometimes closing the server driver would fail and the plugin binary would not be closed, which prevents `cmd.Wait()` from being called and properly handling the child process exit code.

With this commit the RPC client driver tries closing the plugin binary even when closing the driver server fails. This prevents the driver process from entering in `<defunct>` state when it failed before closing.