### PR TITLE
EC2: Update AMIs to mitigate Meltdown and Spectre

### DIFF
--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -8,26 +8,27 @@ type region struct {
 	AmiId string
 }
 
-// Ubuntu 16.04 LTS 20170619.1 hvm:ebs-ssd (amd64)
+// Ubuntu 16.04 LTS 20180228.1 hvm:ebs-ssd (amd64)
 // See https://cloud-images.ubuntu.com/locator/ec2/
 var regionDetails map[string]*region = map[string]*region{
-	"ap-northeast-1":  {"ami-785c491f"},
-	"ap-northeast-2":  {"ami-94d20dfa"},
-	"ap-southeast-1":  {"ami-2378f540"},
-	"ap-southeast-2":  {"ami-e94e5e8a"},
-	"ap-south-1":      {"ami-49e59a26"},
-	"ca-central-1":    {"ami-7ed56a1a"},
-	"cn-north-1":      {"ami-a163b4cc"}, // Note: this is 20170303
-	"eu-central-1":    {"ami-1c45e273"},
-	"eu-west-1":       {"ami-6d48500b"},
-	"eu-west-2":       {"ami-cc7066a8"},
-	"eu-west-3":       {"ami-c1cf79bc"}, // Note: this is 20180126
-	"sa-east-1":       {"ami-34afc458"},
-	"us-east-1":       {"ami-d15a75c7"},
-	"us-east-2":       {"ami-8b92b4ee"},
-	"us-west-1":       {"ami-73f7da13"},
-	"us-west-2":       {"ami-835b4efa"},
-	"us-gov-west-1":   {"ami-939412f2"},
+	"ap-northeast-1":  {"ami-bcb7f6da"},
+	"ap-northeast-2":  {"ami-5073de3e"},
+	"ap-southeast-1":  {"ami-41e4af3d"},
+	"ap-southeast-2":  {"ami-c1498fa3"},
+	"ap-south-1":      {"ami-1083dc7f"},
+	"ca-central-1":    {"ami-8d9e19e9"},
+	"cn-north-1":      {"ami-cc4499a1"}, // Note: this is 20180126
+	"cn-northwest-1":  {"ami-fd0e1a9f"}, // Note: this is 20180126
+	"eu-central-1":    {"ami-bc4925d3"},
+	"eu-west-1":       {"ami-0b541372"},
+	"eu-west-2":       {"ami-ff46a298"},
+	"eu-west-3":       {"ami-9465d3e9"},
+	"sa-east-1":       {"ami-b5501bd9"},
+	"us-east-1":       {"ami-927185ef"},
+	"us-east-2":       {"ami-b9daeddc"},
+	"us-west-1":       {"ami-264c4646"},
+	"us-west-2":       {"ami-78a22900"},
+	"us-gov-west-1":   {"ami-2561ea44"},
 	"custom-endpoint": {""},
 }
 


### PR DESCRIPTION
Also add the cn-northwest-1 region.

Verified Meltdown/Spectre (v1 and v2) mitigations using [speed47/spectre-meltdown-checker](https://github.com/speed47/spectre-meltdown-checker) in `eu-west-1` for the `20180228.1` AMIs.

Note: The latest AMIs for China are from January, so they most certainly
don't have all Meltdown/Spectre mitigations. I don't have access to a
China AWS account, so I can't check.
