### PR TITLE
404 is a success when deleting GCE machine and disk

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -477,4 +478,17 @@ func unwrapGoogleError(err error) error {
 	}
 
 	return err
+}
+
+func isNotFound(err error) bool {
+	googleErr, ok := err.(*googleapi.Error)
+	if !ok {
+		return false
+	}
+
+	if googleErr.Code == http.StatusNotFound {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This MR refactors a little the `googleErr.Code == http.StatusNotFound` check and adds a `isNotFound` check for `c.deleteDisk()` operation.

As with `c.deleteInstance()`, disk deletion should not fail the API call when the disk is already removed (for any reason). In that case only a warning should be logged as it was already done for instance removing.

Signed-off-by: Tomasz Maczukin <tomasz@maczukin.pl>