### PR TITLE
Skip the default docker provisioning script, RancherOS already has a docker installed

### DIFF
--- a/libmachine/provision/rancheros.go
+++ b/libmachine/provision/rancheros.go
@@ -118,9 +118,13 @@ func (provisioner *RancherProvisioner) Provision(swarmOptions swarm.Options, aut
 		}
 	}
 
-	log.Debugf("Selecting docker engine: %s", engineOptions.InstallURL)
-	if err := selectDocker(provisioner, engineOptions.InstallURL); err != nil {
-		return err
+	if engineOptions.InstallURL == drivers.DefaultEngineInstallURL {
+		log.Debugf("Skipping docker engine default: %s", engineOptions.InstallURL)
+	} else {
+		log.Debugf("Selecting docker engine: %s", engineOptions.InstallURL)
+		if err := selectDocker(provisioner, engineOptions.InstallURL); err != nil {
+			return err
+		}
 	}
 
 	log.Debugf("Preparing certificates")


### PR DESCRIPTION
and it seem that the current one causes failures (previously, there was a certificate error, and the provisioning just continued on)