### PR TITLE
Introduce flag for verbatim user-data

### DIFF
--- a/drivers/exoscale/exoscale.go
+++ b/drivers/exoscale/exoscale.go
@@ -40,6 +40,7 @@ type Driver struct {
 	PublicKey        string
 	UserDataFile     string
 	UserData         []byte
+	UserDataString   string
 	ID               string `json:"Id"`
 }
 
@@ -123,6 +124,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "exoscale-userdata",
 			Usage:  "path to file with cloud-init user-data",
 		},
+		mcnflag.StringFlag{
+			EnvVar: "EXOSCALE_USERDATA_STRING",
+			Name:   "exoscale-userdata-string",
+			Usage:  "verbatim user-data string",
+		},
 		mcnflag.StringSliceFlag{
 			EnvVar: "EXOSCALE_AFFINITY_GROUP",
 			Name:   "exoscale-affinity-group",
@@ -200,6 +206,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHUser = flags.String("exoscale-ssh-user")
 	d.SSHKey = flags.String("exoscale-ssh-key")
 	d.UserDataFile = flags.String("exoscale-userdata")
+	d.UserDataString = flags.String("exoscale-userdata-string")
 	d.UserData = []byte(defaultCloudInit)
 	d.SetSwarmConfigFromFlags(flags)
 
@@ -705,6 +712,11 @@ func (d *Driver) getCloudInit() ([]byte, error) {
 	var err error
 	if d.UserDataFile != "" {
 		d.UserData, err = ioutil.ReadFile(d.UserDataFile)
+	}
+
+	if d.UserDataString != "" {
+		d.UserData = []byte(d.UserDataString)
+		err = nil
 	}
 
 	return d.UserData, err


### PR DESCRIPTION
This enables the configuration of user-data directly from a string.

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

Introduce a flag for the Exoscale driver to configure user-data in a string instead in a file.

## Related issue(s)

This would make some integrations a lot easier. E.g.: https://github.com/rancher/rancher/issues/17760
