### PR TITLE
Revert "Add DOCKER_API_VERSION to env"

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -13,12 +13,11 @@ import (
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/check"
 	"github.com/docker/machine/libmachine/log"
-	"github.com/docker/machine/libmachine/mcndockerclient"
 	"github.com/docker/machine/libmachine/shell"
 )
 
 const (
-	envTmpl = `{{ .Prefix }}DOCKER_TLS_VERIFY{{ .Delimiter }}{{ .DockerTLSVerify }}{{ .Suffix }}{{ .Prefix }}DOCKER_HOST{{ .Delimiter }}{{ .DockerHost }}{{ .Suffix }}{{ .Prefix }}DOCKER_CERT_PATH{{ .Delimiter }}{{ .DockerCertPath }}{{ .Suffix }}{{ .Prefix }}DOCKER_MACHINE_NAME{{ .Delimiter }}{{ .MachineName }}{{ .Suffix }}{{ .Prefix }}DOCKER_API_VERSION{{ .Delimiter }}{{ .DockerAPIVersion }}{{ .Suffix }}{{ if .ComposePathsVar }}{{ .Prefix }}COMPOSE_CONVERT_WINDOWS_PATHS{{ .Delimiter }}true{{ .Suffix }}{{end}}{{ if .NoProxyVar }}{{ .Prefix }}{{ .NoProxyVar }}{{ .Delimiter }}{{ .NoProxyValue }}{{ .Suffix }}{{end}}{{ .UsageHint }}`
+	envTmpl = `{{ .Prefix }}DOCKER_TLS_VERIFY{{ .Delimiter }}{{ .DockerTLSVerify }}{{ .Suffix }}{{ .Prefix }}DOCKER_HOST{{ .Delimiter }}{{ .DockerHost }}{{ .Suffix }}{{ .Prefix }}DOCKER_CERT_PATH{{ .Delimiter }}{{ .DockerCertPath }}{{ .Suffix }}{{ .Prefix }}DOCKER_MACHINE_NAME{{ .Delimiter }}{{ .MachineName }}{{ .Suffix }}{{ if .ComposePathsVar }}{{ .Prefix }}COMPOSE_CONVERT_WINDOWS_PATHS{{ .Delimiter }}true{{ .Suffix }}{{end}}{{ if .NoProxyVar }}{{ .Prefix }}{{ .NoProxyVar }}{{ .Delimiter }}{{ .NoProxyValue }}{{ .Suffix }}{{end}}{{ .UsageHint }}`
 )
 
 var (
@@ -32,18 +31,17 @@ func init() {
 }
 
 type ShellConfig struct {
-	Prefix           string
-	Delimiter        string
-	Suffix           string
-	DockerCertPath   string
-	DockerHost       string
-	DockerTLSVerify  string
-	DockerAPIVersion string
-	UsageHint        string
-	MachineName      string
-	NoProxyVar       string
-	NoProxyValue     string
-	ComposePathsVar  bool
+	Prefix          string
+	Delimiter       string
+	Suffix          string
+	DockerCertPath  string
+	DockerHost      string
+	DockerTLSVerify string
+	UsageHint       string
+	MachineName     string
+	NoProxyVar      string
+	NoProxyValue    string
+	ComposePathsVar bool
 }
 
 func cmdEnv(c CommandLine, api libmachine.API) error {
@@ -103,16 +101,6 @@ func shellCfgSet(c CommandLine, api libmachine.API) (*ShellConfig, error) {
 		UsageHint:       defaultUsageHinter.GenerateUsageHint(userShell, os.Args),
 		MachineName:     host.Name,
 	}
-
-	remoteDocker := &mcndockerclient.RemoteDocker{
-		HostURL:    dockerHost,
-		AuthOption: host.AuthOptions(),
-	}
-	dockerAPIVersion, err := mcndockerclient.DockerAPIVersion(remoteDocker)
-	if err != nil {
-		return nil, err
-	}
-	shellCfg.DockerAPIVersion = dockerAPIVersion
 
 	if c.Bool("no-proxy") {
 		ip, err := host.Driver.GetIP()

--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/machine/libmachine/check"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/libmachinetest"
-	"github.com/docker/machine/libmachine/mcndockerclient"
 	"github.com/docker/machine/libmachine/state"
 	"github.com/stretchr/testify/assert"
 )
@@ -97,7 +96,6 @@ func revertUsageHinter(uhg UsageHintGenerator) {
 }
 
 func TestShellCfgSet(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{APIVersion: "1.21"}
 	const (
 		usageHint = "This is a usage hint"
 	)
@@ -154,16 +152,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "export ",
-				Delimiter:        "=\"",
-				Suffix:           "\"\n",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "export ",
+				Delimiter:       "=\"",
+				Suffix:          "\"\n",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -192,16 +189,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "export ",
-				Delimiter:        "=\"",
-				Suffix:           "\"\n",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), defaultMachineName),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      defaultMachineName,
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "export ",
+				Delimiter:       "=\"",
+				Suffix:          "\"\n",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), defaultMachineName),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     defaultMachineName,
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -230,16 +226,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "set -gx ",
-				Suffix:           "\";\n",
-				Delimiter:        " \"",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "set -gx ",
+				Suffix:          "\";\n",
+				Delimiter:       " \"",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -268,16 +263,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "$Env:",
-				Suffix:           "\"\n",
-				Delimiter:        " = \"",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "$Env:",
+				Suffix:          "\"\n",
+				Delimiter:       " = \"",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -306,16 +300,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "(setenv \"",
-				Suffix:           "\")\n",
-				Delimiter:        "\" \"",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "(setenv \"",
+				Suffix:          "\")\n",
+				Delimiter:       "\" \"",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -344,16 +337,15 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "SET ",
-				Suffix:           "\n",
-				Delimiter:        "=",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "SET ",
+				Suffix:          "\n",
+				Delimiter:       "=",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			expectedErr: nil,
 		},
