### PR TITLE
Reorder if's to ensure that err is not null before using it.

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -951,13 +951,13 @@ func (d *Driver) terminate() error {
 		InstanceIds: []*string{&d.InstanceId},
 	})
 
-	if strings.HasPrefix(err.Error(), "unknown instance") ||
-		strings.HasPrefix(err.Error(), "InvalidInstanceID.NotFound") {
-		log.Warn("Remote instance does not exist, proceeding with removing local reference")
-		return nil
-	}
-
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "unknown instance") ||
+			strings.HasPrefix(err.Error(), "InvalidInstanceID.NotFound") {
+			log.Warn("Remote instance does not exist, proceeding with removing local reference")
+			return nil
+		}
+		
 		return fmt.Errorf("unable to terminate instance: %s", err)
 	}
 	return nil


### PR DESCRIPTION
A bug seems to have been introduced that used `err` even though it might be null at the time. See issue #4146.

Now, I'm no go coder, have not compiled this or anything - but it seems like it should work from the code alone. Feel free to reject and re-do as necessary.