### PR TITLE
[VSPHERE] Add vm config params

### DIFF
--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -6,6 +6,7 @@ package vmwarevsphere
 
 import (
 	"archive/tar"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -62,6 +63,7 @@ type Driver struct {
 	Pool       string
 	HostSystem string
 	CfgParams  []string
+	CloudInit  string
 
 	SSHPassword string
 }
@@ -153,6 +155,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "vmwarevsphere-cfgparam",
 			Usage:  "vSphere vm configuration parameters (used for guestinfo)",
 		},
+		mcnflag.StringFlag{
+			EnvVar: "VSPHERE_CLOUDINIT",
+			Name:   "vmwarevsphere-cloudinit",
+			Usage:  "vSphere cloud-init file or url to set in the guestinfo",
+		},
 	}
 }
 
@@ -205,6 +212,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.Pool = flags.String("vmwarevsphere-pool")
 	d.HostSystem = flags.String("vmwarevsphere-hostsystem")
 	d.CfgParams = flags.StringSlice("vmwarevsphere-cfgparam")
+	d.CloudInit = flags.String("vmwarevsphere-cloudinit")
 	d.SetSwarmConfigFromFlags(flags)
 
 	d.ISO = d.ResolveStorePath(isoFilename)
@@ -527,6 +535,30 @@ func (d *Driver) Create() error {
 			Key:   key,
 			Value: value,
 		})
+	}
+	if d.CloudInit != "" {
+		if _, err := url.ParseRequestURI(d.CloudInit); err == nil {
+			log.Infof("setting guestinfo.cloud-init.data.url to %s\n", d.CloudInit)
+			opts = append(opts, &types.OptionValue{
+				Key:   "guestinfo.cloud-init.config.url",
+				Value: d.CloudInit,
+			})
+		} else {
+			if _, err := os.Stat(d.CloudInit); err == nil {
+				if value, err := ioutil.ReadFile(d.CloudInit); err == nil {
+					log.Infof("setting guestinfo.cloud-init.data to encoded content of %s\n", d.CloudInit)
+					encoded := base64.StdEncoding.EncodeToString(value)
+					opts = append(opts, &types.OptionValue{
+						Key:   "guestinfo.cloud-init.config.data",
+						Value: encoded,
+					})
+					opts = append(opts, &types.OptionValue{
+						Key:   "guestinfo.cloud-init.data.encoding",
+						Value: "base64",
+					})
+				}
+			}
+		}
 	}
 
 	task, err = vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{


### PR DESCRIPTION

```
~/bin/machine -D create --driver vmwarevsphere \
	--vmwarevsphere-vcenter 10.10.10.2 \
	--vmwarevsphere-boot2docker-url rancheros.iso \
        --vmwarevsphere-cfgparam guestinfo.rancher.ENVIRONMENT.SVEN=TEST \
        --vmwarevsphere-cfgparam guestinfo.rancher.ENVIRONMENT.ANOTHER=TEST \
        --vmware-vsphere-cfgparamfile <local file|url>
```

and once everything is settled and works, we can use open-vm-tools to get access to the info.

```
machine ssh guestinfo "sudo system-docker exec open-vm-tools vmware-rpctool 'info-get guestinfo.rancher.ENVIRONMENT.SVEN'"
TEST
```

`--vmware-vsphere-cfgparamfile` sets the `guestinfo.cloud-init.config.<data|url>` -

combining both settings will set them all in the vm's `guestinfo`, and the open-vm-tools will make all the values available to the host. its up the the host OS to decide how to use them.

