### PR TITLE
Update EC2 AMIs to newest versions. This should fix AUFS support

### DIFF
--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -8,25 +8,25 @@ type region struct {
 	AmiId string
 }
 
-// Ubuntu 16.04 LTS 20161221 hvm:ebs-ssd (amd64)
+// Ubuntu 16.04 LTS 20170619.1 hvm:ebs-ssd (amd64)
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1":  {"ami-18afc47f"},
-	"ap-northeast-2":  {"ami-93d600fd"},
-	"ap-southeast-1":  {"ami-87b917e4"},
-	"ap-southeast-2":  {"ami-e6b58e85"},
-	"ap-south-1":      {"ami-dd3442b2"},
-	"ca-central-1":    {"ami-7112a015"},
-	"cn-north-1":      {"ami-31499d5c"},
-	"eu-central-1":    {"ami-fe408091"},
-	"eu-west-1":       {"ami-ca80a0b9"},
-	"eu-west-2":       {"ami-ede2e889"},
-	"sa-east-1":       {"ami-e075ed8c"},
-	"us-east-1":       {"ami-9dcfdb8a"},
-	"us-east-2":       {"ami-fcc19b99"},
-	"us-west-1":       {"ami-b05203d0"},
-	"us-west-2":       {"ami-b2d463d2"},
-	"us-gov-west-1":   {"ami-19d56d78"},
+	"ap-northeast-1":  {"ami-785c491f"},
+	"ap-northeast-2":  {"ami-94d20dfa"},
+	"ap-southeast-1":  {"ami-2378f540"},
+	"ap-southeast-2":  {"ami-e94e5e8a"},
+	"ap-south-1":      {"ami-49e59a26"},
+	"ca-central-1":    {"ami-7ed56a1a"},
+	"cn-north-1":      {"ami-a163b4cc"}, // Note: this is 20170303
+	"eu-central-1":    {"ami-1c45e273"},
+	"eu-west-1":       {"ami-6d48500b"},
+	"eu-west-2":       {"ami-cc7066a8"},
+	"sa-east-1":       {"ami-34afc458"},
+	"us-east-1":       {"ami-d15a75c7"},
+	"us-east-2":       {"ami-8b92b4ee"},
+	"us-west-1":       {"ami-73f7da13"},
+	"us-west-2":       {"ami-835b4efa"},
+	"us-gov-west-1":   {"ami-939412f2"},
 	"custom-endpoint": {""},
 }
 


### PR DESCRIPTION
Fixes #4191 

Not sure why this started failing, but the newer AMIs seem to resolve the issue.