### PR TITLE
Fix #3937 invalid handle for termsize in Windows

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -201,7 +201,7 @@ func (client *NativeClient) OutputWithPty(command string) (string, error) {
 	defer closeConn(conn)
 	defer session.Close()
 
-	fd := int(os.Stdin.Fd())
+	fd := int(os.Stdout.Fd())
 
 	termWidth, termHeight, err := terminal.GetSize(fd)
 	if err != nil {


### PR DESCRIPTION
Fixes #3937

this changes the filedescriptor to represent the output, else the syscall for Windows (console info) will fail with an "Invalid handle" error.

```diff
-       fd := int(os.Stdin.Fd())
+	fd := int(os.Stdout.Fd())
	termWidth, termHeight, err := terminal.GetSize(fd)
```