### PR TITLE
Support building a Linux ARM64/aarch64 binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TARGET_OS=darwin TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=windows TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=linux TARGET_ARCH=arm TARGETS="build-x"
+    - TARGET_OS=linux TARGET_ARCH=arm64 TARGETS="build-x"
 script:
     - USE_CONTAINER=true make "$TARGETS"
     - "[[ \"$(find bin -type f -name docker-machine*)\" != \"\" ]]"

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -22,7 +22,7 @@ ifeq ($(TARGET_OS),)
 endif
 
 ifeq ($(TARGET_ARCH),)
-  TARGET_ARCH := amd64 arm 386
+  TARGET_ARCH := amd64 arm arm64 386
 endif
 
 # Output prefix, defaults to local directory if not specified

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,7 +1,7 @@
 extension = $(patsubst windows,.exe,$(filter windows,$(1)))
 
 # Valid target combinations
-VALID_OS_ARCH := "[darwin/amd64][linux/amd64][linux/arm][windows/amd64][windows/386]"
+VALID_OS_ARCH := "[darwin/amd64][linux/amd64][linux/arm][linux/arm64][windows/amd64][windows/386]"
 
 os.darwin := Darwin
 os.linux := Linux
@@ -9,6 +9,7 @@ os.windows := Windows
 
 arch.amd64 := x86_64
 arch.arm := armhf
+arch.arm64 := aarch64
 arch.386 := i386
 
 define gocross


### PR DESCRIPTION
In order to support building for Linux on ARM64/aarch64 (64bit) we could easily cross compile Docker Machine. In Go we use "linux/arm64", but on Linux the architecture is called "aarch64" which can be determined with `uname -m`.

Testing a build locally within Docker and only compile an ARM64 binary is easy with this command:

```
USE_CONTAINER=true TARGET_OS=linux TARGET_ARCH=arm64 make build-x
```

It builds the binary `./bin/docker-machine-Linux-aarch64`.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>