### PR TITLE
Removing "dgageot" handle form "Core maintainers"

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,7 +11,6 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-			"dgageot",
 			"jeanlaurent",
 		]
 


### PR DESCRIPTION
Removing "dgageot" handle form "Core maintainers" since it's description doesn't exist anymore (see 60613ca470897ae9cfe375d8905383695a2781fd)

Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>