### PR TITLE
Fix argument escaping for scp on Windows

### DIFF
--- a/commands/scp.go
+++ b/commands/scp.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/docker/machine/libmachine"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/persist"
 )
@@ -52,26 +51,6 @@ func (s *storeHostInfoLoader) load(name string) (HostInfo, error) {
 	}
 
 	return host.Driver, nil
-}
-
-func cmdScp(c CommandLine, api libmachine.API) error {
-	args := c.Args()
-	if len(args) != 2 {
-		c.ShowHelp()
-		return errWrongNumberArguments
-	}
-
-	src := args[0]
-	dest := args[1]
-
-	hostInfoLoader := &storeHostInfoLoader{api}
-
-	cmd, err := getScpCmd(src, dest, c.Bool("recursive"), c.Bool("delta"), c.Bool("quiet"), hostInfoLoader)
-	if err != nil {
-		return err
-	}
-
-	return runCmdWithStdIo(*cmd)
 }
 
 func getScpCmd(src, dest string, recursive bool, delta bool, quiet bool, hostInfoLoader HostInfoLoader) (*exec.Cmd, error) {

--- a/commands/scp_unix.go
+++ b/commands/scp_unix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+package commands
+
+import (
+	"github.com/docker/machine/libmachine"
+)
+
+func cmdScp(c CommandLine, api libmachine.API) error {
+	args := c.Args()
+	if len(args) != 2 {
+		c.ShowHelp()
+		return errWrongNumberArguments
+	}
+
+	src := args[0]
+	dest := args[1]
+
+	hostInfoLoader := &storeHostInfoLoader{api}
+
+	cmd, err := getScpCmd(src, dest, c.Bool("recursive"), c.Bool("delta"), c.Bool("quiet"), hostInfoLoader)
+	if err != nil {
+		return err
+	}
+
+	return runCmdWithStdIo(*cmd)
+}

--- a/commands/scp_windows.go
+++ b/commands/scp_windows.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+
+	"github.com/docker/machine/libmachine"
+)
+
+func cmdScp(c CommandLine, api libmachine.API) error {
+	args := c.Args()
+	if len(args) != 2 {
+		c.ShowHelp()
+		return errWrongNumberArguments
+	}
+
+	src := args[0]
+	dest := args[1]
+
+	hostInfoLoader := &storeHostInfoLoader{api}
+
+	cmd, err := getScpCmd(src, dest, c.Bool("recursive"), c.Bool("delta"), c.Bool("quiet"), hostInfoLoader)
+	if err != nil {
+		return err
+	}
+
+	// Default argument escaping is not valid for scp.exe with quoted arguments, so we do it ourselves
+	// see golang/go#15566
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.CmdLine = fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+
+	return runCmdWithStdIo(*cmd)
+}


### PR DESCRIPTION
This seemed to work when I tested it on Windows. Sources:
- https://github.com/golang/go/issues/15566
- https://stackoverflow.com/questions/28954729/exec-with-double-quoted-argument

Fixes #4302 

cc @dgageot 