### PR TITLE
Make virtualbox default 'create' driver

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -38,7 +38,7 @@ var (
 		cli.StringFlag{
 			Name:   "driver, d",
 			Usage:  "Driver to create machine with.",
-			Value:  "none",
+			Value:  "virtualbox",
 			EnvVar: "MACHINE_DRIVER",
 		},
 		cli.StringFlag{
@@ -299,8 +299,7 @@ func cmdCreateOuter(c CommandLine, api libmachine.API) error {
 		//TODO: Check Environment have to include flagHackLookup function.
 		driverName = os.Getenv("MACHINE_DRIVER")
 		if driverName == "" {
-			c.ShowHelp()
-			return nil // ?
+			driverName = "virtualbox"
 		}
 	}
 

--- a/its/tester.go
+++ b/its/tester.go
@@ -150,7 +150,7 @@ func (dmt *dockerMachineTest) DriverName() string {
 		return driver
 	}
 
-	return "none"
+	return "virtualbox"
 }
 
 func (dmt *dockerMachineTest) Should() Assertions {


### PR DESCRIPTION
Since almost no-one uses `none` I think a default of `virtualbox` would make more sense.