### PR TITLE
Add delta option to the scp command, using rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:1.7.4
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                openssh-client \
+                rsync \
+        && rm -rf /var/lib/apt/lists/*
+
 RUN go get  github.com/golang/lint/golint \
             github.com/mattn/goveralls \
             golang.org/x/tools/cover

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -355,6 +355,10 @@ var Commands = []cli.Command{
 				Name:  "recursive, r",
 				Usage: "Copy files recursively (required to copy directories)",
 			},
+			cli.BoolFlag{
+				Name:  "delta, d",
+				Usage: "Reduce amount of data sent over network by sending only the differences (uses rsync)",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
When doing repeated syncs, or copying large directories, it is more
efficient to use "rsync" than to use "scp". Both use "ssh" to do it.