### PR TITLE
Return error, not just log it, when failing to get status. Fixed #3971

### DIFF
--- a/commands/status.go
+++ b/commands/status.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/log"
 )
@@ -22,7 +23,7 @@ func cmdStatus(c CommandLine, api libmachine.API) error {
 
 	currentState, err := host.Driver.GetState()
 	if err != nil {
-		log.Errorf("error getting state for host %s: %s", host.Name, err)
+		return fmt.Errorf("error getting state for host %s: %s", host.Name, err)
 	}
 
 	log.Info(currentState)


### PR DESCRIPTION
A proposed fix for issue https://github.com/docker/machine/issues/3971

When `status` command fails, it should return an exit code != 0.
