### PR TITLE
Ignore more errors from EC2 API

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -951,7 +951,8 @@ func (d *Driver) terminate() error {
 		InstanceIds: []*string{&d.InstanceId},
 	})
 
-	if strings.HasPrefix(err.Error(), "unknown instance") {
+	if strings.HasPrefix(err.Error(), "unknown instance") ||
+		strings.HasPrefix(err.Error(), "InvalidInstanceID.NotFound") {
 		log.Warn("Remote instance does not exist, proceeding with removing local reference")
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Jacob Parry <jacob@jacobparry.ca>

This builds on the work done in #4116 to bypass additional variations of the error sent by the EC2 API.