### PR TITLE
drivers/openstack: added flag openstack-metadata

### DIFF
--- a/drivers/openstack/client.go
+++ b/drivers/openstack/client.go
@@ -69,6 +69,7 @@ func (c *GenericClient) CreateInstance(d *Driver) (string, error) {
 		SecurityGroups:   d.SecurityGroups,
 		AvailabilityZone: d.AvailabilityZone,
 		ConfigDrive:      d.ConfigDrive,
+		Metadata:         d.GetMetadata(),
 	}
 	if d.NetworkId != "" {
 		serverOpts.Networks = []servers.Network{


### PR DESCRIPTION
Signed-off-by: xinau <felix.ehrenpfort@codecentric.cloud>

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

This PR adds a new flag for the openstack driver.
`--openstack-metadata` allows the user to add instance metadata to a created docker-machine.
The flag is useful if you use the openstack metadata service (which can be useful for things like service discovery).
It works exactly the same as the `--amazonec2-tags` flag.
