### PR TITLE
minor corrections to amazonec2 driver

### DIFF
--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -503,7 +503,7 @@ func (d *Driver) checkPrereqs() error {
 		}
 
 		if len(subnets.Subnets) == 0 {
-			return fmt.Errorf("unable to find a subnet in the zone: %s", regionZone)
+			return fmt.Errorf("unable to find a subnet that is both in the zone %s and belonging to VPC ID %s", regionZone, d.VpcId)
 		}
 
 		d.SubnetId = *subnets.Subnets[0].SubnetId

--- a/drivers/amazonec2/amazonec2.go
+++ b/drivers/amazonec2/amazonec2.go
@@ -1235,7 +1235,11 @@ func (d *Driver) getDefaultVPCId() (string, error) {
 
 	for _, attribute := range output.AccountAttributes {
 		if *attribute.AttributeName == "default-vpc" {
-			return *attribute.AttributeValues[0].AttributeValue, nil
+			value := *attribute.AttributeValues[0].AttributeValue
+			if value == "none" {
+				return "", errors.New("default-vpc is 'none'")
+			}
+			return value, nil
 		}
 	}
 

--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -227,6 +227,31 @@ func TestDefaultVPCIsMissing(t *testing.T) {
 	assert.Empty(t, vpc)
 }
 
+func TestDefaultVPCIsNone(t *testing.T) {
+	driver := NewDriver("machineFoo", "path")
+	attributeName := "default-vpc"
+	vpcName := "none"
+	driver.clientFactory = func() Ec2Client {
+		return &fakeEC2WithDescribe{
+			output: &ec2.DescribeAccountAttributesOutput{
+				AccountAttributes: []*ec2.AccountAttribute{
+					{
+						AttributeName: &attributeName,
+						AttributeValues: []*ec2.AccountAttributeValue{
+							{AttributeValue: &vpcName},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	vpc, err := driver.getDefaultVPCId()
+
+	assert.EqualError(t, err, "default-vpc is 'none'")
+	assert.Empty(t, vpc)
+}
+
 func TestGetRegionZoneForDefaultEndpoint(t *testing.T) {
 	driver := NewCustomTestDriver(&fakeEC2WithLogin{})
 	driver.awsCredentialsFactory = NewValidAwsCredentials


### PR DESCRIPTION
*  The existing code is written as if `Ec2Client.DescribeAccountAttributes` does not even list a `default-vpc` attribute if no default VPC has been set.  However, in my experience (I have no default VPC set), there is indeed a `default-vpc` attribute, with a value of `none`.  This change accommodates the `none` value, and results in a meaningful error message rather than an irrelevant one.  More details are in the commit message.
*  When failing to find a subnet, the existing code complains only of not finding one in the region/availability zone.  However, the `ec2.Filter` used to search for a subnet has two critera, one for the region and one for the VPC ID.  This change ammends the error message to also show the VPC ID used in the search.