### PR TITLE
Update path of golint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ the directory that contains your `src` directory, e.g.:
     $ export GOPATH=/home/yourname/work
     $ mkdir -p $GOPATH/src/github.com/docker
     $ cd $GOPATH/src/github.com/docker && git clone git@github.com:docker/machine.git
-    $ cd machine        
+    $ cd machine
 
 At this point, simply run:
 
@@ -66,7 +66,7 @@ to clean-up build results.
 ## Tests and validation
 
 We use the usual `go` tools for this, to run those commands you need at least the linter which you can
-install with `go get -u github.com/golang/lint/golint`
+install with `go get -u golang.org/x/lint/golint`
 
 To run basic validation (dco, fmt), and the project unit tests, call:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 sshfs \
         && rm -rf /var/lib/apt/lists/*
 
-RUN go get  github.com/golang/lint/golint \
+RUN go get  golang.org/x/lint/golint \
             github.com/mattn/goveralls \
             golang.org/x/tools/cover
 

--- a/mk/validate.mk
+++ b/mk/validate.mk
@@ -16,5 +16,5 @@ vet:
 
 lint:
 	$(if $(GOLINT), , \
-		$(error Please install golint: go get -u github.com/golang/lint/golint))
+		$(error Please install golint: go get -u golang.org/x/lint/golint))
 	@test -z "$$($(GOLINT) ./... 2>&1 | grep -v vendor/ | grep -v "cli/" | grep -v "amazonec2/" |grep -v "openstack/" |grep -v "softlayer/" | grep -v "should have comment" | tee /dev/stderr)"


### PR DESCRIPTION
The new path is golang.org/x/lint/golint.
See https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3.

This commit prevents the build from failing

Signed-off-by: Julien Barbot <jubarbot@cisco.com>