@@ -386,18 +378,17 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "export ",
-				Delimiter:        "=\"",
-				Suffix:           "\"\n",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				NoProxyVar:       "NO_PROXY",
-				NoProxyValue:     "1.2.3.4", // From FakeDriver
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "export ",
+				Delimiter:       "=\"",
+				Suffix:          "\"\n",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				NoProxyVar:      "NO_PROXY",
+				NoProxyValue:    "1.2.3.4", // From FakeDriver
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			noProxyVar:   "NO_PROXY",
 			noProxyValue: "",
@@ -432,18 +423,17 @@ func TestShellCfgSet(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "export ",
-				Delimiter:        "=\"",
-				Suffix:           "\"\n",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				NoProxyVar:       "no_proxy",
-				NoProxyValue:     "192.168.59.1,1.2.3.4", // From FakeDriver
-				MachineName:      "quux",
-				ComposePathsVar:  isRuntimeWindows,
+				Prefix:          "export ",
+				Delimiter:       "=\"",
+				Suffix:          "\"\n",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				NoProxyVar:      "no_proxy",
+				NoProxyValue:    "192.168.59.1,1.2.3.4", // From FakeDriver
+				MachineName:     "quux",
+				ComposePathsVar: isRuntimeWindows,
 			},
 			noProxyVar:   "no_proxy",
 			noProxyValue: "192.168.59.1",
