### PR TITLE
Add a `docker-machine reinstall`…

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -305,6 +305,17 @@ var Commands = []cli.Command{
 		Action: runCommand(cmdProvision),
 	},
 	{
+		Name:   "reinstall",
+		Usage:  "Re-install and re-provision existing machines",
+		Action: runCommand(cmdReinstall),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "y",
+				Usage: "Assumes automatic yes to proceed with reinstall, without prompting further user confirmation",
+			},
+		},
+	},
+	{
 		Name:        "regenerate-certs",
 		Usage:       "Regenerate TLS Certificates for a machine",
 		Description: "Argument(s) are one or more machine names.",
@@ -420,6 +431,7 @@ func machineCommand(actionName string, host *host.Host, errorChan chan<- error) 
 		"upgrade":       host.Upgrade,
 		"ip":            printIP(host),
 		"provision":     host.Provision,
+		"reinstall":     host.Reinstall,
 	}
 
 	log.Debugf("command=%s machine=%s", actionName, host.Name)

--- a/commands/reinstall.go
+++ b/commands/reinstall.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"github.com/docker/machine/libmachine"
+)
+
+func cmdReinstall(c CommandLine, api libmachine.API) error {
+	if !c.Bool("force") {
+		ok, err := confirmInput("Reinstall remote instances?  Warning: this is irreversible.")
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return nil
+		}
+	}
+
+	return runAction("reinstall", c, api)
+}

--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -329,6 +329,11 @@ func (d *Driver) GetState() (state.State, error) {
 	return state.None, nil
 }
 
