### PR TITLE
libmachine/provision: wait for apt-get update lock

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -52,7 +52,9 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		waitForLockAptGetUpdate(provisioner)
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
+			return err
+		}
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -52,9 +52,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
-			return err
-		}
+		waitForLockAptGetUpdate(provisioner)
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -68,7 +68,9 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 	}
 
 	if updateMetadata {
-		waitForLockAptGetUpdate(provisioner)
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
+			return err
+		}
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -68,9 +68,7 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
-			return err
-		}
+		waitForLockAptGetUpdate(provisioner)
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y  %s", packageAction, name)

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -87,9 +87,7 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		if _, err := provisioner.SSHCommand("sudo apt-get update"); err != nil {
-			return err
-		}
+		waitForLockAptGetUpdate(provisioner)
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y -o Dpkg::Options::=\"--force-confnew\" %s", packageAction, name)

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -87,7 +87,9 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 	}
 
 	if updateMetadata {
-		waitForLockAptGetUpdate(provisioner)
+		if err := waitForLockAptGetUpdate(provisioner); err != nil {
+			return err
+		}
 	}
 
 	command := fmt.Sprintf("DEBIAN_FRONTEND=noninteractive sudo -E apt-get %s -y -o Dpkg::Options::=\"--force-confnew\" %s", packageAction, name)

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -294,3 +294,14 @@ func DockerClientVersion(ssh SSHCommander) (string, error) {
 
 	return strings.TrimRight(words[2], ","), nil
 }
+
+func waitForLockAptGetUpdate(ssh SSHCommander) error {
+	return mcnutils.WaitFor(func() bool {
+		_, err := ssh.SSHCommand("sudo apt-get update")
+		if err != nil {
+			failedToLock := strings.Contains(err.Error(), "Could not get lock")
+			return !failedToLock
+		}
+		return true
+	})
+}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -298,13 +298,12 @@ func DockerClientVersion(ssh SSHCommander) (string, error) {
 func waitForLockAptGetUpdate(ssh SSHCommander) error {
 	var sshErr error
 	err := mcnutils.WaitFor(func() bool {
-		_, err := ssh.SSHCommand("sudo apt-get update")
-		if err != nil {
-			failedToLock := strings.Contains(err.Error(), "Could not get lock")
-			if failedToLock {
+		_, sshErr = ssh.SSHCommand("sudo apt-get update")
+		if sshErr != nil {
+			if strings.Contains(sshErr.Error(), "Could not get lock") {
+				sshErr = nil
 				return false
 			}
-			sshErr = err
 			return true
 		}
 		return true


### PR DESCRIPTION
This PR adds a retry mechanism to the `apt-get update` calls. It will retry if a failure to obtain the lock is detected which may be caused by cloudinit scripts running `apt-get update` before the provisioner.

Signed-off-by: André Carvalho <asantostc@gmail.com>