### PR TITLE
Fix Hyper-V Administrator group member detection

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -85,7 +85,8 @@ func isAdministrator() (bool, error) {
 }
 
 func isHypervAdministrator() bool {
-	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("S-1-5-32-578")`)
+	stdout, err := cmdOut(`$sid = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-578")
+	@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole($sid)`)
 	if err != nil {
 		log.Debug(err)
 		return false


### PR DESCRIPTION
## Description

The current implementation failed to recognize if the user invoking the script is a member of the Hyper-V Administrators group. The IsInRole method expects a SID object, which needs to be generated first.

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
