### PR TITLE
Google Driver: Add support for fully qualified network and subnetwork names

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -235,6 +235,13 @@ func (c *ComputeUtil) instance() (*raw.Instance, error) {
 func (c *ComputeUtil) createInstance(d *Driver) error {
 	log.Infof("Creating instance")
 
+	var net string
+	if strings.Contains(d.Network, "/networks/") {
+		net = d.Network
+	} else {
+		net = c.globalURL + "/networks/" + d.Network
+	}
+
 	instance := &raw.Instance{
 		Name:        c.instanceName,
 		Description: "docker host vm",
@@ -249,7 +256,7 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		},
 		NetworkInterfaces: []*raw.NetworkInterface{
 			{
-				Network: c.globalURL + "/networks/" + d.Network,
+				Network: net,
 			},
 		},
 		Tags: &raw.Tags{
@@ -266,7 +273,9 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		},
 	}
 
-	if c.subnetwork != "" {
+	if strings.Contains(c.subnetwork, "/subnetworks/") {
+		instance.NetworkInterfaces[0].Subnetwork = c.subnetwork
+	} else if c.subnetwork != "" {
 		instance.NetworkInterfaces[0].Subnetwork = "projects/" + c.project + "/regions/" + c.region() + "/subnetworks/" + c.subnetwork
 	}
 


### PR DESCRIPTION
Fixes #4327 

Adds support for providing a network and subnetwork that are not from the same project that the instance will be created in.  This is used for Shared VPC networking.