### PR TITLE
Amazon: Support London (eu-west-2)

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -181,7 +181,7 @@ func TestValidateAwsRegionValid(t *testing.T) {
 }
 
 func TestValidateAwsRegionInvalid(t *testing.T) {
-	regions := []string{"eu-west-2", "eu-central-2"}
+	regions := []string{"eu-central-2"}
 
 	for _, region := range regions {
 		_, err := validateAwsRegion(region)

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -8,24 +8,26 @@ type region struct {
 	AmiId string
 }
 
-// Release 16.04 LTS 20161013
+// Ubuntu 16.04 LTS 20161221 hvm:ebs-ssd (amd64)
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1":  {"ami-31892c50"},
-	"ap-northeast-2":  {"ami-a3915acd"},
-	"ap-southeast-1":  {"ami-18e7417b"},
-	"ap-southeast-2":  {"ami-7be4d618"},
-	"ap-south-1":      {"ami-7e94fe11"},
-	"ca-central-1":    {"ami-ca6ddfae"},
-	"cn-north-1":      {"ami-d7c511ba"},
-	"eu-central-1":    {"ami-597c8236"},
+	"ap-northeast-1":  {"ami-18afc47f"},
+	"ap-northeast-2":  {"ami-93d600fd"},
+	"ap-southeast-1":  {"ami-87b917e4"},
+	"ap-southeast-2":  {"ami-e6b58e85"},
+	"ap-south-1":      {"ami-dd3442b2"},
+	"ca-central-1":    {"ami-7112a015"},
+	"cn-north-1":      {"ami-31499d5c"},
+	"eu-central-1":    {"ami-fe408091"},
+	"eu-west-1":       {"ami-ca80a0b9"},
+	"eu-west-2":       {"ami-ede2e889"},
 	"eu-west-1":       {"ami-c593deb6"},
-	"sa-east-1":       {"ami-909b06fc"},
-	"us-east-1":       {"ami-fd6e3bea"},
-	"us-east-2":       {"ami-0a104a6f"},
-	"us-west-1":       {"ami-73531b13"},
-	"us-west-2":       {"ami-f1ca1091"},
-	"us-gov-west-1":   {"ami-8df24aec"},
+	"sa-east-1":       {"ami-e075ed8c"},
+	"us-east-1":       {"ami-9dcfdb8a"},
+	"us-east-2":       {"ami-fcc19b99"},
+	"us-west-1":       {"ami-b05203d0"},
+	"us-west-2":       {"ami-b2d463d2"},
+	"us-gov-west-1":   {"ami-19d56d78"},
 	"custom-endpoint": {""},
 }
 

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -21,7 +21,6 @@ var regionDetails map[string]*region = map[string]*region{
 	"eu-central-1":    {"ami-fe408091"},
 	"eu-west-1":       {"ami-ca80a0b9"},
 	"eu-west-2":       {"ami-ede2e889"},
-	"eu-west-1":       {"ami-c593deb6"},
 	"sa-east-1":       {"ami-e075ed8c"},
 	"us-east-1":       {"ami-9dcfdb8a"},
 	"us-east-2":       {"ami-fcc19b99"},


### PR DESCRIPTION
Add support for London region, as well as update Ubuntu AMIs to latest version. Please double check I haven't made any mistake when reporting Ubuntu AMI Ids.