### PR TITLE
Allow rancheros (all-non-b2d) to select a different Docker engine version using --engine-install-url

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"errors"
-
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
@@ -94,9 +92,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	if drivers.EngineInstallURLFlagSet(flags) {
-		return errors.New("--engine-install-url cannot be used with the hyperv driver, use --hyperv-boot2docker-url instead")
-	}
 	d.Boot2DockerURL = flags.String("hyperv-boot2docker-url")
 	d.VSwitch = flags.String("hyperv-virtual-switch")
 	d.DiskSize = flags.Int("hyperv-disk-size")

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -228,9 +228,6 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	if drivers.EngineInstallURLFlagSet(flags) {
-		return errors.New("--engine-install-url cannot be used with the virtualbox driver, use --virtualbox-boot2docker-url instead")
-	}
 	d.CPU = flags.Int("virtualbox-cpu-count")
 	d.Memory = flags.Int("virtualbox-memory")
 	d.DiskSize = flags.Int("virtualbox-disk-size")

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -18,8 +18,6 @@ import (
 	"text/template"
 	"time"
 
-	"errors"
-
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"
@@ -145,9 +143,6 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	if drivers.EngineInstallURLFlagSet(flags) {
-		return errors.New("--engine-install-url cannot be used with the vmwarefusion driver, use --vmwarefusion-boot2docker-url instead")
-	}
 	d.Memory = flags.Int("vmwarefusion-memory-size")
 	d.CPU = flags.Int("vmwarefusion-cpu-count")
 	d.DiskSize = flags.Int("vmwarefusion-disk-size")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -183,9 +183,6 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	if drivers.EngineInstallURLFlagSet(flags) {
-		return errors.New("--engine-install-url cannot be used with the vmwarevsphere driver, use --vmwarevsphere-boot2docker-url instead")
-	}
 	d.SSHUser = "docker"
 	d.SSHPort = 22
 	d.CPU = flags.Int("vmwarevsphere-cpu-count")

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -86,6 +86,9 @@ func (d *BaseDriver) SetSwarmConfigFromFlags(flags DriverOptions) {
 }
 
 func EngineInstallURLFlagSet(flags DriverOptions) bool {
-	engineInstallURLFlag := flags.String("engine-install-url")
-	return engineInstallURLFlag != DefaultEngineInstallURL && engineInstallURLFlag != ""
+	return EngineInstallURLSet(flags.String("engine-install-url"))
+}
+
+func EngineInstallURLSet(url string) bool {
+	return url != DefaultEngineInstallURL && url != ""
 }

--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -93,6 +93,8 @@ func (provisioner *RancherProvisioner) Package(name string, action pkgaction.Pac
 }
 
 func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, authOptions auth.Options, engineOptions engine.Options) error {
+	log.Debugf("Running RancherOS provisioner on %s", provisioner.Driver.GetMachineName())
+
 	provisioner.SwarmOptions = swarmOptions
 	provisioner.AuthOptions = authOptions
 	provisioner.EngineOptions = engineOptions
@@ -114,6 +116,11 @@ func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, aut
 		if err := provisioner.Package(pkg, pkgaction.Install); err != nil {
 			return err
 		}
+	}
+
+	log.Debugf("Selecting docker engine: %s", engineOptions.InstallURL)
+	if err := selectDocker(provisioner, engineOptions.InstallURL); err != nil {
+		return err
 	}
 
 	log.Debugf("Preparing certificates")
@@ -230,4 +237,13 @@ func (provisioner *RancherProvisioner) getLatestISOURL() (string, error) {
 	}
 
 	return "", fmt.Errorf("Failed to find current version")
+}
+
+func selectDocker(p Provisioner, baseURL string) error {
+	// TODO: detect if its a cloud-init, or a ros setting - and use that..
+	if output, err := p.SSHCommand(fmt.Sprintf("wget -O- %s | sh -", baseURL)); err != nil {
+		return fmt.Errorf("error selecting docker: (%s) %s", err, output)
+	}
+
+	return nil
 }


