### PR TITLE
drivers/amazonec2: logs userdata file error

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -558,6 +558,7 @@ func (d *Driver) Base64UserData() (userdata string, err error) {
 	if d.UserDataFile != "" {
 		buf, ioerr := ioutil.ReadFile(d.UserDataFile)
 		if ioerr != nil {
+			log.Warnf("failed to read user data file %q: %s", d.UserDataFile, ioerr)
 			err = errorReadingUserData
 			return
 		}


### PR DESCRIPTION
This PR adds a simple log message to help debugging user data issues when trying to read the file (file not found, permission errors) etc.
Signed-off-by: André Carvalho <asantostc@gmail.com>