### PR TITLE
Disable update of existing docker installation on RedHat and its derivatives.

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -177,7 +177,7 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	}
 
 	// update OS -- this is needed for libdevicemapper and the docker install
-	if _, err := provisioner.SSHCommand("sudo -E yum -y update"); err != nil {
+	if _, err := provisioner.SSHCommand("sudo -E yum -y update -x docker-*"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This patch excludes the `docker-*` packages from the `yum update` command issued by the RedHat provisioner. When `docker-engine` was pre-installed on the image used by `docker-machine`, it was always updated to the "latest and greatest" during the provisioning process. This is contrary to the desired behavior of using an installed `docker` if it is found.

This issue came to light during discussions of a bug with interactions between Docker 1.12.4 and GitLab-CI. See discussions here: https://github.com/docker/machine/issues/1702