### PR TITLE
Activate bash completion for Windows executable

### DIFF
--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -285,4 +285,4 @@ _docker_machine() {
     return 0
 }
 
-complete -F _docker_machine docker-machine
+complete -F _docker_machine docker-machine docker-machine.exe


### PR DESCRIPTION
On Unix shells running on Windows (cygwin, Docker Toolbox), command completion will expand the name of the Docker Machine binary to `docker-machine.exe`. If you manually installed bash completion, it will not trigger unless you remove the trailing `.exe`.
This PR makes bash completion work for binaries named `docker-machine` _and_ `docker-machine.exe`.