### PR TITLE
Check NotAfter date on certs and recreate if necessary

### DIFF
--- a/libmachine/cert/bootstrap.go
+++ b/libmachine/cert/bootstrap.go
@@ -10,12 +10,73 @@ import (
 	"github.com/docker/machine/libmachine/mcnutils"
 )
 
-func BootstrapCertificates(authOptions *auth.Options) error {
+func createCACert(authOptions *auth.Options, caOrg string, bits int) error {
+	caCertPath := authOptions.CaCertPath
+	caPrivateKeyPath := authOptions.CaPrivateKeyPath
+
+	log.Infof("Creating CA: %s", caCertPath)
+
+	// check if the key path exists; if so, error
+	if _, err := os.Stat(caPrivateKeyPath); err == nil {
+		return errors.New("certificate authority key already exists")
+	}
+
+	if err := GenerateCACertificate(caCertPath, caPrivateKeyPath, caOrg, bits); err != nil {
+		return fmt.Errorf("generating CA certificate failed: %s", err)
+	}
+
+	return nil
+}
+
+func createCert(authOptions *auth.Options, org string, bits int) error {
 	certDir := authOptions.CertDir
 	caCertPath := authOptions.CaCertPath
 	caPrivateKeyPath := authOptions.CaPrivateKeyPath
 	clientCertPath := authOptions.ClientCertPath
 	clientKeyPath := authOptions.ClientKeyPath
+
+	log.Infof("Creating client certificate: %s", clientCertPath)
+
+	if _, err := os.Stat(certDir); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(certDir, 0700); err != nil {
+				return fmt.Errorf("failure creating machine client cert dir: %s", err)
+			}
+		} else {
+			return err
+		}
+	}
+
+	// check if the key path exists; if so, error
+	if _, err := os.Stat(clientKeyPath); err == nil {
+		return errors.New("client key already exists")
+	}
+
+	// Used to generate the client certificate.
+	certOptions := &Options{
+		Hosts:       []string{""},
+		CertFile:    clientCertPath,
+		KeyFile:     clientKeyPath,
+		CAFile:      caCertPath,
+		CAKeyFile:   caPrivateKeyPath,
+		Org:         org,
+		Bits:        bits,
+		SwarmMaster: false,
+	}
+
+	if err := GenerateCert(certOptions); err != nil {
+		return fmt.Errorf("failure generating client certificate: %s", err)
+	}
+
+	return nil
+}
+
+func BootstrapCertificates(authOptions *auth.Options) error {
+	certDir := authOptions.CertDir
+	caCertPath := authOptions.CaCertPath
+	clientCertPath := authOptions.ClientCertPath
+	clientKeyPath := authOptions.ClientKeyPath
+	caPrivateKeyPath := authOptions.CaPrivateKeyPath
 
 	// TODO: I'm not super happy about this use of "org", the user should
 	// have to specify it explicitly instead of implicitly basing it on
@@ -28,7 +89,7 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 	if _, err := os.Stat(certDir); err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(certDir, 0700); err != nil {
-				return fmt.Errorf("Creating machine certificate dir failed: %s", err)
+				return fmt.Errorf("creating machine certificate dir failed: %s", err)
 			}
 		} else {
 			return err
@@ -36,50 +97,38 @@ func BootstrapCertificates(authOptions *auth.Options) error {
 	}
 
 	if _, err := os.Stat(caCertPath); os.IsNotExist(err) {
-		log.Infof("Creating CA: %s", caCertPath)
-
-		// check if the key path exists; if so, error
-		if _, err := os.Stat(caPrivateKeyPath); err == nil {
-			return errors.New("certificate authority key already exists")
+		if err := createCACert(authOptions, caOrg, bits); err != nil {
+			return err
 		}
-
-		if err := GenerateCACertificate(caCertPath, caPrivateKeyPath, caOrg, bits); err != nil {
-			return fmt.Errorf("Generating CA certificate failed: %s", err)
+	} else {
+		current, err := CheckCertificateDate(caCertPath)
+		if err != nil {
+			return err
+		}
+		if !current {
+			log.Info("CA certificate is outdated and needs to be regenerated")
+			os.Remove(caPrivateKeyPath)
+			if err := createCACert(authOptions, caOrg, bits); err != nil {
+				return err
+			}
 		}
 	}
 
 	if _, err := os.Stat(clientCertPath); os.IsNotExist(err) {
-		log.Infof("Creating client certificate: %s", clientCertPath)
-
-		if _, err := os.Stat(certDir); err != nil {
-			if os.IsNotExist(err) {
-				if err := os.Mkdir(certDir, 0700); err != nil {
-					return fmt.Errorf("failure creating machine client cert dir: %s", err)
-				}
-			} else {
+		if err := createCert(authOptions, org, bits); err != nil {
+			return err
+		}
+	} else {
+		current, err := CheckCertificateDate(clientCertPath)
+		if err != nil {
+			return err
+		}
+		if !current {
+			log.Info("Client certificate is outdated and needs to be regenerated")
+			os.Remove(clientKeyPath)
+			if err := createCert(authOptions, org, bits); err != nil {
 				return err
 			}
-		}
-
-		// check if the key path exists; if so, error
-		if _, err := os.Stat(clientKeyPath); err == nil {
-			return errors.New("client key already exists")
-		}
-
-		// Used to generate the client certificate.
-		certOptions := &Options{
-			Hosts:       []string{""},
-			CertFile:    clientCertPath,
-			KeyFile:     clientKeyPath,
-			CAFile:      caCertPath,
-			CAKeyFile:   caPrivateKeyPath,
-			Org:         org,
-			Bits:        bits,
-			SwarmMaster: false,
-		}
-
-		if err := GenerateCert(certOptions); err != nil {
-			return fmt.Errorf("failure generating client certificate: %s", err)
 		}
 	}
 

--- a/libmachine/cert/cert.go
+++ b/libmachine/cert/cert.go
@@ -267,3 +267,28 @@ func (xcg *X509CertGenerator) ValidateCertificate(addr string, authOptions *auth
 
 	return true, nil
 }
+
+func CheckCertificateDate(certPath string) (bool, error) {
+	log.Debugf("Reading certificate data from %s", certPath)
+	certBytes, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return false, err
+	}
+
+	log.Debug("Decoding PEM data...")
+	pemBlock, _ := pem.Decode(certBytes)
+	if pemBlock == nil {
+		return false, errors.New("Failed to decode PEM data")
+	}
+
+	log.Debug("Parsing certificate...")
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		return false, err
+	}
+	if time.Now().After(cert.NotAfter) {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
Follow-up to #4401 that no longer requires users to manually remove existing certificates.