### PR TITLE
Update the default DigitalOcean droplet size

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -43,7 +43,7 @@ const (
 	defaultSSHUser = "root"
 	defaultImage   = "ubuntu-16-04-x64"
 	defaultRegion  = "nyc3"
-	defaultSize    = "512mb"
+	defaultSize    = "s-1vcpu-1gb"
 )
 
 // GetCreateFlags registers the flags this driver adds to

--- a/vendor/github.com/digitalocean/godo/README.md
+++ b/vendor/github.com/digitalocean/godo/README.md
@@ -59,7 +59,7 @@ dropletName := "super-cool-droplet"
 createRequest := &godo.DropletCreateRequest{
     Name:   dropletName,
     Region: "nyc3",
-    Size:   "512mb",
+    Size:   "s-1vcpu-1gb",
     Image: godo.DropletCreateImage{
         Slug: "ubuntu-14-04-x64",
     },


### PR DESCRIPTION
**DigitalOcean updated their plans** 🎉 

[Here](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/?utm_medium=email&utm_source=local&utm_campaign=NewDroplets2018) is the list of the new size slug.

![standard plans table](https://user-images.githubusercontent.com/4728325/35543326-83473c8c-0532-11e8-846d-fae8415037f7.png)
