### PR TITLE
Return error of command exec in SSH NativeClient

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -321,11 +321,14 @@ func (client *NativeClient) Shell(args ...string) error {
 		if err := session.Shell(); err != nil {
 			return err
 		}
-		session.Wait()
+		if err := session.Wait(); err != nil {
+			return err
+		}
 	} else {
-		session.Run(strings.Join(args, " "))
+		if err := session.Run(strings.Join(args, " ")); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description
Previously SSH NativeClient grasp error about session.Wait(),  session.Run() and always return nil indicating succeeded even if command execution on the destination was failed.
But the error of  session.Wait, Run is that definitely we need to feedback to user. so this PR changed the code to return error if session.Wait, Run failed in Shell func which is used by `docker-machine ssh`.

## Related issue(s)
https://github.com/docker/machine/issues/4549