### PR TITLE
Add support for new options added in v0.14.0 to bash completion

### DIFF
--- a/contrib/completion/bash/docker-machine.bash
+++ b/contrib/completion/bash/docker-machine.bash
@@ -267,7 +267,7 @@ _docker_machine_provision() {
 
 _docker_machine_regenerate_certs() {
     if [[ "${cur}" == -* ]]; then
-        COMPREPLY=($(compgen -W "--force -f --help" -- "${cur}"))
+        COMPREPLY=($(compgen -W "--client-certs --force -f --help" -- "${cur}"))
     else
         COMPREPLY=($(compgen -W "$(_docker_machine_machines --filter state=Running)" -- "${cur}"))
     fi
@@ -299,7 +299,7 @@ _docker_machine_ssh() {
 
 _docker_machine_scp() {
     if [[ "${cur}" == -* ]]; then
-        COMPREPLY=($(compgen -W "--delta -d --help --recursive -r" -- "${cur}"))
+        COMPREPLY=($(compgen -W "--delta -d --help --quiet -q --recursive -r" -- "${cur}"))
     else
         _filedir
         # It would be really nice to ssh to the machine and ls to complete


### PR DESCRIPTION
New features according to the [release notes](https://github.com/docker/machine/releases/tag/v0.14.0-rc1):
- Added `--client-certs` flag to the docker-machine `regenerate-certs` command.
- Added `--quiet` flag to `scp` to suppress progress output