### PR TITLE
use proxy vars if set for build

### DIFF
--- a/script/build_in_container.sh
+++ b/script/build_in_container.sh
@@ -4,12 +4,25 @@ set -e
 
 DOCKER_IMAGE_NAME="docker-machine-build"
 DOCKER_CONTAINER_NAME="docker-machine-build-container"
+DOCKER_BUILD_ARGS=${DOCKER_BUILD_ARGS:-""}
 
 if [[ $(docker ps -a | grep $DOCKER_CONTAINER_NAME) != "" ]]; then
   docker rm -f $DOCKER_CONTAINER_NAME 2>/dev/null
 fi
 
-docker build -t $DOCKER_IMAGE_NAME .
+if [[  ${http_proxy:+x} ]]; then
+   DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg http_proxy"
+fi
+
+if [[  ${https_proxy:+x} ]]; then
+   DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg https_proxy"
+fi
+
+if [[  ${no_proxy:+x} ]]; then
+   DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS} --build-arg no_proxy"
+fi
+
+docker build ${DOCKER_BUILD_ARGS} -t $DOCKER_IMAGE_NAME .
 
 docker run --name $DOCKER_CONTAINER_NAME \
   -e DEBUG \


### PR DESCRIPTION
Use any http_proxy variables that are set for the image build when building in a container
Signed-off-by: Garth Bushell <garth@garthy.com>