### PR TITLE
Use systemd drop-in for the docker-machine configuration

### DIFF
--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -75,22 +75,11 @@ func (provisioner *CoreOSProvisioner) GenerateDockerOptions(dockerPort int) (*Do
 		arg = ""
 	}
 
-	engineConfigTmpl := `[Unit]
-Description=Docker Socket for the API
-After=docker.socket early-docker.target network.target
-Requires=docker.socket early-docker.target
-
-[Service]
+	engineConfigTmpl := `[Service]
 Environment=TMPDIR=/var/tmp
-EnvironmentFile=-/run/flannel_docker_opts.env
-MountFlags=slave
-LimitNOFILE=1048576
-LimitNPROC=1048576
+ExecStart=
 ExecStart=/usr/lib/coreos/dockerd ` + arg + ` --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:{{.DockerPort}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}}{{ range .EngineOptions.Labels }} --label {{.}}{{ end }}{{ range .EngineOptions.InsecureRegistry }} --insecure-registry {{.}}{{ end }}{{ range .EngineOptions.RegistryMirror }} --registry-mirror {{.}}{{ end }}{{ range .EngineOptions.ArbitraryFlags }} --{{.}}{{ end }} \$DOCKER_OPTS \$DOCKER_OPT_BIP \$DOCKER_OPT_MTU \$DOCKER_OPT_IPMASQ
 Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
 `
 
 	t, err := template.New("engineConfig").Parse(engineConfigTmpl)

--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -27,25 +27,10 @@ priority=1
 enabled=1
 gpgkey=https://yum.dockerproject.org/gpg
 `
-	engineConfigTemplate = `[Unit]
-Description=Docker Application Container Engine
-After=network.target
-
-[Service]
-Type=notify
+	engineConfigTemplate = `[Service]
+ExecStart=
 ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:{{.DockerPort}} -H unix:///var/run/docker.sock --storage-driver {{.EngineOptions.StorageDriver}} --tlsverify --tlscacert {{.AuthOptions.CaCertRemotePath}} --tlscert {{.AuthOptions.ServerCertRemotePath}} --tlskey {{.AuthOptions.ServerKeyRemotePath}} {{ range .EngineOptions.Labels }}--label {{.}} {{ end }}{{ range .EngineOptions.InsecureRegistry }}--insecure-registry {{.}} {{ end }}{{ range .EngineOptions.RegistryMirror }}--registry-mirror {{.}} {{ end }}{{ range .EngineOptions.ArbitraryFlags }}--{{.}} {{ end }}
-ExecReload=/bin/kill -s HUP $MAINPID
-MountFlags=slave
-LimitNOFILE=infinity
-LimitNPROC=infinity
-LimitCORE=infinity
-TimeoutStartSec=0
-Delegate=yes
-KillMode=process
 Environment={{range .EngineOptions.Env}}{{ printf "%q" . }} {{end}}
-
-[Install]
-WantedBy=multi-user.target
 `
 
 	majorVersionRE = regexp.MustCompile(`^(\d+)(\..*)?`)

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -181,7 +181,7 @@ func ConfigureAuth(p Provisioner) error {
 
 	log.Info("Setting Docker configuration on the remote daemon...")
 
-	if _, err = p.SSHCommand(fmt.Sprintf("printf %%s \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
+	if _, err = p.SSHCommand(fmt.Sprintf("sudo mkdir -p %s && printf %%s \"%s\" | sudo tee %s", path.Dir(dkrcfg.EngineOptionsPath), dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Using systemd drop-in for the configuration is better for inherit the
package default settings, without the need of sync the settings
between 2 projects.

Fixes https://github.com/docker/machine/issues/3963

Signed-off-by: Tao Wang <twang2218@gmail.com>