### PR TITLE
Allow vmware drivers to work with non-boot2docker hosts

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -368,7 +368,10 @@ func (d *Driver) Create() error {
 	vmrun("-gu", B2DUser, "-gp", B2DPass, "CopyFileFromHostToGuest", d.vmxPath(), d.ResolveStorePath("userdata.tar"), "/home/docker/userdata.tar")
 
 	// Expand tar file.
-	vmrun("-gu", B2DUser, "-gp", B2DPass, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo /bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar && sudo tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1 && sudo chown -R docker:staff /home/docker")
+	vmrun("-gu", B2DUser, "-gp", B2DPass, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo sh -c \"tar xvf userdata.tar -C /home/docker > /var/log/userdata.log 2>&1 && chown -R docker:staff /home/docker\"")
+
+	// copy to /var/lib/boot2docker
+	vmrun("-gu", B2DUser, "-gp", B2DPass, "runScriptInGuest", d.vmxPath(), "/bin/sh", "sudo /bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar")
 
 	// Enable Shared Folders
 	vmrun("-gu", B2DUser, "-gp", B2DPass, "enableSharedFolders", d.vmxPath())

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -554,10 +554,25 @@ func (d *Driver) Create() error {
 		return err
 	}
 
+	// first, untar - only boot2docker has /var/lib/boot2docker
+	// TODO: don't hard-code to docker & staff - they are also just b2d
 	var env []string
 	guestspec := types.GuestProgramSpec{
 		ProgramPath:      "/usr/bin/sudo",
-		Arguments:        "/bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar && /usr/bin/sudo tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1 && /usr/bin/sudo chown -R docker:staff /home/docker",
+		Arguments:        "/usr/bin/sudo /bin/sh -c \"tar xvf userdata.tar -C /home/docker > /var/log/userdata.log 2>&1 && chown -R docker:staff /home/docker\"",
+		WorkingDirectory: "",
+		EnvVariables:     env,
+	}
+
+	_, err = procman.StartProgram(ctx, auth.Auth(), &guestspec)
+	if err != nil {
+		return err
+	}
+
+	// now move to /var/lib/boot2docker if its there
+	guestspec = types.GuestProgramSpec{
+		ProgramPath:      "/usr/bin/sudo",
+		Arguments:        "/bin/mv /home/docker/userdata.tar /var/lib/boot2docker/userdata.tar",
 		WorkingDirectory: "",
 		EnvVariables:     env,
 	}


### PR DESCRIPTION
tested with a RancherOS that auto-starts the open-vm-tools 

I'm not sure what iso's of ubuntu/alpine/whatever have that also running, but if there is one :+1: 