### PR TITLE
change default storage driver for redhat

### DIFF
--- a/libmachine/provision/redhat.go
+++ b/libmachine/provision/redhat.go
@@ -134,7 +134,7 @@ func (provisioner *RedHatProvisioner) Provision(swarmOptions swarm.Options, auth
 	swarmOptions.Env = engineOptions.Env
 
 	// set default storage driver for redhat
-	storageDriver, err := decideStorageDriver(provisioner, "devicemapper", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/redhat_test.go
+++ b/libmachine/provision/redhat_test.go
@@ -14,7 +14,7 @@ func TestRedHatDefaultStorageDriver(t *testing.T) {
 	p := NewRedHatProvisioner("", &fakedriver.Driver{})
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "devicemapper" {
-		t.Fatal("Default storage driver should be devicemapper")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }


### PR DESCRIPTION
## Description

Changes the default storagedriver for redhat based provisioner as documented offically:
https://docs.docker.com/install/linux/docker-ee/rhel/#architectures-and-storage-drivers

The change was quietly introduced in Feb'18 
https://github.com/docker/docker.github.io/commit/423a614511f3246dae07dbd69943014d801d3d1b#diff-90fcac2a0f7b7ffd643b9490af45ffbb

## Related issue(s)

no issues known or reported just from an experience.