### PR TITLE
openstack: don't fail when trying to delete non-existing keypair

### DIFF
--- a/drivers/openstack/openstack.go
+++ b/drivers/openstack/openstack.go
@@ -473,7 +473,15 @@ func (d *Driver) Remove() error {
 	if !d.ExistingKey {
 		log.Debug("deleting key pair...", map[string]string{"Name": d.KeyPairName})
 		if err := d.client.DeleteKeyPair(d, d.KeyPairName); err != nil {
-			return err
+			if gopherErr, ok := err.(*gophercloud.UnexpectedResponseCodeError); ok {
+				if gopherErr.Actual == http.StatusNotFound {
+					log.Warn("Keypair already deleted")
+				} else {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description

When deleting a machine and it's associated key-pair in the openstack driver the process will fail if the keypair does not exist.  If the vm instance is (already) gone only a warning is produced instead of an error. This PR applies the same logic to key-pairs.