### PR TITLE
fix hyper-v pre check

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -61,7 +61,7 @@ func hypervAvailable() error {
 	}
 
 	resp := parseLines(stdout)
-	if resp[0] != "Hyper-V" {
+	if strings.ToLower(resp[0]) != "hyper-v" {
 		return ErrNotInstalled
 	}
 


### PR DESCRIPTION
 @(Get-Command hyper-v\Get-VM).ModuleName now returns "hyper-v".