### PR TITLE
Add bash completion for `docker-machine provision`

### DIFF
--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -165,7 +165,7 @@ _docker_machine_regenerate_certs() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--force -f --help" -- "${cur}"))
     else
-        COMPREPLY=($(compgen -W "$(_docker_machine_machines)" -- "${cur}"))
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines --filter state=Running)" -- "${cur}"))
     fi
 }
 

--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -153,6 +153,14 @@ _docker_machine_ls() {
     fi
 }
 
+_docker_machine_provision() {
+    if [[ "${cur}" == -* ]]; then
+        COMPREPLY=($(compgen -W "--help" -- "${cur}"))
+    else
+        COMPREPLY=($(compgen -W "$(_docker_machine_machines --filter state=Running)" -- "${cur}"))
+    fi
+}
+
 _docker_machine_regenerate_certs() {
     if [[ "${cur}" == -* ]]; then
         COMPREPLY=($(compgen -W "--force -f --help" -- "${cur}"))
@@ -266,7 +274,7 @@ _docker_machine_docker_machine() {
 
 _docker_machine() {
     COMPREPLY=()
-    local commands=(active config create env inspect ip kill ls regenerate-certs restart rm ssh scp start status stop upgrade url version help)
+    local commands=(active config create env inspect ip kill ls provision regenerate-certs restart rm ssh scp start status stop upgrade url version help)
 
     local flags=(--debug --native-ssh --github-api-token --bugsnag-api-token --help --version)
     local wants_dir=(--storage-path)


### PR DESCRIPTION
I'm not sure whether this is correct. I assume that `docker-machine provision` should work on running and stopped machines. But on a quick test, `docker-machine provision` only worked with a running machine.

Is this how it is supposed to work? If so, I will have to update this PR to only complete running machines.
Currently all machines are completed.