### PR TITLE
Exclude x.x.x.0 addresses in getRandomIPinSubnet

### DIFF
--- a/drivers/virtualbox/misc.go
+++ b/drivers/virtualbox/misc.go
@@ -81,13 +81,19 @@ type RandomInter interface {
 }
 
 func NewRandomInter() RandomInter {
-	return &defaultRandomInter{}
+	src := rand.NewSource(time.Now().UnixNano())
+
+	return &defaultRandomInter{
+		rand: rand.New(src),
+	}
 }
 
-type defaultRandomInter struct{}
+type defaultRandomInter struct {
+	rand *rand.Rand
+}
 
 func (d *defaultRandomInter) RandomInt(n int) int {
-	return rand.Intn(n)
+	return d.rand.Intn(n)
 }
 
 // Sleeper sleeps for given duration.

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -991,7 +991,7 @@ func getRandomIPinSubnet(d *Driver, baseIP net.IP) (net.IP, error) {
 	// select pseudo-random DHCP addr; make sure not to clash with the host
 	// only try 5 times and bail if no random received
 	for i := 0; i < 5; i++ {
-		n := d.randomInter.RandomInt(25)
+		n := d.randomInter.RandomInt(24) + 1
 		if byte(n) != nAddr[3] {
 			dhcpAddr = net.IPv4(nAddr[0], nAddr[1], nAddr[2], byte(n))
 			break

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -454,7 +454,7 @@ func (v *MockCreateOperations) Wait(d *Driver) error {
 }
 
 func (v *MockCreateOperations) RandomInt(n int) int {
-	return 6
+	return 5
 }
 
 func (v *MockCreateOperations) Sleep(d time.Duration) {


### PR DESCRIPTION
Also improves defaultRandInter entropy

Fixes #4247 