### PR TITLE
drivers/amazonec2: adds flag to prevent mutating security groups

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -98,6 +98,15 @@ func TestConfigureSecurityGroupPermissionsDockerAndSsh(t *testing.T) {
 	assert.Empty(t, perms)
 }
 
+func TestConfigureSecurityGroupPermissionsSkipReadOnly(t *testing.T) {
+	driver := NewTestDriver()
+	driver.SecurityGroupReadOnly = true
+	perms, err := driver.configureSecurityGroupPermissions(securityGroup)
+
+	assert.Nil(t, err)
+	assert.Len(t, perms, 0)
+}
+
 func TestConfigureSecurityGroupPermissionsOpenPorts(t *testing.T) {
 	driver := NewTestDriver()
 	driver.OpenPorts = []string{"8888/tcp", "8080/udp", "9090"}


### PR DESCRIPTION
This adds a workaround for issues like #4093, #3810. The user can
set a boolean flag to prevent the driver from editing their security groups.
The default behavior is kept the same for compatibility reasons.


Signed-off-by: André Carvalho <asantostc@gmail.com>