### PR TITLE
libmachine/provision: retries pkg installation if fails to get lock

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -64,11 +64,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForLock(provisioner, command)
 }
 
 func (provisioner *DebianProvisioner) dockerDaemonResponding() bool {

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -80,11 +80,7 @@ func (provisioner *UbuntuSystemdProvisioner) Package(name string, action pkgacti
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForLock(provisioner, command)
 }
 
 func (provisioner *UbuntuSystemdProvisioner) dockerDaemonResponding() bool {

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -96,11 +96,7 @@ func (provisioner *UbuntuProvisioner) Package(name string, action pkgaction.Pack
 
 	log.Debugf("package: action=%s name=%s", action.String(), name)
 
-	if _, err := provisioner.SSHCommand(command); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForLock(provisioner, command)
 }
 
 func (provisioner *UbuntuProvisioner) dockerDaemonResponding() bool {

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -296,9 +296,13 @@ func DockerClientVersion(ssh SSHCommander) (string, error) {
 }
 
 func waitForLockAptGetUpdate(ssh SSHCommander) error {
+	return waitForLock(ssh, "sudo apt-get update")
+}
+
+func waitForLock(ssh SSHCommander, cmd string) error {
 	var sshErr error
 	err := mcnutils.WaitFor(func() bool {
-		_, sshErr = ssh.SSHCommand("sudo apt-get update")
+		_, sshErr = ssh.SSHCommand(cmd)
 		if sshErr != nil {
 			if strings.Contains(sshErr.Error(), "Could not get lock") {
 				sshErr = nil
@@ -309,10 +313,10 @@ func waitForLockAptGetUpdate(ssh SSHCommander) error {
 		return true
 	})
 	if sshErr != nil {
-		return fmt.Errorf("Error running apt-get update: %s", sshErr)
+		return fmt.Errorf("Error running %q: %s", cmd, sshErr)
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to obtain apt-get update lock: %s", err)
+		return fmt.Errorf("Failed to obtain lock: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This commit is a follow-up on #3891 and makes sure we retry pkg installations if we fail to acquire a lock.

This is pretty useful if the user provides a userdata that also install pkgs and prevents errors such as:
Error creating machine: Error running provisioning: ssh command error:
command : DEBIAN_FRONTEND=noninteractive sudo -E apt-get install -y  curl
err     : exit status 100
output  : E: Could not get lock /var/lib/dpkg/lock - open (11: Resource temporarily unavailable)
E: Unable to lock the administration directory (/var/lib/dpkg/), is another process using it?

PTAL @shin- @SvenDowideit 

Signed-off-by: André Carvalho <asantostc@gmail.com>