### PR TITLE
Modified error message output on host already or does not exist

### DIFF
--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use \"docker-machine ls\" to list machines. Use \"docker-machine create [OPTIONS]\" to add a new one.", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use \"docker-machine ls\" to list machines. Use \"docker-machine create\" to add a new one.", e.Name)
 }
 
 type ErrHostAlreadyExists struct {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Docker machine \"%q\" does not exist", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use docker-machine create to add one.", e.Name)
 }
 
 type ErrHostAlreadyExists struct {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use docker-machine create to add one.", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use docker-machine ls to list machines. Use docker-machine create [OPTIONS] to add a new one.", e.Name)
 }
 
 type ErrHostAlreadyExists struct {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use docker-machine ls to list machines. Use docker-machine create [OPTIONS] to add a new one.", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" does not exist. Use \"docker-machine ls\" to list machines. Use \"docker-machine create [OPTIONS]\" to add a new one.", e.Name)
 }
 
 type ErrHostAlreadyExists struct {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Docker machine %q does not exist", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" does not exist", e.Name)
 }
 
 type ErrHostAlreadyExists struct {
@@ -25,7 +25,7 @@ type ErrHostAlreadyExists struct {
 }
 
 func (e ErrHostAlreadyExists) Error() string {
-	return fmt.Sprintf("Docker machine %q already exists", e.Name)
+	return fmt.Sprintf("Docker machine \"%q\" already exists", e.Name)
 }
 
 type ErrDuringPreCreate struct {

--- a/libmachine/mcnerror/errors.go
+++ b/libmachine/mcnerror/errors.go
@@ -17,7 +17,7 @@ type ErrHostDoesNotExist struct {
 }
 
 func (e ErrHostDoesNotExist) Error() string {
-	return fmt.Sprintf("Host does not exist: %q", e.Name)
+	return fmt.Sprintf("Docker machine %q does not exist", e.Name)
 }
 
 type ErrHostAlreadyExists struct {
@@ -25,7 +25,7 @@ type ErrHostAlreadyExists struct {
 }
 
 func (e ErrHostAlreadyExists) Error() string {
-	return fmt.Sprintf("Host already exists: %q", e.Name)
+	return fmt.Sprintf("Docker machine %q already exists", e.Name)
 }
 
 type ErrDuringPreCreate struct {


### PR DESCRIPTION
### What's changed

- Modified error message outputs for `docker-machine` actions that result in `host does not exist` and `host already exists` to be a little more user-friendly 

### Related

- Partially fixes an issue logged on the Docs repo as [#4379](https://github.com/docker/docker.github.io/issues/4379)

### Reviewers

@shin- please take a look, and if you don't like this you can just close the PR. We got some feedback on confusing error messages in [#4379](https://github.com/docker/docker.github.io/issues/4379). This slight change may help somewhat, and I can also see what else can do in the docs.

@johndmulhausen @mstanleyjones 

Signed-off-by: Victoria Bialas <victoria.bialas@docker.com>