### PR TITLE
Use GitLab CI to build docker-machine

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,48 @@
+image: docker
+
+stages:
+- validate
+- build
+
+services:
+- docker:dind
+
+variables:
+  USE_CONTAINER: "true"
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_DRIVER: overlay
+
+before_script:
+- apk add -U make bash
+
+.build_base: &build_base
+  stage: build
+  before_script:
+  - apk add -U make bash
+  - export TARGET_OS=$(echo $CI_JOB_NAME | cut -d ' ' -f 1)
+  - export TARGET_ARCH=$(echo $CI_JOB_NAME | cut -d ' ' -f 2)
+  after_script:
+  - "[[ \"$(find bin -type f -name docker-machine*)\" != \"\" ]]"
+  artifacts:
+    paths:
+    - bin/
+    expire_in: 1 week
+  tags:
+  - docker
+  - privileged
+
+.build_validate: &build_validate
+  <<: *build_base
+  stage: validate
+  script: make build validate
+
+.build_x: &build_x
+  <<: *build_base
+  script: make build-x
+
+linux amd64: *build_validate
+darwin amd64: *build_x
+windows amd64: *build_x
+linux arm: *build_x
+linux arm64: *build_x
+


### PR DESCRIPTION
This MR adds a `.gitlab-ci.yml` file with configuration for GitLab CI. It's a very basic configuration that will allow user to build and test Linux/amd64 binary, and if this stage passes to build binaries for some other architectures.

Signed-off-by: Tomasz Maczukin <tomasz@maczukin.pl>