### PR TITLE
fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,7 @@ Misc
 
 - Update docker-machine version
 - Updated the bash completion with new options added
-- Bugsnag: Retrieve windows version on non-english OS
+- Bugsnag: Retrieve windows version on non-English OS
 
 Drivers
 

--- a/libmachine/crashreport/os_windows.go
+++ b/libmachine/crashreport/os_windows.go
@@ -29,7 +29,7 @@ func parseSystemInfoOutput(output string) string {
 		}
 	}
 
-	// If we couldn't find the version, maybe the output is not in english
+	// If we couldn't find the version, maybe the output is not in English
 	// Let's parse the fourth line since it seems to be the one always used
 	// for the version.
 	if len(lines) >= 4 {


### PR DESCRIPTION
Signed-off-by: kaiwentan <kaiwentan@harmonycloud.cn>


If a word refer to a kind of language, it should be capitalized.