### PR TITLE
Add bash completion of machines to `docker-machine rm`

### DIFF
--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -167,10 +167,9 @@ _docker_machine_restart() {
 
 _docker_machine_rm() {
     if [[ "${cur}" == -* ]]; then
-        COMPREPLY=($(compgen -W "--help --force -y" -- "${cur}"))
+        COMPREPLY=($(compgen -W "--help --force -f -y" -- "${cur}"))
     else
-        # For rm, it's best to be explicit
-        COMPREPLY=()
+	COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
     fi
 }
 


### PR DESCRIPTION
Bash completion of `docker-machine rm` intentionally does not complete machine names.
In practice, this is annoying. It feels as if completion were broken in this place.

There are use cases where machines are created and destroyed quite frequently. As examples see Viktor Farcic's book _The Devops 2.1 Toolkit_, where at the end of each chapter alle machines are removed, and his tutorials, e.g. http://proxy.dockerflow.com/swarm-mode-auto/.

Also added the missing `-f` option.