### PR TITLE
Use PKG_NAME in mk so it can be reused in drivers

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -16,7 +16,7 @@ define gocross
 	$(if $(findstring [$(1)/$(2)],$(VALID_OS_ARCH)), \
 	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 \
 		$(GO) build \
-		-o $(PREFIX)/bin/docker-machine-${os.$(1)}-${arch.$(2)}$(call extension,$(GOOS)) \
+		-o $(PREFIX)/bin/$(PKG_NAME)-${os.$(1)}-${arch.$(2)}$(call extension,$(GOOS)) \
 		-a $(VERBOSE_GO) -tags "static_build netgo $(BUILDTAGS)" -installsuffix netgo \
 		-ldflags "$(GO_LDFLAGS) -extldflags -static" $(GO_GCFLAGS) ./cmd/machine.go;)
 endef
@@ -27,10 +27,10 @@ build-clean:
 build-x: $(shell find . -type f -name '*.go')
 	$(foreach GOARCH,$(TARGET_ARCH),$(foreach GOOS,$(TARGET_OS),$(call gocross,$(GOOS),$(GOARCH))))
 
-$(PREFIX)/bin/docker-machine$(call extension,$(GOOS)): $(shell find . -type f -name '*.go')
+$(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS)): $(shell find . -type f -name '*.go')
 	$(GO) build \
 	-o $@ \
 	$(VERBOSE_GO) -tags "$(BUILDTAGS)" \
 	-ldflags "$(GO_LDFLAGS)" $(GO_GCFLAGS) ./cmd/machine.go
 
-build: $(PREFIX)/bin/docker-machine$(call extension,$(GOOS))
+build: $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS))

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -49,7 +49,7 @@ include mk/validate.mk
 default: build
 
 install:
-	cp $(PREFIX)/bin/docker-machine /usr/local/bin
+	cp $(PREFIX)/bin/$(PKG_NAME) /usr/local/bin
 
 clean: coverage-clean build-clean
 test: dco fmt test-short lint vet


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

I thought I'd work on a non-libvirt qemu driver again, and this was almost the only change I needed to make to be able to reuse the docker-machine mk files... 

AKA - you have a PKG_NAME var, so you may as well use it.

the other change was to replace the references to `machine.go` with `main.go` which i kinda feel is better anyhow.