### PR TITLE
Fix integrate tests of core commands cases

### DIFF
--- a/test/integration/core/core-commands.bats
+++ b/test/integration/core/core-commands.bats
@@ -8,7 +8,7 @@ use_shared_machine
   run machine inspect UNKNOWN
   echo ${output}
   [ "$status" -eq 1 ]
-  [[ ${lines[0]} =~ "Host does not exist: \"UNKNOWN\"" ]]
+  [[ ${lines[0]} =~ "Docker machine \"UNKNOWN\" does not exist" ]]
 }
 
 @test "$DRIVER: appears with ls" {
@@ -29,7 +29,7 @@ use_shared_machine
   run machine create -d $DRIVER $NAME
   echo ${output}
   [ "$status" -eq 1  ]
-  [[ ${lines[0]} == "Host already exists: \"$NAME\"" ]]
+  [[ ${lines[0]} == "Docker machine \"$NAME\" already exists" ]]
 }
 
 @test "$DRIVER: run busybox container" {


### PR DESCRIPTION
## Description

There are two test cases in `test/integration/core/core-commands.bats` will fail because wrong test result assertions.

## Related issue(s)

#4542 
