### PR TITLE
driver: sadeem.io driver

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/machine/drivers/none"
 	"github.com/docker/machine/drivers/openstack"
 	"github.com/docker/machine/drivers/rackspace"
+	"github.com/docker/machine/drivers/sadeem"
 	"github.com/docker/machine/drivers/softlayer"
 	"github.com/docker/machine/drivers/virtualbox"
 	"github.com/docker/machine/drivers/vmwarefusion"
@@ -187,6 +188,8 @@ func runDriver(driverName string) {
 		plugin.RegisterDriver(openstack.NewDriver("", ""))
 	case "rackspace":
 		plugin.RegisterDriver(rackspace.NewDriver("", ""))
+	case "sadeem":
+		plugin.RegisterDriver(sadeem.NewDriver("", ""))
 	case "softlayer":
 		plugin.RegisterDriver(softlayer.NewDriver("", ""))
 	case "virtualbox":

--- a/drivers/sadeem/sadeem.go
+++ b/drivers/sadeem/sadeem.go
@@ -1,0 +1,305 @@
+package sadeem
+
+import (
+	"fmt"
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/mcnflag"
+	"github.com/docker/machine/libmachine/ssh"
+	"github.com/docker/machine/libmachine/state"
+	"io/ioutil"
+	"time"
+)
+
+type vmData struct {
+	Hostname          string
+	OfferId           string
+	TemplateId        string
+	DatacenterId      string
+	PrivateNetworking bool
+	DiskSize          int
+	CpuCount          int
+	VCpu              int
+	Memory            int
+}
+
+type Driver struct {
+	*drivers.BaseDriver
+	ApiKey   string
+	ClientId string
+	VmId     string
+	VmData   *vmData
+	SSHKey   string
+}
+
+const (
+	defaultSSHPort        = 22
+	defaultSSHUser        = "root"
+	defaultPrivateNetwork = false
+	defaultDatacenter     = "riyadh"
+	defaultOffer          = "25"
+	defaultTemplate       = "ubuntu"
+)
+
+func (d *Driver) GetCreateFlags() []mcnflag.Flag {
+
+	return []mcnflag.Flag{
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_APIKEY",
+			Name:   "sadeem-apikey",
+			Usage:  "Sadeem Api Key",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_CLIENT_ID",
+			Name:   "sadeem_client_id",
+			Usage:  "Sadeem Client Id",
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_DATACENTER",
+			Name:   "sadeem_datacenter",
+			Usage:  "Sadeem Datacenter Name",
+			Value:  defaultDatacenter,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_SERVICE_OFFER",
+			Name:   "sadeem_service_offer",
+			Usage:  "Sadeem Service Offer Name",
+			Value:  defaultOffer,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_TEMPLATE",
+			Name:   "sadeem_template",
+			Usage:  "Sadeem Template Name",
+			Value:  defaultTemplate,
+		},
+		mcnflag.StringFlag{
+			EnvVar: "SADEEM_PRIVATE_NETWORK",
+			Name:   "sadeem_private_network",
+			Usage:  "enable private networking for Vm",
+		},
+	}
+}
+
+func ValidateDriverConfig(d *Driver) error {
+	if d.ApiKey == "" {
+		return fmt.Errorf("sadeem driver requires the --sadeem-apikey")
+	}
+
+	if d.ClientId == "" {
+		return fmt.Errorf("sadeem driver requires the --sadeem_client_id")
+	}
+	return nil
+}
+
+func NewDriver(hostName, storePath string) *Driver {
+
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+		VmData: &vmData{
+			Hostname: hostName,
+		},
+	}
+}
+
+func (d *Driver) DriverName() string {
+	return "sadeem"
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	d.ApiKey = flags.String("sadeem-apikey")
+	d.ClientId = flags.String("sadeem_client_id")
+	c := NewClient(d.ApiKey, d.ClientId)
+
+	DCName := flags.String("sadeem_datacenter")
+	Template := flags.String("sadeem_template")
+	OfferName := flags.String("sadeem_service_offer")
+
+	DcId, e := c.GetDatacenterId(DCName)
+
+	if e != nil {
+		return e
+	}
+
+	TempId, e := c.GetTemplateId(Template)
+	if e != nil {
+		return e
+	}
+
+	OfferId, e := c.GetOferrId(OfferName, DcId)
+
+	if e != nil {
+		return e
+	}
+
+	d.VmData = &vmData{
+		OfferId:           OfferId,
+		TemplateId:        TempId,
+		DatacenterId:      DcId,
+		PrivateNetworking: false,
+	}
+
+	d.SetSwarmConfigFromFlags(flags)
+	return ValidateDriverConfig(d)
+
+}
+
+func (d *Driver) GetURL() (string, error) {
+	if err := drivers.MustBeRunning(d); err != nil {
+		return "", err
+	}
+
+	ip, err := d.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("tcp://%s:2376", ip), nil
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return d.GetIP()
+}
+
+func (d *Driver) GetSSHPort() (int, error) {
+	return 22, nil
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return "root"
+}
+
+func (d *Driver) Create() error {
+	key, err := d.CreateSSHKey()
+
+	if err != nil {
+		return err
+	}
+
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+
+	c := NewClient(ApiKey, ClientId)
+	d.SSHKey = key
+
+	offer_id := d.VmData.OfferId
+	tmp_id := d.VmData.TemplateId
+	dc_id := d.VmData.DatacenterId
+
+	vmId, err := c.CreateNewVM(d.MachineName, dc_id, offer_id, tmp_id, key)
+	if err != nil {
+		return err
+	}
+	IP, err := c.GetVmIP(vmId)
+
+	if err != nil {
+		return err
+	}
+
+	d.VmId = vmId
+	d.IPAddress = string(IP)
+
+	for {
+
+		b, _ := c.GetVmState(d.VmId)
+
+		switch b {
+		case "pending":
+			break
+		case "archived":
+			return fmt.Errorf("Failed to create VM")
+		default:
+			return nil
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+	return nil
+}
+
+func (d *Driver) Start() error {
+
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	err := client.StartVm(d.VmId)
+
+	return err
+}
+
+func (d *Driver) Stop() error {
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	err := client.StopVm(d.VmId)
+
+	return err
+}
+
+func (d *Driver) Restart() error {
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	err := client.RebootVm(d.VmId)
+
+	return err
+}
+
+func (d *Driver) Kill() error {
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	err := client.KillVm(d.VmId)
+	return err
+}
+
+func (d *Driver) Remove() error {
+
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	err := client.destroyVm(d.VmId)
+	return err
+}
+
+func (d *Driver) publicSSHKeyPath() string {
+	return d.GetSSHKeyPath() + ".pub"
+}
+
+func (d *Driver) CreateSSHKey() (string, error) {
+	SSHKeyPath := d.GetSSHKeyPath()
+
+	if err := ssh.GenerateSSHKey(SSHKeyPath); err != nil {
+		return "", err
+	}
+
+	publicKey, err := ioutil.ReadFile(d.publicSSHKeyPath())
+	if err != nil {
+		return "", err
+	}
+
+	return string(publicKey), err
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	ApiKey := d.ApiKey
+	ClientId := d.ClientId
+	client := NewClient(ApiKey, ClientId)
+	b, err := client.GetVmState(d.VmId)
+
+	if err != nil {
+		return state.Error, err
+	}
+
+	switch b {
+	case "pending":
+		return state.Starting, nil
+	case "running":
+		return state.Running, nil
+	case "power-off":
+		return state.Stopped, nil
+	case "archived":
+		return state.Error, fmt.Errorf("Vm already deleted")
+	}
+	return state.None, nil
+}

--- a/drivers/sadeem/sadeem_utils.go
+++ b/drivers/sadeem/sadeem_utils.go
@@ -1,0 +1,338 @@
+package sadeem
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	defaultBaseURL = "http://api.sadeem.io/api/v1/"
+	mediaType      = "application/json"
+	userAgent      = "docker-machine"
+)
+
+// http client to connect sadeem
+
+func NewClient(apiKey, clientId string) *Client {
+
+	httpClient := http.DefaultClient
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	c := &Client{
+		client:    httpClient,
+		BaseURL:   baseURL,
+		UserAgent: userAgent,
+		ApiKey:    apiKey,
+		ClientId:  clientId,
+	}
+	return c
+}
+
+func (c *Client) CreateSShKey(name, key string) (string, error) {
+	var sshKey SSHKey
+	sshKey = SSHKey{Name: name, Key: key}
+	body, err := json.Marshal(sshKey)
+	url := defaultBaseURL + "sshkeys/"
+	resp, err := c.SendRequets(url, "POST", string(body))
+	if err != nil {
+		return "", err
+	} else {
+		return ReadCreateResponse(resp)
+	}
+}
+
+func (c *Client) CreateNewVM(hostName, datacenterId, serviceOfferId, templateId, sSHKey string) (string, error) {
+	var newVm VMNew
+	url := defaultBaseURL + "vms/"
+	userScript := "#!/bin/bash\n\necho \"" + sSHKey + "\" > ~/.ssh/authorized_keys"
+
+	newVm = VMNew{
+		Hostname:       hostName,
+		DatacenterId:   datacenterId,
+		ServiceOfferId: serviceOfferId,
+		TemplateId:     templateId,
+		PrivateNetwork: false,
+		EnableFirewall: false,
+		UserScript:     userScript,
+	}
+	body, _ := json.Marshal(newVm)
+	resp, err := c.SendRequets(url, "POST", string(body))
+
+	if err != nil {
+		return "", err
+	} else {
+		return ReadCreateResponse(resp)
+	}
+
+}
+
+func (c *Client) GetVmState(vm_id string) (string, error) {
+	if vm_id == "" {
+		return "", fmt.Errorf("Not valid VM Id")
+	}
+	url := defaultBaseURL + "vms/" + vm_id
+
+	resp, err := c.SendRequets(url, "GET", "")
+
+	var NewData VMResp
+	if err == nil {
+		NewData, err = ReadVmResponse(resp)
+		if err != nil {
+			return "", err
+		} else {
+			return NewData.Data.Status, nil
+		}
+	} else {
+		return "", err
+	}
+}
+
+// Vms Actions
+func (c *Client) StartVm(vm_id string) error {
+	url := defaultBaseURL + "vms/" + vm_id + "/start"
+	resp, err := c.SendRequets(url, "POST", "")
+	if err != nil {
+		return err
+	} else {
+		ReadActionResponse(resp)
+		return nil
+	}
+}
+
+func (c *Client) StopVm(vm_id string) error {
+	url := defaultBaseURL + "vms/" + vm_id + "/shutdown"
+	resp, err := c.SendRequets(url, "POST", "")
+	if err != nil {
+		return err
+	} else {
+		ReadActionResponse(resp)
+		return nil
+	}
+}
+
+func (c *Client) KillVm(vm_id string) error {
+	url := defaultBaseURL + "vms/" + vm_id + "/shutdown?force=true"
+	resp, err := c.SendRequets(url, "POST", "")
+	if err != nil {
+		return err
+	} else {
+		ReadActionResponse(resp)
+		return nil
+	}
+}
+
+func (c *Client) RebootVm(vm_id string) error {
+	url := defaultBaseURL + "vms/" + vm_id + "/reboot"
+	resp, err := c.SendRequets(url, "POST", "")
+	if err != nil {
+		return err
+	} else {
+		ReadActionResponse(resp)
+		return nil
+	}
+}
+
+func (c *Client) destroyVm(vm_id string) error {
+	if vm_id == "" {
+		return nil
+	}
+	url := defaultBaseURL + "vms/" + vm_id
+	resp, err := c.SendRequets(url, "DELETE", "")
+	if err != nil {
+		return err
+	} else {
+		_, err := ReadActionResponse(resp)
+		return err
+	}
+}
+
+// end of Vms actions
+
+// get Vm IP
+func (c *Client) GetVmIP(vm_id string) (string, error) {
+	url := defaultBaseURL + "vms/" + vm_id
+
+	resp, err := c.SendRequets(url, "GET", "")
+
+	var NewData VMResp
+	if err == nil {
+		NewData, err = ReadVmResponse(resp)
+		if err != nil {
+			return "", err
+		} else {
+			return NewData.Data.Network[0].IP.String(), nil
+		}
+	} else {
+		return "", err
+	}
+}
+
+func (c *Client) GetDatacenterId(DcName string) (string, error) {
+	url := defaultBaseURL + "datacenters/"
+	resp, err := c.SendRequets(url, "GET", "")
+	if err != nil {
+		return "", err
+	}
+	Data, err := ReadListResponse(resp)
+
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(Data); i++ {
+		if strings.ToLower(Data[i].Name) == strings.ToLower(DcName) {
+			return Data[i].ID, nil
+		}
+	}
+	return "", errors.New("datacenter not found")
+}
+
+func (c *Client) GetOferrId(DcName, DcId string) (string, error) {
+	url := defaultBaseURL + "offers/datacenter/" + DcId
+	resp, err := c.SendRequets(url, "GET", "")
+	if err != nil {
+		return "", err
+	}
+	Data, err := ReadListResponse(resp)
+
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(Data); i++ {
+		if strings.ToLower(Data[i].Name) == strings.ToLower(DcName) {
+			return Data[i].ID, nil
+		}
+	}
+	return "", errors.New("Service Offer not found")
+}
+
+func (c *Client) GetTemplateId(TemplateName string) (string, error) {
+	url := defaultBaseURL + "templates/"
+	resp, err := c.SendRequets(url, "GET", "")
+	if err != nil {
+		return "", err
+	}
+	Data, err := ReadListResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(Data); i++ {
+		if strings.ToLower(Data[i].Name) == strings.ToLower(TemplateName) {
+			return Data[i].ID, nil
+		}
+	}
+	return "", errors.New("Template not found")
+}
+
+//
+// Functions to read response from Sadeem API
+//Send Http request
+func (c *Client) SendRequets(url, method, body string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	var emptyResp *http.Response
+
+	if err != nil {
+		return emptyResp, err
+	}
+	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Add("x-api-key", c.ApiKey)
+	req.Header.Add("x-client-id", c.ClientId)
+	req.Header.Add("content-type", "application/json")
+
+	return c.client.Do(req)
+}
+
+// Read response for get vm/$id
+func ReadVmResponse(r *http.Response) (VMResp, error) {
+	var re1 VMResp
+	if r.StatusCode >= 300 {
+		return re1, ReadErrorResponse(r)
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return re1, err
+	}
+
+	err = json.Unmarshal(data, &re1)
+	if err != nil {
+		return re1, err
+	}
+	return re1, nil
+}
+
+func ReadListResponse(r *http.Response) ([]*ListObject, error) {
+	var re1 ListResp
+	if r.StatusCode >= 300 {
+		return re1.Data, ReadErrorResponse(r)
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return re1.Data, err
+	}
+	err = json.Unmarshal(data, &re1)
+	if err != nil {
+		return re1.Data, err
+	}
+	return re1.Data, nil
+}
+
+// Read result from cerate, return the Id string
+func ReadCreateResponse(r *http.Response) (string, error) {
+	var createResponce CreateResponce
+	if r.StatusCode >= 300 {
+		return "", ReadErrorResponse(r)
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(data, &createResponce)
+	if err != nil {
+		return "", err
+	}
+	return createResponce.Id, nil
+}
+
+//Read Error Response
+func ReadErrorResponse(r *http.Response) error {
+	var errorMsg ErrorMessage
+	data, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		return fmt.Errorf("Undefined error %s", r.Status)
+	}
+	err = json.Unmarshal(data, &errorMsg)
+	if err != nil {
+		return fmt.Errorf("Undefined error %s", r.Status)
+	}
+	return fmt.Errorf(errorMsg.Error.Message)
+}
+
+func ReadActionResponse(r *http.Response) (string, error) {
+	var createResponce CreateResponce
+	if r.StatusCode >= 300 {
+		return "", ReadErrorResponse(r)
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(data, &createResponce)
+	if err != nil {
+		return "", err
+	}
+
+	return createResponce.Id, nil
+}

--- a/drivers/sadeem/templates.go
+++ b/drivers/sadeem/templates.go
@@ -1,0 +1,82 @@
+package sadeem
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+)
+
+type ListResp struct {
+	Href string        `json:"href"`
+	Data []*ListObject `json:"data"`
+}
+
+type ListObject struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Client struct {
+	client    *http.Client
+	BaseURL   *url.URL
+	UserAgent string
+	ApiKey    string
+	ClientId  string
+}
+
+type VMResp struct {
+	Href string `json:"href"`
+	Data *VM    `json:"data"`
+}
+type VM struct {
+	Hostname   string     `json:"hostname"`
+	Id         string     `json:"id"`
+	CpuShare   int        `json:"cpu_shares"`
+	VCpu       int        `json:"vcpu"`
+	Memory     int        `json:"ram"`
+	Datacenter string     `json:"datacenter_id"`
+	Template   string     `json:"template_value"`
+	Status     string     `json:"status"`
+	Network    []*Network `json:"network"`
+}
+
+type SSHKey struct {
+	Id     string `json:"id,omitempty"`
+	Key    string `json:"key"`
+	Status string `json:"status,omitempty"`
+	Name   string `json:"name"`
+}
+
+type CreateResponce struct {
+	Id string `json:"id"`
+}
+
+type ErrorMessage struct {
+	Error ErrorMessageBody `json:"error"`
+}
+
+type ErrorMessageBody struct {
+	Code    int    `json:"code"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type Network struct {
+	ID      uint   `json:"id"`
+	IP      net.IP `json:"ip"`
+	Gateway net.IP `json:"gateway"`
+	Netmask net.IP `json:"netmask"`
+	Mac     string `json: "mac"`
+}
+
+type VMNew struct {
+	Hostname       string   `json:"hostname"`
+	DatacenterId   string   `json:"dc_id"`
+	ServiceOfferId string   `json:"service_offer_id"`
+	TemplateId     string   `json:"template_id"`
+	SSHKeyId       []string `json:"ssh_key_id,omitempty"`
+	UserScript     string   `json:"user_script,omitempty"`
+	PrivateNetwork bool     `json:"private_network,omitempty"`
+	Firewall       []string `json:"firewall,omitempty"`
+	EnableFirewall bool     `json:"enable_firewall,omitempty"`
+}

--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -19,7 +19,7 @@ var (
 	CurrentBinaryIsDockerMachine = false
 	CoreDrivers                  = []string{"amazonec2", "azure", "digitalocean",
 		"exoscale", "generic", "google", "hyperv", "none", "openstack",
-		"rackspace", "softlayer", "virtualbox", "vmwarefusion",
+		"rackspace", "sadeem", "softlayer", "virtualbox", "vmwarefusion",
 		"vmwarevcloudair", "vmwarevsphere"}
 )
 


### PR DESCRIPTION
Add support for Sadeem.io, **[Sadeem.io](https://www.sadeem.io)** currently provide cloud in **Saudi Arabia**, **UAE**, and soon over **Turkey** and overall Middle East 

# Configuration

**The main configuration options are:**

**--sadeem-apikey**: Sadeem api key
**--sadeem_client_id**: client Id in Sadeem
**--sadeem_datacenter**: Sadeem Datacenter Name to create vm on
**--sadeem_service_offer**: Service offer name to use
**--sadeem_template**: Name of Template to use to create vm wih
	

SSH keypair will be generated for each new VM.

The default template used is Ubuntu Template and may be changed with the **--sadeem_template** option.

## Docker machine support

The following docker machine commands work as expected:

**create
ls
ssh
start, stop, restart, kill and rm
inspect**
