### PR TITLE
Fix up old image name calling convention

### DIFF
--- a/drivers/google/google.go
+++ b/drivers/google/google.go
@@ -196,6 +196,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	if !d.UseExisting {
 		d.MachineType = flags.String("google-machine-type")
 		d.MachineImage = flags.String("google-machine-image")
+		d.MachineImage = strings.TrimPrefix(d.MachineImage, "https://www.googleapis.com/compute/v1/projects/")
 		d.DiskSize = flags.Int("google-disk-size")
 		d.DiskType = flags.String("google-disk-type")
 		d.Address = flags.String("google-address")


### PR DESCRIPTION
#3557 changed the way images were specified, this PR makes the old way work, by removing the prefix.

Note also that the docs are still implying the use of the full URL - https://docs.docker.com/machine/drivers/gce/

though they're vague enough to make it harder to use gce than it should be.