### PR TITLE
Update "aufs" to "overlay2" in several places

### DIFF
--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -76,7 +76,7 @@ func (api *Client) NewHost(driverName string, rawDriver []byte) (*host.Host, err
 			},
 			EngineOptions: &engine.Options{
 				InstallURL:    drivers.DefaultEngineInstallURL,
-				StorageDriver: "aufs",
+				StorageDriver: "overlay2",
 				TLSVerify:     true,
 			},
 			SwarmOptions: &swarm.Options{

--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -232,7 +232,7 @@ func (provisioner *Boot2DockerProvisioner) Provision(swarmOptions swarm.Options,
 	swarmOptions.Env = engineOptions.Env
 
 	if provisioner.EngineOptions.StorageDriver == "" {
-		provisioner.EngineOptions.StorageDriver = "aufs"
+		provisioner.EngineOptions.StorageDriver = "overlay2"
 	}
 
 	if err = provisioner.SetHostname(provisioner.Driver.GetMachineName()); err != nil {

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -86,7 +86,7 @@ func (provisioner *DebianProvisioner) Provision(swarmOptions swarm.Options, auth
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/debian_test.go
+++ b/libmachine/provision/debian_test.go
@@ -14,7 +14,7 @@ func TestDebianDefaultStorageDriver(t *testing.T) {
 	p := NewDebianProvisioner(&fakedriver.Driver{}).(*DebianProvisioner)
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "aufs" {
-		t.Fatal("Default storage driver should be aufs")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }

--- a/libmachine/provision/ubuntu_systemd.go
+++ b/libmachine/provision/ubuntu_systemd.go
@@ -102,7 +102,7 @@ func (provisioner *UbuntuSystemdProvisioner) Provision(swarmOptions swarm.Option
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/ubuntu_systemd_test.go
+++ b/libmachine/provision/ubuntu_systemd_test.go
@@ -38,7 +38,7 @@ func TestUbuntuSystemdDefaultStorageDriver(t *testing.T) {
 	p := NewUbuntuSystemdProvisioner(&fakedriver.Driver{}).(*UbuntuSystemdProvisioner)
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "aufs" {
-		t.Fatal("Default storage driver should be aufs")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }

--- a/libmachine/provision/ubuntu_upstart.go
+++ b/libmachine/provision/ubuntu_upstart.go
@@ -118,7 +118,7 @@ func (provisioner *UbuntuProvisioner) Provision(swarmOptions swarm.Options, auth
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	storageDriver, err := decideStorageDriver(provisioner, "aufs", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/ubuntu_upstart_test.go
+++ b/libmachine/provision/ubuntu_upstart_test.go
@@ -38,7 +38,7 @@ func TestUbuntuDefaultStorageDriver(t *testing.T) {
 	p := NewUbuntuProvisioner(&fakedriver.Driver{}).(*UbuntuProvisioner)
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "aufs" {
-		t.Fatal("Default storage driver should be aufs")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -233,7 +233,7 @@ func decideStorageDriver(p Provisioner, defaultDriver, suppliedDriver string) (s
 		if remoteFilesystemType == "btrfs" {
 			bestSuitedDriver = "btrfs"
 		} else {
-			bestSuitedDriver = "aufs"
+			bestSuitedDriver = defaultDriver
 		}
 	}
 	return bestSuitedDriver, nil


### PR DESCRIPTION
## Description

Update the default storage driver from `aufs` to `overlay2`.

## Related issue(s)

- https://github.com/moby/moby/pull/34430

  - `overlay2` now preferred over `aufs` (since 17.09.0; https://github.com/docker/docker-ce/commit/479e9126c543937f0d16482d043b8003d8654a8f)

- https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-18060-ce-win70-2018-07-25
  > AUFS storage driver is deprecated in Docker Desktop and AUFS support will be removed in the next major release. You can continue with AUFS in Docker Desktop 18.06.x, but you will need to reset disk image (in Settings > Reset menu) before updating to the next major update.

- https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18060-ce-mac70-2018-07-25
  > AUFS storage driver is deprecated in Docker Desktop and AUFS support will be removed in the next major release. You can continue with AUFS in Docker Desktop 18.06.x, but you will need to reset disk image (in Preferences > Reset menu) before updating to the next major update.

- https://github.com/boot2docker/boot2docker/issues/1326

Given that `overlay2` has been preferred over `aufs` since 17.09.0 _and_ that the next major releases of Docker Desktop will no longer include AUFS support _and_ that AUFS has consistently been a source of pain around updating the kernel in boot2docker, this makes a lot of sense.

To be completely honest, I'm not sure I understand why Docker Machine is so explicit about choosing a graph driver instead of simply letting Docker autodetect/choose, but I'm sure there's context I'm missing (so this PR simply replaces `aufs` with `overlay2` in several places). :+1: :heart: