### PR TITLE
exoscale: fix a typo in the env variable name

### DIFF
--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -74,7 +74,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "exoscale disk size (10, 50, 100, 200, 400)",
 		},
 		mcnflag.StringFlag{
-			EnvVar: "EXSOCALE_IMAGE",
+			EnvVar: "EXOSCALE_IMAGE",
 			Name:   "exoscale-image",
 			Value:  defaultImage,
 			Usage:  "exoscale image template",


### PR DESCRIPTION
Signed-off-by: Yoan Blanc <yoan.blanc@exoscale.ch>