### PR TITLE
Refine bash completion of machines in start and stop commands

### DIFF
--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -14,6 +14,16 @@
 #    . ~/.docker-machine-completion.sh
 #
 
+# --- helper functions -------------------------------------------------------
+
+_docker_machine_q() {
+    docker-machine 2>/dev/null "$@"
+}
+
+_docker_machine_machines() {
+    _docker_machine_q ls --format '{{.Name}}' "$@"
+}
+
 _docker_machine_value_of_option() {
     local pattern="$1"
     for (( i=2; i < ${cword}; ++i)); do
@@ -23,6 +33,8 @@ _docker_machine_value_of_option() {
         fi
     done
 }
+
+# --- completion functions ---------------------------------------------------
 
 _docker_machine_active() {
     if [[ "${cur}" == -* ]]; then
@@ -36,7 +48,7 @@ _docker_machine_config() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--swarm --help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -65,7 +77,7 @@ _docker_machine_create() {
     # driver specific options are only included in help output if --driver is given,
     # so we have to pass that option when calling docker-machine to harvest options.
     local driver="$(_docker_machine_value_of_option '--driver|-d')"
-    local parsed_options="$(docker-machine 2>/dev/null create ${driver:+--driver $driver} --help | grep '^   -' | sed 's/^   //; s/[^a-z0-9-].*$//')"
+    local parsed_options="$(_docker_machine_q create ${driver:+--driver $driver} --help | grep '^   -' | sed 's/^   //; s/[^a-z0-9-].*$//')"
     if [[ ${cur} == -* ]]; then
         COMPREPLY=($(compgen -W "${parsed_options} -d --help" -- "${cur}"))
     fi
@@ -81,7 +93,7 @@ _docker_machine_env() {
             if [[ "${cur}" == -* ]]; then
                 COMPREPLY=($(compgen -W "--swarm --shell --unset --no-proxy --help" -- "${cur}"))
             else
-                COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+                COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
             fi
     esac
 }
@@ -91,7 +103,7 @@ _docker_machine_use() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--swarm --unset --help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -104,7 +116,7 @@ _docker_machine_inspect() {
             if [[ "${cur}" == -* ]]; then
                 COMPREPLY=($(compgen -W "--format --help" -- "${cur}"))
             else
-                COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+                COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
             fi
             ;;
     esac
@@ -114,7 +126,7 @@ _docker_machine_ip() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -122,7 +134,7 @@ _docker_machine_kill() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -141,7 +153,7 @@ _docker_machine_regenerate_certs() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help --force" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -149,7 +161,7 @@ _docker_machine_restart() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -166,7 +178,7 @@ _docker_machine_ssh() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -177,7 +189,7 @@ _docker_machine_scp() {
         _filedir
         # It would be really nice to ssh to the machine and ls to complete
         # remote files.
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q | sed 's/$/:/')" -- "${cur}") "${COMPREPLY[@]}")
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines | sed 's/$/:/')" -- "${cur}") "${COMPREPLY[@]}")
     fi
 }
 
@@ -185,7 +197,7 @@ _docker_machine_start() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines --filter state=Stopped)" -- "${cur}"))
     fi
 }
 
@@ -193,7 +205,7 @@ _docker_machine_status() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -201,7 +213,7 @@ _docker_machine_stop() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines --filter state=Running)" -- "${cur}"))
     fi
 }
 
@@ -209,7 +221,7 @@ _docker_machine_upgrade() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -217,7 +229,7 @@ _docker_machine_url() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 
@@ -225,7 +237,7 @@ _docker_machine_version() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(docker-machine ls -q)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 


### PR DESCRIPTION
Bash completion for `docker-machine start` and `docker-machine stop` always completed all machines, regardless of their state.
This PR refines this so that `docker-machine start` only completes stopped machines and `docker-machine stop` only completes running machines.

A new function `_docker_machine_machines` was factored out that lists machines and accepts additional parameters that get passed on to `docker-machine`. It can also be invoked directly, e.g.
```bash
_docker_machine_machines --filter state=Running
_docker_machine_machines --filter state=Running --filter driver=vmwarevsphere --format='{{.Name}}\t{{.State}}'
```
Such functions are widely used in Docker's bash completion.