### PR TITLE
Fix wrong docker daemon process name of engine options tests

### DIFF
--- a/test/integration/core/engine-options.bats
+++ b/test/integration/core/engine-options.bats
@@ -28,7 +28,7 @@ use_disposable_machine
 
 @test "$DRIVER: test docker process envs" {
   # get pid of docker process, check process envs for set Environment Variable from above test
-  run machine ssh $NAME 'sudo cat /proc/$(pgrep -f "docker [d]aemon")/environ'
+  run machine ssh $NAME 'sudo cat /proc/$(pgrep -f $(which dockerd))/environ'
   echo ${output}
   [ $status -eq 0 ]
   [[ "${output}" =~ "TEST=VALUE" ]]


### PR DESCRIPTION
Signed-off-by: liusheng <liusheng@huawei.com>

## Description

In the integrate test "test docker process envs" in `test/integration/core/engine-options.bats`, there is an error of docker daemon process name, since now it has been changed to `dockerd` than the old `docker daemon`.

## Related issue(s)

#4544 
