### PR TITLE
Fixes #3246 - openstack: add option for enabling configuration drive

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -68,6 +68,7 @@ func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 		UserData:         d.UserData,
 		SecurityGroups:   d.SecurityGroups,
 		AvailabilityZone: d.AvailabilityZone,
+		ConfigDrive:      d.ConfigDrive,
 	}
 	if d.NetworkId != "" {
 		serverOpts.Networks = []servers.Network{

--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -45,6 +45,7 @@ type Driver struct {
 	ComputeNetwork   bool
 	FloatingIpPoolId string
 	IpVersion        int
+	ConfigDrive      bool
 	client           Client
 }
 
@@ -222,6 +223,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "OpenStack active timeout",
 			Value:  defaultActiveTimeout,
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "OS_CONFIG_DRIVE",
+			Name:   "openstack-config-drive",
+			Usage:  "Enables the OpenStack config drive for the instance",
+		},
 	}
 }
 
@@ -285,6 +291,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPort = flags.Int("openstack-ssh-port")
 	d.KeyPairName = flags.String("openstack-keypair-name")
 	d.PrivateKeyFile = flags.String("openstack-private-key-file")
+	d.ConfigDrive = flags.Bool("openstack-config-drive")
 
 	if flags.String("openstack-user-data-file") != "" {
 		userData, err := ioutil.ReadFile(flags.String("openstack-user-data-file"))


### PR DESCRIPTION
This PR fixes #3246 by adding a new bool flag command line option to turn on the configuration drive when launching openstack instances.

This is required to use the Rancher-provided RancherOS openstack images with docker-machine per http://rancher.com/docs/os/v1.1/en/running-rancheros/cloud/openstack/.

> Openstack
> As of v0.5.0, RancherOS releases include an Openstack image that can be found on our releases page. The image format is QCOW2.
> 
> When launching an instance using the image, you must enable Advanced Options -> Configuration Drive and in order to use a cloud-config file.