### PR TITLE
amazonec2: prevent nil pointer dereference on machine terminate

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -950,14 +950,12 @@ func (d *Driver) terminate() error {
 	_, err := d.getClient().TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{&d.InstanceId},
 	})
-
-	if strings.HasPrefix(err.Error(), "unknown instance") ||
-		strings.HasPrefix(err.Error(), "InvalidInstanceID.NotFound") {
-		log.Warn("Remote instance does not exist, proceeding with removing local reference")
-		return nil
-	}
-
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "unknown instance") ||
+			strings.HasPrefix(err.Error(), "InvalidInstanceID.NotFound") {
+			log.Warn("Remote instance does not exist, proceeding with removing local reference")
+			return nil
+		}
 		return fmt.Errorf("unable to terminate instance: %s", err)
 	}
 	return nil


### PR DESCRIPTION
Fixes #4175.

Signed-off-by: André Carvalho <asantostc@gmail.com>