### PR TITLE
Remove @nathanleclaire as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,7 +14,6 @@
 			"dgageot",
 			"ehazlett",
 			"jeanlaurent",
-			"nathanleclaire",
 		]
 
 [people]
@@ -39,8 +38,3 @@
 	Name = "Jean-Laurent de Morlhon"
 	Email = "jeanlaurent@docker.com>"
 	GitHub = "jeanlaurent"
-
-	[people.nathanleclaire]
-	Name = "Nathan LeClaire"
-	Email = "nathan.leclaire@docker.com"
-	GitHub = "nathanleclaire"


### PR DESCRIPTION
Sad to say this day has come! But, as always, change is the only constant of life.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>