### PR TITLE
drivers/digitalocean: fix empty tags being added to droplets

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -393,7 +393,9 @@ func (d *Driver) getTags() []string {
 
 	for _, t := range strings.Split(d.Tags, ",") {
 		t = strings.TrimSpace(t)
-		tagList = append(tagList, t)
+		if t != "" {
+			tagList = append(tagList, t)
+		}
 	}
 
 	return tagList

--- a/drivers/digitalocean/digitalocean_test.go
+++ b/drivers/digitalocean/digitalocean_test.go
@@ -89,7 +89,7 @@ func TestTags(t *testing.T) {
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
 			"digitalocean-access-token": "TOKEN",
-			"digitalocean-tags":         "docker,swarm, no-leading-space",
+			"digitalocean-tags":         "docker,swarm, no-leading-space,,",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}
@@ -97,4 +97,19 @@ func TestTags(t *testing.T) {
 	err := driver.SetConfigFromFlags(checkFlags)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"docker", "swarm", "no-leading-space"}, driver.getTags())
+}
+
+func TestTagsEmpty(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"digitalocean-access-token": "TOKEN",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+	assert.NoError(t, err)
+	assert.Nil(t, driver.getTags())
 }


### PR DESCRIPTION
Currently an empty tag was always being added to the droplet. This causes digitalocean to reject the droplet creation request due to invalid tags.

This PR fixes this and adds a new test case to ensure the Tags attribute is nil if no tags were set.