### PR TITLE
Remove unused upstart commands left in GCE driver.

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -38,12 +38,10 @@ type ComputeUtil struct {
 }
 
 const (
-	apiURL             = "https://www.googleapis.com/compute/v1/projects/"
-	firewallRule       = "docker-machines"
-	port               = "2376"
-	firewallTargetTag  = "docker-machine"
-	dockerStartCommand = "sudo service docker start"
-	dockerStopCommand  = "sudo service docker stop"
+	apiURL            = "https://www.googleapis.com/compute/v1/projects/"
+	firewallRule      = "docker-machines"
+	port              = "2376"
+	firewallTargetTag = "docker-machine"
 )
 
 // NewComputeUtil creates and initializes a ComputeUtil.


### PR DESCRIPTION
Found unused code in GCE driver, `dockerStartCommand` and `dockerStopCommand` has not been used since 75f79ed, so this PR remove them.

Signed-off-by: Tao Wang <twang2218@gmail.com>