### PR TITLE
Initial support for building on OpenBSD

### DIFF
--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -171,7 +172,13 @@ func TestGetScpCmdWithDelta(t *testing.T) {
 		"/tmp/foo",
 		"user@1.2.3.4:/home/docker/foo",
 	)
-	expectedCmd := exec.Command("/usr/local/bin/rsync", expectedArgs...)
+
+	var expectedCmd *exec.Cmd
+	if runtime.GOOS == "openbsd" {
+		expectedCmd = exec.Command("/usr/local/bin/rsync", expectedArgs...)
+	} else {
+		expectedCmd = exec.Command("/usr/bin/rsync", expectedArgs...)
+	}
 
 	assert.Equal(t, expectedCmd, cmd)
 	assert.NoError(t, err)

--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -171,7 +171,7 @@ func TestGetScpCmdWithDelta(t *testing.T) {
 		"/tmp/foo",
 		"user@1.2.3.4:/home/docker/foo",
 	)
-	expectedCmd := exec.Command("/usr/bin/rsync", expectedArgs...)
+	expectedCmd := exec.Command("/usr/local/bin/rsync", expectedArgs...)
 
 	assert.Equal(t, expectedCmd, cmd)
 	assert.NoError(t, err)

--- a/drivers/virtualbox/disk_test.go
+++ b/drivers/virtualbox/disk_test.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/ip.go
+++ b/drivers/virtualbox/ip.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/network_test.go
+++ b/drivers/virtualbox/network_test.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/virtualbox_openbsd.go
+++ b/drivers/virtualbox/virtualbox_openbsd.go
@@ -1,0 +1,11 @@
+package virtualbox
+
+import "github.com/docker/machine/libmachine/drivers"
+
+func detectVBoxManageCmd() string {
+	return ""
+}
+
+func NewDriver(hostName, storePath string) drivers.Driver {
+	return drivers.NewDriverNotSupported("virtualbox", hostName, storePath)
+}

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/vm_test.go
+++ b/drivers/virtualbox/vm_test.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/drivers/virtualbox/vtx.go
+++ b/drivers/virtualbox/vtx.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import "strings"

--- a/drivers/virtualbox/vtx_test.go
+++ b/drivers/virtualbox/vtx_test.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package virtualbox
 
 import (

--- a/libmachine/crashreport/os_openbsd.go
+++ b/libmachine/crashreport/os_openbsd.go
@@ -1,0 +1,12 @@
+package crashreport
+
+import "os/exec"
+
+func localOSVersion() string {
+	command := exec.Command("uname", "-r")
+	output, err := command.Output()
+	if err != nil {
+		return ""
+	}
+	return string(output)
+}

--- a/libmachine/examples/main.go
+++ b/libmachine/examples/main.go
@@ -1,3 +1,5 @@
+// +build !openbsd
+
 package main
 
 import (

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -2,8 +2,15 @@
 GO_LDFLAGS := -X `go list ./version`.GitCommit=`git rev-parse --short HEAD 2>/dev/null`
 GO_GCFLAGS :=
 
+# Honor verbose
+VERBOSE_GO := 
+GO := go
+ifeq ($(VERBOSE),true)
+	VERBOSE_GO := -v
+endif
+
 # Full package list
-PKGS := $(shell go list -tags "$(BUILDTAGS)" ./... | grep -v "/vendor/" | grep -v "/cmd")
+PKGS := $(shell $(GO) list -tags "$(BUILDTAGS)" ./... | grep -v "/vendor/" | grep -v "/cmd")
 
 # Resolving binary dependencies for specific targets
 GOLINT_BIN := $(GOPATH)/bin/golint
@@ -25,13 +32,6 @@ endif
 ifeq ($(STATIC),true)
 	# Append to the version
 	GO_LDFLAGS := $(GO_LDFLAGS) -extldflags -static
-endif
-
-# Honor verbose
-VERBOSE_GO := 
-GO := go
-ifeq ($(VERBOSE),true)
-	VERBOSE_GO := -v
 endif
 
 include mk/build.mk

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -12,7 +12,7 @@ fmt:
 	@test -z "$$(gofmt -s -l . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 
 vet:
-	@test -z "$$(go vet $(PKGS) 2>&1 | tee /dev/stderr)"
+	@test -z "$$($(GO) vet $(PKGS) 2>&1 | tee /dev/stderr)"
 
 lint:
 	$(if $(GOLINT), , \

--- a/vendor/github.com/docker/docker/pkg/term/termios_openbsd.go
+++ b/vendor/github.com/docker/docker/pkg/term/termios_openbsd.go
@@ -1,0 +1,65 @@
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	getTermios = syscall.TIOCGETA
+	setTermios = syscall.TIOCSETA
+
+	IGNBRK = syscall.IGNBRK
+	PARMRK = syscall.PARMRK
+	INLCR  = syscall.INLCR
+	IGNCR  = syscall.IGNCR
+	ECHONL = syscall.ECHONL
+	CSIZE  = syscall.CSIZE
+	ICRNL  = syscall.ICRNL
+	ISTRIP = syscall.ISTRIP
+	PARENB = syscall.PARENB
+	ECHO   = syscall.ECHO
+	ICANON = syscall.ICANON
+	ISIG   = syscall.ISIG
+	IXON   = syscall.IXON
+	BRKINT = syscall.BRKINT
+	INPCK  = syscall.INPCK
+	OPOST  = syscall.OPOST
+	CS8    = syscall.CS8
+	IEXTEN = syscall.IEXTEN
+)
+
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]byte
+	Ispeed uint32
+	Ospeed uint32
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= (IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
+	newState.Oflag &^= OPOST
+	newState.Lflag &^= (ECHO | ECHONL | ICANON | ISIG | IEXTEN)
+	newState.Cflag &^= (CSIZE | PARENB)
+	newState.Cflag |= CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
+
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}


### PR DESCRIPTION
This is an attempt to add support for building on OpenBSD. I've been able to use it with a locally patched and built Docker [cli](https://github.com/voutilad/cli) to control a locally running Ubuntu 17.04 VM under [vmm](http://man.openbsd.org/vmm) using the generic driver.

The majority of the tweaks are to deal with the fact that there's no VirtualBox for OpenBSD. Unfortunately, a lot of the VirtualBox code needs to be disabled in a similar fashion to VMWare Fusion.

Let me be the first to admit it looks really silly having a lot of `// +build !openbsd` comments added to the VirtualBox driver code. I'm not very experienced with Go, so hopefully there's a better way that's not nearly as silly looking.

Also: `make validate` _does_ fail currently due to an apparent lack of support for `go test -race` on OpenBSD's Go package.