### PR TITLE
Now able to specify a priority to Azure VMs

### DIFF
--- a/drivers/azure/azure.go
+++ b/drivers/azure/azure.go
@@ -41,6 +41,8 @@ const (
 	flAzureDockerPort      = "azure-docker-port"
 	flAzureLocation        = "azure-location"
 	flAzureSize            = "azure-size"
+	flAzurePriority        = "azure-priority"
+	flAzureEvictionPolicy  = "azure-evictionPolicy"
 	flAzureImage           = "azure-image"
 	flAzureVNet            = "azure-vnet"
 	flAzureSubnet          = "azure-subnet"
@@ -77,6 +79,8 @@ type Driver struct {
 	DockerPort      int
 	Location        string
 	Size            string
+	Priority        string
+	EvictionPolicy  string
 	Image           string
 	VirtualNetwork  string
 	SubnetName      string
@@ -156,6 +160,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Size for Azure Virtual Machine",
 			EnvVar: "AZURE_SIZE",
 			Value:  defaultAzureSize,
+		},
+		mcnflag.StringFlag{
+			Name:   flAzurePriority,
+			Usage:  "Priority for Azure Virtual Machine",
+			EnvVar: "AZURE_PRIORITY",
+		},
+		mcnflag.StringFlag{
+			Name:   flAzureEvictionPolicy,
+			Usage:  "Eviction Policy for Azure Virtual Machine",
+			EnvVar: "AZURE_EVICTION_POLICY",
 		},
 		mcnflag.StringFlag{
 			Name:   flAzureImage,
@@ -267,6 +281,8 @@ func (d *Driver) SetConfigFromFlags(fl drivers.DriverOptions) error {
 	}
 
 	// Optional flags or Flags of other types
+	d.Priority = fl.String(flAzurePriority)
+	d.EvictionPolicy = fl.String(flAzureEvictionPolicy)
 	d.Environment = fl.String(flAzureEnvironment)
 	d.OpenPorts = fl.StringSlice(flAzurePorts)
 	d.PrivateIPAddr = fl.String(flAzurePrivateIPAddr)
@@ -390,7 +406,7 @@ func (d *Driver) Create() error {
 	if err := d.generateSSHKey(d.ctx); err != nil {
 		return err
 	}
-	err = c.CreateVirtualMachine(d.ResourceGroup, d.naming().VM(), d.Location, d.Size, d.ctx.AvailabilitySetID,
+	err = c.CreateVirtualMachine(d.ResourceGroup, d.naming().VM(), d.Location, d.Size, d.Priority, d.EvictionPolicy, d.ctx.AvailabilitySetID,
 		d.ctx.NetworkInterfaceID, d.BaseDriver.SSHUser, d.ctx.SSHPublicKey, d.Image, customData, d.ctx.StorageAccount)
 	return err
 }

--- a/drivers/azure/azureutil/azureutil.go
+++ b/drivers/azure/azureutil/azureutil.go
@@ -496,14 +496,16 @@ func (a AzureClient) removeOSDiskBlob(resourceGroup, vmName, vhdURL string) erro
 	return err
 }
 
-func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, availabilitySetID, networkInterfaceID,
+func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, priority, evictionPolicy, availabilitySetID, networkInterfaceID,
 	username, sshPublicKey, imageName, customData string, storageAccount *storage.AccountProperties) error {
 	log.Info("Creating virtual machine.", logutil.Fields{
-		"name":     name,
-		"location": location,
-		"size":     size,
-		"username": username,
-		"osImage":  imageName,
+		"name":           name,
+		"location":       location,
+		"size":           size,
+		"username":       username,
+		"osImage":        imageName,
+		"priority":       priority,
+		"evictionPolicy": evictionPolicy,
 	})
 
 	img, err := parseImageName(imageName)
@@ -557,6 +559,8 @@ func (a AzureClient) CreateVirtualMachine(resourceGroup, name, location, size, a
 				},
 				OsProfile: osProfile,
 				StorageProfile: &compute.StorageProfile{
+					Priority:       to.StringPtr(priority),
+					EvictionPolicy: to.StringPtr(evictionPolicy),
 					ImageReference: &compute.ImageReference{
 						Publisher: to.StringPtr(img.publisher),
 						Offer:     to.StringPtr(img.offer),

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/models.go
@@ -19,10 +19,11 @@ package compute
 // regenerated.
 
 import (
+	"net/http"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
-	"net/http"
 )
 
 // CachingTypes enumerates the values for caching types.
@@ -611,6 +612,8 @@ type SSHPublicKey struct {
 
 // StorageProfile is describes a storage profile.
 type StorageProfile struct {
+	Priority       *string         `json:"priority,omitempty"`
+	EvictionPolicy *string         `json:"evictionPolicy,omitempty"`
 	ImageReference *ImageReference `json:"imageReference,omitempty"`
 	OsDisk         *OSDisk         `json:"osDisk,omitempty"`
 	DataDisks      *[]DataDisk     `json:"dataDisks,omitempty"`


### PR DESCRIPTION
Azure lets us create some [Low Priority VMs](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-low-priority) and this allows us to create them.

Signed-off-by: Jonathan Jayet <jayet.j@gmail.com>