### PR TITLE
drivers/softlayer: don't set the request method again

### DIFF
--- a/drivers/softlayer/softlayer.go
+++ b/drivers/softlayer/softlayer.go
@@ -114,7 +114,6 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 	}
 
 	req.SetBasicAuth(c.User, c.ApiKey)
-	req.Method = method
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
It would be set by the request returned by http.NewRequest.

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