### PR DESCRIPTION
RancherOS v1.0.1 defaults to use Docker v17.03.1-ce, and `--engine-install-url` is a nice standard way to change it (though there's way too many `sleep`'s in the existing scripts

initially tested using vbox... (which required removing the hardcoded "we can't do things because we only install b2d")

```
svend@x260 MINGW64 ~/src/github.com/docker/machine (master)
$ ./machine.exe create --virtualbox-boot2docker-url https://releases.rancher.com/os/latest/rancheros.iso --engine-install-url https://raw.githubusercontent.com/SvenDowideit/install-docker/5896b863698967df0738976d6ee98efc5d4637ae/1.12.6.sh rancheros-1.12.6
Running pre-create checks...
(rancheros-1.12.6) Boot2Docker URL was explicitly set to "https://releases.rancher.com/os/latest/rancheros.iso" at create time, so Docker Machine cannot upgrade this machine to the latest version.
Creating machine...
(rancheros-1.12.6) Boot2Docker URL was explicitly set to "https://releases.rancher.com/os/latest/rancheros.iso" at create time, so Docker Machine cannot upgrade this machine to the latest version.
(rancheros-1.12.6) Downloading C:\Users\svend\.docker\machine\cache\boot2docker.iso from https://releases.rancher.com/os/latest/rancheros.iso...
(rancheros-1.12.6) 0%....10%....20%....30%....40%....50%....60%....70%....80%....90%....100%
(rancheros-1.12.6) Creating VirtualBox VM...
(rancheros-1.12.6) Creating SSH key...
(rancheros-1.12.6) Starting the VM...
(rancheros-1.12.6) Check network to re-create if needed...
(rancheros-1.12.6) Waiting for an IP...
Waiting for machine to be running, this may take a few minutes...
Detecting operating system of created instance...
Waiting for SSH to be available...
Detecting the provisioner...
Provisioning with rancheros...
Running RancherOS provisioner on rancheros-1.12.6
Setting hostname rancheros-1.12.6
Selecting docker engine: https://raw.githubusercontent.com/SvenDowideit/install-docker/5896b863698967df0738976d6ee98efc5d4637ae/1.12.6.sh
Select Docker result: Connecting to raw.githubusercontent.com (151.101.0.133:443)
-                    100% |*******************************| 15837   0:00:00 ETA

Warning: the "docker" command appears to already exist on this system.

If you already have Docker installed, this script can cause trouble, which is
why we're displaying this warning and provide the opportunity to cancel the
installation.

If you installed the current Docker package using this script and are using it
again to update Docker, you can safely ignore this message.

You may press Ctrl+C now to abort this script.
+ sleep 20
++ cut -d ' ' -f 2
++ head -n 1
++ grep 1.12.6
++ sudo ros engine list
+ sudo -E sh -c 'sleep 3; ros engine switch -f docker-1.12.6'
> time="2017-05-10T02:27:08Z" level=info msg="Project [os]: Starting project "
> time="2017-05-10T02:27:08Z" level=info msg="[0/16] [docker]: Starting "
Pulling docker (rancher/os-docker:1.12.6)...
1.12.6: Pulling from rancher/os-docker
52160511971f: Pulling fs layer
52160511971f: Verifying Checksum
52160511971f: Download complete
52160511971f: Pull complete
Digest: sha256:1916540f838dbef62602e0565541a3e25dcb66649369ed697266326fc3cd615c
Status: Downloaded newer image for rancher/os-docker:1.12.6
> time="2017-05-10T02:27:54Z" level=info msg="Recreating docker"
> time="2017-05-10T02:27:55Z" level=info msg="[1/16] [docker]: Started "

Preparing certificates
Setting up certificates
Copying certs to the local machine directory...
Copying certs to the remote machine...
Setting Docker configuration on the remote daemon...
Configuring swarm
Checking connection to Docker...
Docker is up and running!
To see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: C:\Users\svend\src\github.com\docker\machine\machine.exe env rancheros-1.12.6

svend@x260 MINGW64 ~/src/github.com/docker/machine (master)
$

svend@x260 MINGW64 ~/src/github.com/docker/machine (master)
$

svend@x260 MINGW64 ~/src/github.com/docker/machine (master)
$ ./machine.exe ls
NAME               ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER    ERRORS
rancheros-1.12.6   -        virtualbox   Running   tcp://192.168.99.100:2376           v1.12.6
```