### PR TITLE
drivers/google: add --google-open-port flag

### DIFF
--- a/drivers/google/compute_util_test.go
+++ b/drivers/google/compute_util_test.go
@@ -32,9 +32,10 @@ func TestPortsUsed(t *testing.T) {
 		expectedPorts []string
 		expectedError error
 	}{
-		{"use docker port", &ComputeUtil{}, []string{"2376"}, nil},
-		{"use docker and swarm port", &ComputeUtil{SwarmMaster: true, SwarmHost: "tcp://host:3376"}, []string{"2376", "3376"}, nil},
-		{"use docker and non default swarm port", &ComputeUtil{SwarmMaster: true, SwarmHost: "tcp://host:4242"}, []string{"2376", "4242"}, nil},
+		{"use docker port", &ComputeUtil{}, []string{"2376/tcp"}, nil},
+		{"use docker and swarm port", &ComputeUtil{SwarmMaster: true, SwarmHost: "tcp://host:3376"}, []string{"2376/tcp", "3376/tcp"}, nil},
+		{"use docker and non default swarm port", &ComputeUtil{SwarmMaster: true, SwarmHost: "tcp://host:4242"}, []string{"2376/tcp", "4242/tcp"}, nil},
+		{"include additional ports", &ComputeUtil{openPorts: []string{"80", "2377/udp"}}, []string{"2376/tcp", "80/tcp", "2377/udp"}, nil},
 	}
 
 	for _, test := range tests {
@@ -50,14 +51,15 @@ func TestMissingOpenedPorts(t *testing.T) {
 		description     string
 		allowed         []*raw.FirewallAllowed
 		ports           []string
-		expectedMissing []string
+		expectedMissing map[string][]string
 	}{
-		{"no port opened", []*raw.FirewallAllowed{}, []string{"2376"}, []string{"2376"}},
-		{"docker port opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376"}}}, []string{"2376"}, []string{}},
-		{"missing swarm port", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376"}}}, []string{"2376", "3376"}, []string{"3376"}},
-		{"missing docker port", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"3376"}}}, []string{"2376", "3376"}, []string{"2376"}},
-		{"both ports opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376", "3376"}}}, []string{"2376", "3376"}, []string{}},
-		{"more ports opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376", "3376", "22", "1024-2048"}}}, []string{"2376", "3376"}, []string{}},
+		{"no port opened", []*raw.FirewallAllowed{}, []string{"2376"}, map[string][]string{"tcp": {"2376"}}},
+		{"docker port opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376"}}}, []string{"2376"}, map[string][]string{}},
+		{"missing swarm port", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376"}}}, []string{"2376", "3376"}, map[string][]string{"tcp": {"3376"}}},
+		{"missing docker port", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"3376"}}}, []string{"2376", "3376"}, map[string][]string{"tcp": {"2376"}}},
+		{"both ports opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376", "3376"}}}, []string{"2376", "3376"}, map[string][]string{}},
+		{"more ports opened", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376", "3376", "22", "1024-2048"}}}, []string{"2376", "3376"}, map[string][]string{}},
+		{"additional missing", []*raw.FirewallAllowed{{IPProtocol: "tcp", Ports: []string{"2376", "2377/tcp"}}}, []string{"2377/udp", "80/tcp", "2376"}, map[string][]string{"tcp": {"80"}, "udp": {"2377"}}},
 	}
 
 	for _, test := range tests {

--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -30,6 +30,7 @@ type Driver struct {
 	Project           string
 	Tags              string
 	UseExisting       bool
+	OpenPorts         []string
 }
 
 const (
@@ -131,6 +132,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Don't create a new VM, use an existing one",
 			EnvVar: "GOOGLE_USE_EXISTING",
 		},
+		mcnflag.StringSliceFlag{
+			Name:  "google-open-port",
+			Usage: "Make the specified port number accessible from the Internet, e.g, 8080/tcp",
+		},
 	}
 }
 
@@ -191,6 +196,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.UseInternalIPOnly = flags.Bool("google-use-internal-ip-only")
 		d.Scopes = flags.String("google-scopes")
 		d.Tags = flags.String("google-tags")
+		d.OpenPorts = flags.StringSlice("google-open-port")
 	}
 	d.SSHUser = flags.String("google-username")
 	d.SSHPort = 22


### PR DESCRIPTION
This PR adds the --google-open-port flag
to allow the user to make other host ports
available to the internet. Uses the same pattern as other
drivers, e.g, amazonec2 and azure.

Continues the work discussed in #3642.

Signed-off-by: André Carvalho <asantostc@gmail.com>