### PR TITLE
Enable proxy for openstack

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/docker/machine",
+	"ImportPath": "github.com/michalmedvecky/machine",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v79",
 	"Packages": [

--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -596,7 +596,7 @@ func (c *GenericClient) SetTLSConfig(d *Driver) error {
 		config.RootCAs = certpool
 	}
 
-	transport := &http.Transport{TLSClientConfig: config}
+        transport := &http.Transport{TLSClientConfig: config, Proxy: http.ProxyFromEnvironment}
 	c.Provider.HTTPClient.Transport = transport
 	return nil
 }


### PR DESCRIPTION
This fix allows docker-machine to reach OS_AUTH_URL using proxy.