@@ -468,7 +458,6 @@ func TestShellCfgSet(t *testing.T) {
 }
 
 func TestShellCfgSetWindowsRuntime(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{APIVersion: "1.21"}
 	const (
 		usageHint = "This is a usage hint"
 	)
@@ -513,16 +502,15 @@ func TestShellCfgSetWindowsRuntime(t *testing.T) {
 				Err:         nil,
 			},
 			expectedShellCfg: &ShellConfig{
-				Prefix:           "$Env:",
-				Suffix:           "\"\n",
-				Delimiter:        " = \"",
-				DockerCertPath:   filepath.Join(mcndirs.GetMachineDir(), "quux"),
-				DockerHost:       "tcp://1.2.3.4:2376",
-				DockerTLSVerify:  "1",
-				DockerAPIVersion: "1.21",
-				UsageHint:        usageHint,
-				MachineName:      "quux",
-				ComposePathsVar:  true,
+				Prefix:          "$Env:",
+				Suffix:          "\"\n",
+				Delimiter:       " = \"",
+				DockerCertPath:  filepath.Join(mcndirs.GetMachineDir(), "quux"),
+				DockerHost:      "tcp://1.2.3.4:2376",
+				DockerTLSVerify: "1",
+				UsageHint:       usageHint,
+				MachineName:     "quux",
+				ComposePathsVar: true,
 			},
 			expectedErr: nil,
 		},
@@ -549,7 +537,6 @@ func TestShellCfgSetWindowsRuntime(t *testing.T) {
 }
 
 func TestShellCfgUnset(t *testing.T) {
-	mcndockerclient.CurrentDockerVersioner = &mcndockerclient.FakeDockerVersioner{APIVersion: "1.21"}
 	const (
 		usageHint = "This is the unset usage hint"
 	)

--- a/libmachine/mcndockerclient/docker_versioner.go
+++ b/libmachine/mcndockerclient/docker_versioner.go
@@ -6,15 +6,10 @@ var CurrentDockerVersioner DockerVersioner = &defaultDockerVersioner{}
 
 type DockerVersioner interface {
 	DockerVersion(host DockerHost) (string, error)
-	DockerAPIVersion(host DockerHost) (string, error)
 }
 
 func DockerVersion(host DockerHost) (string, error) {
 	return CurrentDockerVersioner.DockerVersion(host)
-}
-
-func DockerAPIVersion(host DockerHost) (string, error) {
-	return CurrentDockerVersioner.DockerAPIVersion(host)
 }
 
 type defaultDockerVersioner struct{}
@@ -31,18 +26,4 @@ func (dv *defaultDockerVersioner) DockerVersion(host DockerHost) (string, error)
 	}
 
 	return version.Version, nil
-}
-
-func (dv *defaultDockerVersioner) DockerAPIVersion(host DockerHost) (string, error) {
-	client, err := DockerClient(host)
-	if err != nil {
-		return "", fmt.Errorf("Unable to query docker API version: %s", err)
-	}
-
-	version, err := client.Version()
-	if err != nil {
-		return "", fmt.Errorf("Unable to query docker API version: %s", err)
-	}
-
-	return version.ApiVersion, nil
 }

--- a/libmachine/mcndockerclient/fake_docker_versioner.go
+++ b/libmachine/mcndockerclient/fake_docker_versioner.go
@@ -1,9 +1,8 @@
 package mcndockerclient
 
 type FakeDockerVersioner struct {
-	Version    string
-	APIVersion string
-	Err        error
+	Version string
+	Err     error
 }
 
 func (dv *FakeDockerVersioner) DockerVersion(host DockerHost) (string, error) {
@@ -12,12 +11,4 @@ func (dv *FakeDockerVersioner) DockerVersion(host DockerHost) (string, error) {
 	}
 
 	return dv.Version, nil
-}
-
-func (dv *FakeDockerVersioner) DockerAPIVersion(host DockerHost) (string, error) {
-	if dv.Err != nil {
-		return "", dv.Err
-	}
-
-	return dv.APIVersion, nil
 }


### PR DESCRIPTION
This reverts commit cc6c432ad8f9578d8ceca1b70d634972cbd1be05.

cfr: https://github.com/docker/docker/issues/29040

Since the Docker client now does version negotiation itself, this change will not be needed in versions of Docker >=1.13.0 .

Since "no is temporary, yes is forever", I am reverting this for now (0.9.0) to see how many users continue to experience issues.  We can re-add it later if desired.

FYI @s-koba and sorry for the shuffle.