+func (d *Driver) Reinstall() error {
+	_, _, err := d.getClient().DropletActions.RebuildByImageSlug(d.DropletID, d.Image)
+	return err
+}
+
 func (d *Driver) Start() error {
 	_, _, err := d.getClient().DropletActions.PowerOn(d.DropletID)
 	return err

--- a/drivers/errdriver/error.go
+++ b/drivers/errdriver/error.go
@@ -79,6 +79,10 @@ func (d *Driver) Create() error {
 	return NotLoadable{d.Name}
 }
 
+func (d *Driver) Reinstall() error {
+	return NotLoadable{d.Name}
+}
+
 func (d *Driver) Remove() error {
 	return NotLoadable{d.Name}
 }

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"errors"
 	"path/filepath"
+	"fmt"
 )
 
 const (
@@ -71,6 +72,11 @@ func (d *BaseDriver) GetSSHUsername() string {
 // PreCreateCheck is called to enforce pre-creation steps
 func (d *BaseDriver) PreCreateCheck() error {
 	return nil
+}
+
+// PreCreateCheck is called to enforce pre-creation steps
+func (d *BaseDriver) Reinstall() error {
+	return fmt.Errorf("Reinstall operation is not supported for %q driver.", d.DriverName)
 }
 
 // ResolveStorePath returns the store path where the machine is

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -54,6 +54,9 @@ type Driver interface {
 	// PreCreateCheck allows for pre-create operations to make sure a driver is ready for creation
 	PreCreateCheck() error
 
+	// Reinstall a host
+	Reinstall() error
+
 	// Remove a host
 	Remove() error
 

--- a/libmachine/drivers/notsupported.go
+++ b/libmachine/drivers/notsupported.go
@@ -64,6 +64,10 @@ func (d *DriverNotSupported) Create() error {
 	return NotSupported{d.DriverName()}
 }
 
+func (d *DriverNotSupported) Reinstall() error {
+	return NotSupported{d.DriverName()}
+}
+
 func (d *DriverNotSupported) Remove() error {
 	return NotSupported{d.DriverName()}
 }

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -77,6 +77,7 @@ const (
 	GetStateMethod           = `.GetState`
 	PreCreateCheckMethod     = `.PreCreateCheck`
 	CreateMethod             = `.Create`
+	ReinstallMethod          = `.Reinstall`
 	RemoveMethod             = `.Remove`
 	StartMethod              = `.Start`
 	StopMethod               = `.Stop`
@@ -340,6 +341,10 @@ func (c *RPCClientDriver) PreCreateCheck() error {
 
 func (c *RPCClientDriver) Create() error {
 	return c.Client.Call(CreateMethod, struct{}{}, nil)
+}
+
+func (c *RPCClientDriver) Reinstall() error {
+	return c.Client.Call(ReinstallMethod, struct{}{}, nil)
 }
 
 func (c *RPCClientDriver) Remove() error {

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -201,6 +201,10 @@ func (r *RPCServerDriver) PreCreateCheck(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.PreCreateCheck()
 }
 
+func (r *RPCServerDriver) Reinstall(_ *struct{}, _ *struct{}) error {
+	return r.ActualDriver.Reinstall()
+}
+
 func (r *RPCServerDriver) Remove(_ *struct{}, _ *struct{}) error {
 	return r.ActualDriver.Remove()
 }

--- a/libmachine/drivers/serial.go
+++ b/libmachine/drivers/serial.go
@@ -131,6 +131,13 @@ func (d *SerialDriver) PreCreateCheck() error {
 }
 
 // Remove a host
+func (d *SerialDriver) Reinstall() error {
+	d.Lock()
+	defer d.Unlock()
+	return d.Driver.Reinstall()
+}
+
+// Remove a host
 func (d *SerialDriver) Remove() error {
 	d.Lock()
 	defer d.Unlock()

--- a/libmachine/drivers/serial_test.go
+++ b/libmachine/drivers/serial_test.go
@@ -250,6 +250,15 @@ func TestSerialDriverPreCreateCheck(t *testing.T) {
 	assert.Equal(t, []string{"Lock", "PreCreateCheck", "Unlock"}, callRecorder.calls)
 }
 
+func TestSerialDriverReinstall(t *testing.T) {
+	callRecorder := &CallRecorder{}
+
+	driver := newSerialDriverWithLock(&MockDriver{calls: callRecorder}, &MockLocker{calls: callRecorder})
+	driver.Reinstall()
+
+	assert.Equal(t, []string{"Lock", "Reinstall", "Unlock"}, callRecorder.calls)
+}
+
 func TestSerialDriverRemove(t *testing.T) {
 	callRecorder := &CallRecorder{}
 

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -221,3 +221,28 @@ func (h *Host) Provision() error {
 
 	return provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
 }
+
+func (h *Host) Reinstall() error {
+	log.Infof("Stopping %q...", h.Name)
+	if err := h.runActionForState(h.Driver.Stop, state.Stopped); err != nil {
+		return err
+	}
+
+	log.Infof("Reinstalling %q...", h.Name)
+	if err := h.Driver.Reinstall(); err != nil {
+		return err
+	}
+
+	log.Infof("Waiting for %q to become Running...", h.Name)
+	if err := mcnutils.WaitFor(drivers.MachineInState(h.Driver, state.Running)); err != nil {
+		return err
+	}
+
+	log.Infof("Machine %q was started.", h.Name)
+	provisioner, err := provision.DetectProvisioner(h.Driver)
+	if err != nil {
+		return err
+	}
+
+	return provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions)
+}


### PR DESCRIPTION
This commands allows to use a cloud instance API to schedule reinstall of machine, by completely wipping its content and then re-provisioning.

This PR is created as proof-of-concept supports only `DigitalOcean` reinstall API, but quite easily any other API can be supported.

This is the output of command execution on existing machine:
```
Stopping "kamil-gitlab-test-reinstall"...
Reinstalling "kamil-gitlab-test-reinstall"...
Waiting for "kamil-gitlab-test-reinstall" to become Running...
Machine "kamil-gitlab-test-reinstall" was started.
Waiting for SSH to be available...
Detecting the provisioner...
Installing Docker...
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
```

This feature is needed by [GitLab Runner docker-machine based auto-scaling](https://docs.gitlab.com/runner/configuration/autoscale.html) to make it possible to re-use existing machines.

What do you think of this? Is this something worth and mergeable (if improved)?
