### PR TITLE
Make the SUSE/openSUSE provisioner more resilient

### DIFF
--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -98,10 +98,14 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	// figure out the filesystem used by /var/lib
-	fs, err := provisioner.SSHCommand("stat -f -c %T /var/lib/")
+	// figure out the filesystem used by /var/lib/docker
+	fs, err := provisioner.SSHCommand("stat -f -c %T /var/lib/docker")
 	if err != nil {
-		return err
+		// figure out the filesystem used by /var/lib
+		fs, err = provisioner.SSHCommand("stat -f -c %T /var/lib/")
+		if err != nil {
+			return err
+		}
 	}
 	graphDriver := "overlay"
 	if strings.Contains(fs, "btrfs") {
@@ -144,13 +148,13 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 	// create symlinks for containerd, containerd-shim and runc.
 	// We have to do that because machine overrides the openSUSE systemd
 	// unit of docker
-	if _, err := provisioner.SSHCommand("sudo -E ln -s /usr/sbin/runc /usr/sbin/docker-runc"); err != nil {
+	if _, err := provisioner.SSHCommand("sudo -E ln -sf /usr/sbin/runc /usr/sbin/docker-runc"); err != nil {
 		return err
 	}
-	if _, err := provisioner.SSHCommand("sudo -E ln -s /usr/sbin/containerd /usr/sbin/docker-containerd"); err != nil {
+	if _, err := provisioner.SSHCommand("sudo -E ln -sf /usr/sbin/containerd /usr/sbin/docker-containerd"); err != nil {
 		return err
 	}
-	if _, err := provisioner.SSHCommand("sudo -E ln -s /usr/sbin/containerd-shim /usr/sbin/docker-containerd-shim"); err != nil {
+	if _, err := provisioner.SSHCommand("sudo -E ln -sf /usr/sbin/containerd-shim /usr/sbin/docker-containerd-shim"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Do not let the provisioner fail when ran against an already initialized machine.

