### PR TITLE
Fix issue with localized groups

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -85,7 +85,7 @@ func isAdministrator() (bool, error) {
 }
 
 func isHypervAdministrator() bool {
-	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("Hyper-V Administrators")`)
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("S-1-5-32-578")`)
 	if err != nil {
 		log.Debug(err)
 		return false


### PR DESCRIPTION
Fixes:  #4282

See https://github.com/minishift/minishift/issues/1541

Doing:
```
([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole('Hyper-V Administrators')
```
 will return False on a localized version of Windows. Eg. on a `pt_br` vesion of Windows the test needs to be:
 
```
([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole('Administradores do Hyper-V')
```

According to MSDN, the best way to solve this is to use a security identifier needs to be used:

_Relative identifiers (RIDs) are components of a Windows user group's security identifier (SID) and are supported to help prevent cross-platform localization issues. Many user accounts, local groups, and global groups have a default RID value that is constant across all versions of Windows._

_For example, the RID for the BUILTIN\Administrators role is 0x220. Using 0x220 as the input parameter for the IsInRole method results in true being returned if the current principal is an administrator._

Ref: https://msdn.microsoft.com/en-us/library/86wd8zba(v=vs.110).aspx

According to:
https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems the following `S-1-5-32-578` will work:

```
([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole('
S-1-5-32-578')
```
