### PR TITLE
Update GCE and Rackspace default image to Ubuntu 16.04

### DIFF
--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -36,7 +36,7 @@ const (
 	defaultZone        = "us-central1-a"
 	defaultUser        = "docker-user"
 	defaultMachineType = "n1-standard-1"
-	defaultImageName   = "ubuntu-os-cloud/global/images/ubuntu-1510-wily-v20160627"
+	defaultImageName   = "ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20161130"
 	defaultScopes      = "https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write"
 	defaultDiskType    = "pd-standard"
 	defaultDiskSize    = 10

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -57,7 +57,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "OS_IMAGE_ID",
 			Name:   "rackspace-image-id",
-			Usage:  "Rackspace image ID. Default: Ubuntu 15.10 (Wily Werewolf) (PVHVM)",
+			Usage:  "Rackspace image ID. Default: Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "OS_FLAVOR_ID",
@@ -144,10 +144,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	if d.ImageId == "" {
-		// Default to the Ubuntu 15.10 image.
+		// Default to the Ubuntu 16.04 image.
 		// This is done here, rather than in the option registration, to keep the default value
 		// from making "machine create --help" ugly.
-		d.ImageId = "59a3fadd-93e7-4674-886a-64883e17115f"
+		d.ImageId = "821ba5f4-712d-4ec8-9c65-a3fa4bc500f9"
 	}
 
 	if d.EndpointType != "publicURL" && d.EndpointType != "adminURL" && d.EndpointType != "internalURL" {


### PR DESCRIPTION
The default image in GCE driver and Rackspace are still 15.10, which is already EOL, and not available in Rackspace. So just update it to 16.04.

Signed-off-by: Tao Wang <twang2218@gmail.com>