### PR TITLE
Fixes incorrect parsing of ISO version number.

### DIFF
--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -307,14 +307,16 @@ func (b *b2dISO) version() (string, error) {
 
 	fullVersion := string(isoMetadata)
 
-	versionIndex := strings.Index(fullVersion, versionPrefix)
+	trimmedVersion := strings.TrimSpace( fullVersion )
+
+	versionIndex := strings.Index(trimmedVersion, versionPrefix)
 	if versionIndex == -1 {
 		return "", fmt.Errorf("Did not find prefix %q in version string", versionPrefix)
 	}
 
 	// Original magic file string looks similar to this: "Boot2Docker-v0.1.0              "
 	// This will return "v0.1.0" given the above string
-	vers := strings.TrimSpace(fullVersion)[versionIndex+1:]
+	vers := trimmedVersion[versionIndex+1:]
 
 	log.Debug("local Boot2Docker ISO version: ", vers)
 	return vers, nil

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Version = "0.12.2"
+	Version = "dev"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Version = "dev"
+	Version = "0.12.2"
 
 	// GitCommit will be overwritten automatically by the build system
 	GitCommit = "HEAD"


### PR DESCRIPTION
It appears the full version contained within the ISO file may start with spaces.
As such, it must be trimmed before version number starting index is determined, else the version number won't be correctly extracted (and hence the ISO file will be downloaded each time as a version mismatch will always be detected). 