### PR TITLE
adds an example driver to --help

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -38,7 +38,7 @@ var (
 		cli.StringFlag{
 			Name: "driver, d",
 			Usage: fmt.Sprintf(
-				"Driver to create machine with.",
+				"Driver to create machine with, for example virtualbox",
 			),
 			Value:  "none",
 			EnvVar: "MACHINE_DRIVER",


### PR DESCRIPTION
Just adds a few words to the `create --help` text so you don't actually need to read the doc to remind yourself what some of the drivers are.

cc @nathanleclaire for 👀 

Signed-off-by: LRubin <lrubin@docker.com>