### PR TITLE
Fix broken IsVTXDisabled detection on AMD CPU

### DIFF
--- a/drivers/virtualbox/vtx_intel.go
+++ b/drivers/virtualbox/vtx_intel.go
@@ -6,7 +6,7 @@ import "github.com/intel-go/cpuid"
 
 // IsVTXDisabled checks if VT-x is disabled in the CPU.
 func (d *Driver) IsVTXDisabled() bool {
-	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasFeature(cpuid.SVM) {
+	if cpuid.HasFeature(cpuid.VMX) || cpuid.HasExtraFeature(cpuid.SVM) {
 		return false
 	}
 


### PR DESCRIPTION
VMX is in FeatureNames, but SVM is in ExtraFeatureNames
This meant that detection *always* failed for SVM (AMD)

Thanks to user @hilbertxia


## Description

The new library approach to cpuid introduced in 5a8ce1ae43de21b0b875189293267164f37acf5e was broken on AMD CPU (SVM).
Unfortunately it also disabled all tests that were in the previous file-based version 850e2646a6979e9c484297ce1828684800d66406

## Related issue(s)

Closes #4669
