### PR TITLE
Enable http-proxy for openstack module

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -596,7 +596,7 @@ func (c *GenericClient) SetTLSConfig(d *Driver) error {
 		config.RootCAs = certpool
 	}
 
-	transport := &http.Transport{TLSClientConfig: config}
+	transport := &http.Transport{TLSClientConfig: config, Proxy: http.ProxyFromEnvironment}
 	c.Provider.HTTPClient.Transport = transport
 	return nil
 }


### PR DESCRIPTION
This options allows go http client to use http_proxy/https_proxy env vars. 

Resolves #4040 