### PR TITLE
ISSUE-4450 Added ServerAliveInterval among the default ssh options

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -68,14 +68,15 @@ const (
 var (
 	baseSSHArgs = []string{
 		"-F", "/dev/null",
-		"-o", "PasswordAuthentication=no",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 		"-o", "ConnectionAttempts=3", // retry 3 times if SSH connection fails
 		"-o", "ConnectTimeout=10", // timeout after 10 seconds
 		"-o", "ControlMaster=no", // disable ssh multiplexing
 		"-o", "ControlPath=none",
+		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
+		"-o", "PasswordAuthentication=no",
+		"-o", "ServerAliveInterval=60", // prevents connection to be dropped if command takes too long
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
 	}
 	defaultClientType = External
 )


### PR DESCRIPTION
and sorted them alphabetically to improve readability
This solves [issue #4450](https://github.com/docker/machine/issues/4450)