### PR TITLE
Update the Go version used in circle.yml to 1.7.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/1.0.22/binscripts/gvm-installer)
 
   post:
-    - gvm install go1.6 -B --name=stable
+    - gvm install go1.7 -B --name=stable
 
   environment:
     CHECKOUT: /home/ubuntu/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
Both the project's Dockerfile and Godeps.json specify Go 1.7. Tests should run with the same version.

Related to #4028

Signed-off-by: Andrew Starr-Bochicchio <a.starr.b@gmail.com>