### PR TITLE
Add OpenBSD/amd64 crossbuild to CI scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,8 +40,9 @@ before_script:
   <<: *build_base
   script: make build-x
 
-linux amd64: *build_validate
 darwin amd64: *build_x
+linux amd64: *build_validate
+openbsd amd64: *build_x
 windows amd64: *build_x
 linux arm: *build_x
 linux arm64: *build_x

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: bash
 services: docker
 env:
   matrix:
-    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="build validate"
     - TARGET_OS=darwin TARGET_ARCH=amd64 TARGETS="build-x"
+    - TARGET_OS=linux TARGET_ARCH=amd64 TARGETS="build validate"
+    - TARGET_OS=openbsd TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=windows TARGET_ARCH=amd64 TARGETS="build-x"
     - TARGET_OS=linux TARGET_ARCH=arm TARGETS="build-x"
     - TARGET_OS=linux TARGET_ARCH=arm64 TARGETS="build-x"

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,10 +1,11 @@
 extension = $(patsubst windows,.exe,$(filter windows,$(1)))
 
 # Valid target combinations
-VALID_OS_ARCH := "[darwin/amd64][linux/amd64][linux/arm][linux/arm64][windows/amd64][windows/386]"
+VALID_OS_ARCH := "[darwin/amd64][linux/amd64][linux/arm][linux/arm64][openbsd/amd64][windows/amd64][windows/386]"
 
 os.darwin := Darwin
 os.linux := Linux
+os.openbsd := OpenBSD
 os.windows := Windows
 
 arch.amd64 := x86_64


### PR DESCRIPTION
To exclude regressions in the future on this platform.