### PR TITLE
Fix parsing of '--virtualbox-share-folder' on Windows

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -456,12 +456,11 @@ func (d *Driver) CreateVM() error {
 	shareName, shareDir := getShareDriveAndName()
 
 	if d.ShareFolder != "" {
-		split := strings.Split(d.ShareFolder, ":")
-		shareDir, shareName = split[0], split[1]
+		shareDir, shareName = parseShareFolder(d.ShareFolder)
 	}
 
 	if shareDir != "" && !d.NoShare {
-		log.Debugf("setting up shareDir")
+		log.Debugf("setting up shareDir '%s' -> '%s'", shareDir, shareName)
 		if _, err := os.Stat(shareDir); err != nil && !os.IsNotExist(err) {
 			return err
 		} else if !os.IsNotExist(err) {
@@ -485,6 +484,13 @@ func (d *Driver) CreateVM() error {
 	}
 
 	return nil
+}
+
+func parseShareFolder(shareFolder string) (string, string) {
+	split := strings.Split(shareFolder, ":")
+	shareDir := strings.Join(split[:len(split)-1], ":")
+	shareName := split[len(split)-1]
+	return shareDir, shareName
 }
 
 func (d *Driver) hostOnlyIPAvailable() bool {

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -63,6 +63,25 @@ func TestDefaultSSHUsername(t *testing.T) {
 	assert.Equal(t, "docker", username)
 }
 
+var parseShareFolderTestCases = []struct {
+	shareFolder       string
+	expectedShareDir  string
+	expectedShareName string
+}{
+	{"dir:name", "dir", "name"},
+	{"C:\\dir:name", "C:\\dir", "name"},
+	{"C:\\:name", "C:\\", "name"},
+}
+
+func TestParseShareFolder(t *testing.T) {
+	for _, parseShareFolderTestCase := range parseShareFolderTestCases {
+		shareDir, shareName := parseShareFolder(parseShareFolderTestCase.shareFolder)
+
+		assert.Equal(t, shareDir, parseShareFolderTestCase.expectedShareDir)
+		assert.Equal(t, shareName, parseShareFolderTestCase.expectedShareName)
+	}
+}
+
 func TestState(t *testing.T) {
 	var tests = []struct {
 		stdOut string


### PR DESCRIPTION
Allow use of ':' in the left part of the mapping to use Windows paths.
Assume the right part of the mapping does not contains ':'.
Should fix issue #3908