### PR TITLE
Add usage of ss to check Docker Engine listening port when netstat is not available

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -255,7 +255,7 @@ func checkDaemonUp(p Provisioner, dockerPort int) func() bool {
 	reDaemonListening := fmt.Sprintf(":%d\\s+.*:.*", dockerPort)
 	return func() bool {
 		// HACK: Check netstat's output to see if anyone's listening on the Docker API port.
-		netstatOut, err := p.SSHCommand("netstat -tln")
+		netstatOut, err := p.SSHCommand("if ! type netstat 1>/dev/null; then ss -tln; else netstat -tln; fi")
 		if err != nil {
 			log.Warnf("Error running SSH command: %s", err)
 			return false

--- a/libmachine/provision/utils_test.go
+++ b/libmachine/provision/utils_test.go
@@ -43,6 +43,26 @@ tcp6       0      0 :::22                   :::*                    LISTEN`
 	}
 }
 
+func TestMatchSsOutMissing(t *testing.T) {
+	ssOut := `State      Recv-Q Send-Q Local Address:Port               Peer Address:Port              
+LISTEN     0      128          *:22                       *:*                  
+LISTEN     0      128         :::22                      :::*                  
+LISTEN     0      128         :::23760                   :::*                  `
+	if matchNetstatOut(reDaemonListening, ssOut) {
+		t.Fatal("Expected not to match the ss output as showing the daemon listening but got a match")
+	}
+}
+
+func TestMatchSsOutPresent(t *testing.T) {
+	ssOut := `State      Recv-Q Send-Q Local Address:Port               Peer Address:Port              
+LISTEN     0      128          *:22                       *:*                  
+LISTEN     0      128         :::22                      :::*                  
+LISTEN     0      128         :::2376                    :::*                  `
+	if !matchNetstatOut(reDaemonListening, ssOut) {
+		t.Fatal("Expected to match the ss output as showing the daemon listening but didn't")
+	}
+}
+
 func TestGenerateDockerOptionsBoot2Docker(t *testing.T) {
 	p := &Boot2DockerProvisioner{
 		Driver: &fakedriver.Driver{},


### PR DESCRIPTION
Hello,
This PR add the usage of the `ss` tool to check the Docker Engine listening port when `netstat` is unavailable. The package `net-tools` including `netstat` is deprecated and no longer installed by default in some distributions like [CentOS 7](https://bugzilla.redhat.com/show_bug.cgi?id=1119297) and [Debian 9](https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#iproute2).