### PR TITLE
fix invalid ignorance of bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.log
 *.iml
 .idea/
-./bin
+/bin/
 cover


### PR DESCRIPTION
`./bin` doest't take effect under latest git cli  after I compile this project and release bin directory. 