### PR TITLE
Add monitoring flag for Digital Ocean droplets

### DIFF
--- a/drivers/digitalocean/digitalocean.go
+++ b/drivers/digitalocean/digitalocean.go
@@ -35,6 +35,7 @@ type Driver struct {
 	Backups           bool
 	PrivateNetworking bool
 	UserDataFile      string
+	Monitoring        bool
 	Tags              string
 }
 
@@ -115,6 +116,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "digitalocean-userdata",
 			Usage:  "path to file with cloud-init user-data",
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "DIGITALOCEAN_MONITORING",
+			Name:   "digitalocean-monitoring",
+			Usage:  "enable monitoring for droplet",
+		},
 		mcnflag.StringFlag{
 			EnvVar: "DIGITALOCEAN_TAGS",
 			Name:   "digitalocean-tags",
@@ -157,6 +163,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPort = flags.Int("digitalocean-ssh-port")
 	d.SSHKeyFingerprint = flags.String("digitalocean-ssh-key-fingerprint")
 	d.SSHKey = flags.String("digitalocean-ssh-key-path")
+	d.Monitoring = flags.Bool("digitalocean-monitoring")
 	d.Tags = flags.String("digitalocean-tags")
 
 	d.SetSwarmConfigFromFlags(flags)
@@ -232,6 +239,7 @@ func (d *Driver) Create() error {
 		Backups:           d.Backups,
 		UserData:          userdata,
 		SSHKeys:           []godo.DropletCreateSSHKey{{ID: d.SSHKeyID}},
+		Monitoring:        d.Monitoring,
 		Tags:              d.getTags(),
 	}
 


### PR DESCRIPTION
Digital Ocean now has the functionality for more extensive monitoring of droplets, which includes the ability to set alerts for droplets. These new features only work if a monitoring script is run on the droplet upon startup, fortunately the Digital Ocean API allows for a flag to be passed through (similar to how `private networking` is switched on) that pre-installs the monitoring script allowing the more in-depth monitoring. I have simply added this flag to `docker-machine`.

**Testing:**
1. Manually tested the updated help text

Using:
```
./docker-machine create --driver digitalocean --help
```

Output:
```
...
   --digitalocean-ipv6								enable ipv6 for droplet [$DIGITALOCEAN_IPV6]
   --digitalocean-monitoring							enable monitoring for droplet [$DIGITALOCEAN_MONITORING]
   --digitalocean-private-networking						enable private networking for droplet [$DIGITALOCEAN_PRIVATE_NETWORKING]
...
```

2. Manually created a droplet using the flag and verified the monitoring script was detected in the Digital Ocean UI

Using (in ./bin/):
```
./docker-machine create --driver digitalocean --digitalocean-access-token xxxxx --digitalocean-private-networking=true --digitalocean-monitoring=true docker-sandbox
```

Fixes: #4227 

Signed-off-by: Steven Cooney <dev@stevenjamescooney.com>