### PR TITLE
Fix issue #4424 - Pre-create check: "Hyper-V PowerShell Module is not available"

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -128,7 +128,7 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	stdout, err := cmdOut("(", "hyper-v\\Get-VM", d.MachineName, ").state")
+	stdout, err := cmdOut("(", "Hyper-V\\Get-VM", d.MachineName, ").state")
 	if err != nil {
 		return state.None, fmt.Errorf("Failed to find the VM status")
 	}
@@ -205,7 +205,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := cmd("hyper-v\\New-VM",
+	if err := cmd("Hyper-V\\New-VM",
 		d.MachineName,
 		"-Path", fmt.Sprintf("'%s'", d.ResolveStorePath(".")),
 		"-SwitchName", quote(virtualSwitch),
@@ -214,7 +214,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.CPU > 1 {
-		if err := cmd("hyper-v\\Set-VMProcessor",
+		if err := cmd("Hyper-V\\Set-VMProcessor",
 			d.MachineName,
 			"-Count", fmt.Sprintf("%d", d.CPU)); err != nil {
 			return err
@@ -222,7 +222,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.MacAddr != "" {
-		if err := cmd("hyper-v\\Set-VMNetworkAdapter",
+		if err := cmd("Hyper-V\\Set-VMNetworkAdapter",
 			"-VMName", d.MachineName,
 			"-StaticMacAddress", fmt.Sprintf("\"%s\"", d.MacAddr)); err != nil {
 			return err
@@ -230,7 +230,7 @@ func (d *Driver) Create() error {
 	}
 
 	if d.VLanID > 0 {
-		if err := cmd("hyper-v\\Set-VMNetworkAdapterVlan",
+		if err := cmd("Hyper-V\\Set-VMNetworkAdapterVlan",
 			"-VMName", d.MachineName,
 			"-Access",
 			"-VlanId", fmt.Sprintf("%d", d.VLanID)); err != nil {
@@ -238,13 +238,13 @@ func (d *Driver) Create() error {
 		}
 	}
 
-	if err := cmd("hyper-v\\Set-VMDvdDrive",
+	if err := cmd("Hyper-V\\Set-VMDvdDrive",
 		"-VMName", d.MachineName,
 		"-Path", quote(d.ResolveStorePath("boot2docker.iso"))); err != nil {
 		return err
 	}
 
-	if err := cmd("hyper-v\\Add-VMHardDiskDrive",
+	if err := cmd("Hyper-V\\Add-VMHardDiskDrive",
 		"-VMName", d.MachineName,
 		"-Path", quote(diskImage)); err != nil {
 		return err
@@ -257,7 +257,7 @@ func (d *Driver) Create() error {
 func (d *Driver) chooseVirtualSwitch() (string, error) {
 	if d.VSwitch == "" {
 		// Default to the first external switche and in the process avoid DockerNAT
-		stdout, err := cmdOut("(hyper-v\\Get-VMSwitch -SwitchType External).Name")
+		stdout, err := cmdOut("(Hyper-V\\Get-VMSwitch -SwitchType External).Name")
 		if err != nil {
 			return "", err
 		}
@@ -271,7 +271,7 @@ func (d *Driver) chooseVirtualSwitch() (string, error) {
 		return switches[0], nil
 	}
 
-	stdout, err := cmdOut("(hyper-v\\Get-VMSwitch).Name")
+	stdout, err := cmdOut("(Hyper-V\\Get-VMSwitch).Name")
 	if err != nil {
 		return "", err
 	}
@@ -327,7 +327,7 @@ func (d *Driver) waitStopped() error {
 
 // Start starts an host
 func (d *Driver) Start() error {
-	if err := cmd("hyper-v\\Start-VM", d.MachineName); err != nil {
+	if err := cmd("Hyper-V\\Start-VM", d.MachineName); err != nil {
 		return err
 	}
 
@@ -343,7 +343,7 @@ func (d *Driver) Start() error {
 
 // Stop stops an host
 func (d *Driver) Stop() error {
-	if err := cmd("hyper-v\\Stop-VM", d.MachineName); err != nil {
+	if err := cmd("Hyper-V\\Stop-VM", d.MachineName); err != nil {
 		return err
 	}
 
@@ -369,7 +369,7 @@ func (d *Driver) Remove() error {
 		}
 	}
 
-	return cmd("hyper-v\\Remove-VM", d.MachineName, "-Force")
+	return cmd("Hyper-V\\Remove-VM", d.MachineName, "-Force")
 }
 
 // Restart stops and starts an host
@@ -384,7 +384,7 @@ func (d *Driver) Restart() error {
 
 // Kill force stops an host
 func (d *Driver) Kill() error {
-	if err := cmd("hyper-v\\Stop-VM", d.MachineName, "-TurnOff"); err != nil {
+	if err := cmd("Hyper-V\\Stop-VM", d.MachineName, "-TurnOff"); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func (d *Driver) GetIP() (string, error) {
 		return "", drivers.ErrHostIsNotRunning
 	}
 
-	stdout, err := cmdOut("((", "hyper-v\\Get-VM", d.MachineName, ").networkadapters[0]).ipaddresses[0]")
+	stdout, err := cmdOut("((", "Hyper-V\\Get-VM", d.MachineName, ").networkadapters[0]).ipaddresses[0]")
 	if err != nil {
 		return "", err
 	}
@@ -440,7 +440,7 @@ func (d *Driver) generateDiskImage() (string, error) {
 	}
 
 	log.Infof("Creating VHD")
-	if err := cmd("hyper-v\\New-VHD", "-Path", quote(fixed), "-SizeBytes", fixedDiskSize, "-Fixed"); err != nil {
+	if err := cmd("Hyper-V\\New-VHD", "-Path", quote(fixed), "-SizeBytes", fixedDiskSize, "-Fixed"); err != nil {
 		return "", err
 	}
 
@@ -462,12 +462,12 @@ func (d *Driver) generateDiskImage() (string, error) {
 	}
 	file.Close()
 
-	if err := cmd("hyper-v\\Convert-VHD", "-Path", quote(fixed), "-DestinationPath", quote(diskImage), "-VHDType", "Dynamic", "-DeleteSource"); err != nil {
+	if err := cmd("Hyper-V\\Convert-VHD", "-Path", quote(fixed), "-DestinationPath", quote(diskImage), "-VHDType", "Dynamic", "-DeleteSource"); err != nil {
 		return "", err
 	}
 
 	if isWindowsAdmin {
-		if err := cmd("hyper-v\\Resize-VHD", "-Path", quote(diskImage), "-SizeBytes", toMb(d.DiskSize)); err != nil {
+		if err := cmd("Hyper-V\\Resize-VHD", "-Path", quote(diskImage), "-SizeBytes", toMb(d.DiskSize)); err != nil {
 			return "", err
 		}
 	}

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -55,7 +55,7 @@ func parseLines(stdout string) []string {
 }
 
 func hypervAvailable() error {
-	stdout, err := cmdOut("@(Get-Command hyper-v\\Get-VM).ModuleName")
+	stdout, err := cmdOut("@(Get-Module -ListAvailable hyper-v).Name | Get-Unique")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pull request #4404 adds the ability to run Hyper-V driver when VMware PowerCLI is installed, but it make the pre-create check for Hyper-V module fail.

This corrects the test as indicated as best solution on #4424.