### PR TITLE
Ignore "unknown instance" error when rm instance

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -952,6 +952,7 @@ func (d *Driver) terminate() error {
 	})
 
 	if strings.HasPrefix(err.Error(), "unknown instance") {
+		log.Warn("Remote instance does not exist, proceeding with removing local reference")
 		return nil
 	}
 

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -950,6 +950,11 @@ func (d *Driver) terminate() error {
 	_, err := d.getClient().TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{&d.InstanceId},
 	})
+
+	if strings.HasPrefix(err.Error(), "unknown instance") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("unable to terminate instance: %s", err)
 	}


### PR DESCRIPTION
Fixes #4112 

This is especially useful when using Spot instances on EC2, as they may be removed at any time.