### PR TITLE
Fix issue #4119: automatically re-render 'PS1' in place upon you chan…

### DIFF
--- a/contrib/completion/bash/docker-machine-prompt.bash
+++ b/contrib/completion/bash/docker-machine-prompt.bash
@@ -66,4 +66,3 @@ __update_shell_prompt () {
 
 bind '"\C-M":"\n __update_shell_prompt\n"'
 
-

--- a/contrib/completion/bash/docker-machine-prompt.bash
+++ b/contrib/completion/bash/docker-machine-prompt.bash
@@ -64,5 +64,5 @@ __update_shell_prompt () {
     tput cup $((current_row-2)) 0 && tput el
 }
 
-bind '"\C-M":"\n __update_shell_prompt\n"'
+bind '"\e[C":"\n __update_shell_prompt\n"'
 

--- a/contrib/completion/bash/docker-machine-prompt.bash
+++ b/contrib/completion/bash/docker-machine-prompt.bash
@@ -9,6 +9,8 @@
 #  1b. Alternatively, just copy this file into into /etc/bash_completion.d
 #  2. Change your PS1 to call __docker-machine-ps1 as command-substitution
 #     PS1='[\u@\h \W$(__docker_machine_ps1 " [%s]")]\$ '
+#  3. Add 'export HISTCONTROL=ignorespace' to your '~/.bash_profile' or '~/.bashrc'
+#     to prevent potential commands history pollution.
 #
 # Configuration:
 #
@@ -18,7 +20,7 @@
 #
 
 __docker_machine_ps1 () {
-    local format=${1:- [%s]}
+    local format=${1:- [[%s]]}
     if test ${DOCKER_MACHINE_NAME}; then
         local status
         if test ${DOCKER_MACHINE_PS1_SHOWSTATUS:-false} = true; then
@@ -45,3 +47,23 @@ __docker_machine_ps1 () {
         printf -- "${format}" "${DOCKER_MACHINE_NAME}${status}"
     fi
 }
+
+__update_shell_prompt () {
+    if [ -n "$(__docker_machine_ps1)" ]; then
+        local new_shell_prompt re="[[:space:]]*\[\[[^]]*\]\]"
+        if [[ $PS1 =~ $re ]]; then
+            new_shell_prompt=$(echo "$PS1" | sed -e "s/$re/$(__docker_machine_ps1)/")
+        else
+            new_shell_prompt=$(echo "$PS1" | sed -e "s/\(.*\)\]\(.*\)/\1$(__docker_machine_ps1)]\2/")
+        fi
+        export PS1=$new_shell_prompt
+    fi
+
+    IFS=';' read -sdR -p $'\E[6n' ROW COL; local current_row=`echo "${ROW#*[}"`
+
+    tput cup $((current_row-2)) 0 && tput el
+}
+
+bind '"\C-M":"\n __update_shell_prompt\n"'
+
+

--- a/contrib/completion/bash/docker-machine-prompt.bash
+++ b/contrib/completion/bash/docker-machine-prompt.bash
@@ -64,5 +64,5 @@ __update_shell_prompt () {
     tput cup $((current_row-2)) 0 && tput el
 }
 
-bind '"\e[C":"\n __update_shell_prompt\n"'
+bind '"\e[24~":"\n __update_shell_prompt\n"'
 


### PR DESCRIPTION
Scenario details:
1. Use Unix builtin function `bind` to bind one function `__update_shell_prompt` to `Enter key: \C-M`;

2. Upon any enter key hitting, the function `__update_shell_prompt` will be invoked, then based on whether you changed the 'docker-machine env' or not the function would try to re-render the `PS1`;

3. Since any executed command will be echoed back in the terminal, it is a bit annoying, so here I just use the Unix builtin function `tput` to omit the echoed `__update_shell_prompt` line, to make it looks like nothing ever happened;

4. Also since by default any executed command will be recored in the history(so you can use the `up` and `down` key to switch between them conveniently), so the above `2` will pollute your history, but as you can see the command ` __update_shell_prompt` which is bind to the `Enter key: \C-M` is prefixed with one space, so put `export HISTCONTROL=ignorespace` into your `~/.bash_profile` or `~/.bashrc`, then you can prevent this potential commands history pollution;

Then it works perfectly, enjoy 🙂