### PR TITLE
Vendor package github.com/bugsnag/panicwrap to v1.1.0 to support ARM64

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/docker/machine",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"github.com/docker/machine",
 		"github.com/docker/machine/cmd",
@@ -262,8 +262,8 @@
 		},
 		{
 			"ImportPath": "github.com/bugsnag/panicwrap",
-			"Comment": "1.0.0",
-			"Rev": "e5f9854865b9778a45169fc249e99e338d4d6f27"
+			"Comment": "1.1.0",
+			"Rev": "aceac81c6e2f55f23844821679a0553b545e91df"
 		},
 		{
 			"ImportPath": "github.com/cenkalti/backoff",

--- a/vendor/github.com/bugsnag/panicwrap/CHANGELOG.md
+++ b/vendor/github.com/bugsnag/panicwrap/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.1.0 (2016-01-18)
+
+* Add ARM64 support
+  [liusdu](https://github.com/liusdu)
+  [#1](https://github.com/bugsnag/panicwrap/pull/1)
+
+## 1.0.0 (2014-11-10)
+
+### Enhancements
+
+* Add ability to monitor a process

--- a/vendor/github.com/bugsnag/panicwrap/dup2.go
+++ b/vendor/github.com/bugsnag/panicwrap/dup2.go
@@ -1,0 +1,11 @@
+// +build darwin dragonfly freebsd linux,!arm64 netbsd openbsd
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/vendor/github.com/bugsnag/panicwrap/dup3.go
+++ b/vendor/github.com/bugsnag/panicwrap/dup3.go
@@ -1,0 +1,11 @@
+// +build linux,arm64
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/vendor/github.com/bugsnag/panicwrap/monitor.go
+++ b/vendor/github.com/bugsnag/panicwrap/monitor.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bugsnag/osext"
 	"os"
 	"os/exec"
-	"syscall"
 )
 
 func monitor(c *WrapConfig) (int, error) {
@@ -54,7 +53,7 @@ func monitor(c *WrapConfig) (int, error) {
 		return -1, err
 	}
 
-	err = syscall.Dup2(int(write.Fd()), int(os.Stderr.Fd()))
+	err = dup2(int(write.Fd()), int(os.Stderr.Fd()))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Done with command `godep update -v github.com/bugsnag/panicwrap`.

This PR is essential to fix the build errors detected in PR #3960, it supersedes PR #3961.

Signed-off-by: Boris Pruessmann <boris@pruessmann.org>

@DieterReuter FYI