### PR TITLE
Google Driver: Enable AutoDelete of Disks for GCE

### DIFF
--- a/drivers/google/compute_util.go
+++ b/drivers/google/compute_util.go
@@ -242,7 +242,7 @@ func (c *ComputeUtil) createInstance(d *Driver) error {
 		Disks: []*raw.AttachedDisk{
 			{
 				Boot:       true,
-				AutoDelete: false,
+				AutoDelete: true,
 				Type:       "PERSISTENT",
 				Mode:       "READ_WRITE",
 			},


### PR DESCRIPTION
This is how currently my disk listing looks like (this are gitlab-runners, started/managed with docker-machine and using Preemptible VMs)
![screen shot 2018-01-04 at 15 03 54](https://user-images.githubusercontent.com/350038/34566987-e318ce0e-f160-11e7-8df7-9a4cb2031163.png)
Note that most disks are there, but not attached to any VM.
The related VMs are gone.

This means disks are not reliably deleted. For example when using together with Preemptible VMs. It can happen that the Disk stays forever.

This Pull request enables the auto-delete feature for disks.
https://cloud.google.com/sdk/gcloud/reference/compute/instances/set-disk-auto-delete
The documentation states that this is a feature which is enabled by default usually.