### PR TITLE
Azure driver: Fix issue #3976

### DIFF
--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -460,6 +460,22 @@ func (a AzureClient) removeOSDiskBlob(resourceGroup, vmName, vhdURL string) erro
 	if err != nil {
 		log.Debugf("Container remove happened: %v", ok)
 	}
+
+	cts, err := bs.GetBlobService().ListContainers(blobstorage.ListContainersParameters{})
+	if err != nil {
+		return err
+	}
+
+	if len(cts.Containers) == 0 {
+		log.Debugf("No storage containers left. Deleting virtual machine storage account.")
+		resp, err := a.storageAccountsClient().Delete(resourceGroup, storageAccount)
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("Storage account deletion happened: %v", resp.Response.Status)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
This PR will fix #3976

## Why
The current driver behavior does not delete the empty storage accounts. This will mess up your Microsoft Azure cloud resource group, like I wrote it as comment on the referenced issue. The current behavior will produce the following result if you, like we do, use for example Gitlab autoscaling runners.
![screenshot](https://user-images.githubusercontent.com/9364572/30175057-8183f076-93fd-11e7-9512-4a3cf254840e.png)

## What I've done
I added a functionality which checks, if there are storage blobs left over in the associated storage account of the virtual machine, after the virtual machine is deleted. If there are no container items left in the storage account, this PR will delete the corresponding storage account.

## How it is done
I modified the removeOSDiskBlob method and used the already existing client methods to retrieve a list of the containers associated with the storage account. If the retrieved list is empty, after the deletion of the virtual machine, the PR deletes the storage account too with the appropriate methods.

## Result
No more dangling storage accounts.