### PR TITLE
Bugfixes to the SCP command in Windows + Add trusted CA command

### DIFF
--- a/commands/add_ca_certificate.go
+++ b/commands/add_ca_certificate.go
@@ -30,7 +30,7 @@ func cmdAddCACertificate(c CommandLine, api libmachine.API) error {
 		return errFirstArgIsNotPEMFile
 	}
 
-	target, err := targetHostWithOffset(c, api, 1)
+	target, err := targetHost(c, api, 1)
 	if err != nil {
 		return err
 	}

--- a/commands/add_ca_certificate.go
+++ b/commands/add_ca_certificate.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/machine/commands/commandstest"
+
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/log"
+)
+
+const (
+	trustedCertsFolder = "/var/lib/boot2docker/certs"
+)
+
+var (
+	errFirstArgIsNotPEMFile = errors.New("The first argument should the path of a file with extention '.pem'")
+)
+
+func cmdAddCACertificate(c CommandLine, api libmachine.API) error {
+	args := c.Args()
+	if len(args) == 0 {
+		c.ShowHelp()
+		return errWrongNumberArguments
+	}
+
+	if len(args) <= 2 && !strings.Contains(args[0], ".pem") {
+		return errFirstArgIsNotPEMFile
+	}
+
+	target, err := targetHostWithOffset(c, api, 1)
+	if err != nil {
+		return err
+	}
+
+	err = createFolder(target, api)
+	if err != nil {
+		return err
+	}
+
+	src := args[0]
+	targetPath := fmt.Sprintf("%s:%s", target, trustedCertsFolder)
+
+	err = uploadCertificate(src, targetPath, api)
+	if err != nil {
+		return err
+	}
+
+	if c.Bool("restart") {
+		if err := runAction("restart", c, api); err != nil {
+			return err
+		}
+	} else {
+		log.Info("In order for the change to be effective, you need to restart the docker-machine with:\n%s", "docker-machine restart")
+	}
+
+	return nil
+}
+
+func createFolder(targetHost string, api libmachine.API) error {
+	commandLine := &commandstest.FakeCommandLine{
+		CliArgs: strings.Split(fmt.Sprintf("sudo mkdir -p %s", trustedCertsFolder), " "),
+	}
+
+	log.Debug(commandLine)
+	err := cmdSSH(commandLine, api)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func uploadCertificate(src, targetPath string, api libmachine.API) error {
+	commandLine := &commandstest.FakeCommandLine{
+		CliArgs: []string{
+			src,
+			targetPath,
+		},
+	}
+	log.Debug(commandLine)
+	err := cmdScp(commandLine, api)
+	if err != nil {
+		return err
+	}
+	log.Info("Certificate uploaded")
+	return nil
+}

--- a/commands/add_ca_certificate_test.go
+++ b/commands/add_ca_certificate_test.go
@@ -1,0 +1,177 @@
+package commands
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/docker/machine/commands/commandstest"
+	"github.com/docker/machine/drivers/fakedriver"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/libmachinetest"
+	"github.com/docker/machine/libmachine/state"
+	"github.com/docker/machine/libmachine/swarm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdAddCACertificate(t *testing.T) {
+	testCases := []struct {
+		commandLine        CommandLine
+		api                libmachine.API
+		expectedErr        error
+		sshClientCreator   host.SSHClientCreator
+		expectedSSHShell   []string
+		assertOnScpCommand func(cmd exec.Cmd) bool
+	}{
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name:   "foo",
+						Driver: &fakedriver.Driver{},
+						HostOptions: &host.Options{
+							EngineOptions: &engine.Options{},
+							AuthOptions:   &auth.Options{},
+							SwarmOptions:  &swarm.Options{},
+						},
+					},
+				},
+			},
+			expectedErr:      errWrongNumberArguments,
+			sshClientCreator: &FakeSSHClientCreator{},
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"somefile.txt"},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name:   "foo",
+						Driver: &fakedriver.Driver{},
+						HostOptions: &host.Options{
+							EngineOptions: &engine.Options{},
+							AuthOptions:   &auth.Options{},
+							SwarmOptions:  &swarm.Options{},
+						},
+					},
+				},
+			},
+			expectedErr:      errFirstArgIsNotPEMFile,
+			sshClientCreator: &FakeSSHClientCreator{},
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"somefile.pem"},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name:   "foo",
+						Driver: &fakedriver.Driver{},
+						HostOptions: &host.Options{
+							EngineOptions: &engine.Options{},
+							AuthOptions:   &auth.Options{},
+							SwarmOptions:  &swarm.Options{},
+						},
+					},
+				},
+			},
+			expectedErr:      ErrNoDefault,
+			sshClientCreator: &FakeSSHClientCreator{},
+		},
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"somefile.pem", "default"},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name:   "default",
+						Driver: &fakedriver.Driver{},
+						HostOptions: &host.Options{
+							EngineOptions: &engine.Options{},
+							AuthOptions:   &auth.Options{},
+							SwarmOptions:  &swarm.Options{},
+						},
+					},
+				},
+			},
+			expectedErr:      errStateInvalidForSSH{"default"},
+			sshClientCreator: &FakeSSHClientCreator{},
+		},
+		// This one can timeout hence the comment
+		// {
+		// 	commandLine: &commandstest.FakeCommandLine{
+		// 		CliArgs: []string{"somefile.pem", "default"},
+		// 		LocalFlags: &commandstest.FakeFlagger{
+		// 			Data: map[string]interface{}{
+		// 				"restart": true,
+		// 			},
+		// 		},
+		// 	},
+		// 	api: &libmachinetest.FakeAPI{
+		// 		Hosts: []*host.Host{
+		// 			{
+		// 				Name: "default",
+		// 				Driver: &fakedriver.Driver{
+		// 					MockState: state.Running,
+		// 				},
+		// 				HostOptions: &host.Options{
+		// 					EngineOptions: &engine.Options{},
+		// 					AuthOptions:   &auth.Options{},
+		// 					SwarmOptions:  &swarm.Options{},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	expectedErr:      errStateInvalidForSSH{"default"},
+		// 	sshClientCreator: &FakeSSHClientCreator{},
+		// },
+		{
+			commandLine: &commandstest.FakeCommandLine{
+				CliArgs: []string{"somefile.pem", "default"},
+			},
+			api: &libmachinetest.FakeAPI{
+				Hosts: []*host.Host{
+					{
+						Name: "default",
+						Driver: &fakedriver.Driver{
+							MockState: state.Running,
+						},
+						HostOptions: &host.Options{
+							EngineOptions: &engine.Options{},
+							AuthOptions:   &auth.Options{},
+							SwarmOptions:  &swarm.Options{},
+						},
+					},
+				},
+			},
+			expectedErr:      nil,
+			sshClientCreator: &FakeSSHClientCreator{},
+			assertOnScpCommand: func(cmd exec.Cmd) bool {
+				lastTwoArgs := cmd.Args[len(cmd.Args)-2:]
+				assert.Equal(t, "somefile.pem", lastTwoArgs[0])
+				assert.Equal(t, "@:/var/lib/boot2docker/certs/", lastTwoArgs[1])
+				return true
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		host.SetSSHClientCreator(tc.sshClientCreator)
+
+		SetCommandRunner(&MockCommandRunner{
+			assertion: tc.assertOnScpCommand,
+		})
+		err := cmdAddCACertificate(tc.commandLine, tc.api)
+
+		assert.Equal(t, tc.expectedErr, err)
+
+	}
+}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -76,28 +76,9 @@ func (c *contextCommandLine) Application() *cli.App {
 }
 
 // targetHost returns a specific host name if one is indicated by the first CLI
-// arg, or the default host name if no host is specified.
-func targetHost(c CommandLine, api libmachine.API) (string, error) {
-	if len(c.Args()) == 0 {
-		defaultExists, err := api.Exists(defaultMachineName)
-		if err != nil {
-			return "", fmt.Errorf("Error checking if host %q exists: %s", defaultMachineName, err)
-		}
-
-		if defaultExists {
-			return defaultMachineName, nil
-		}
-
-		return "", ErrNoDefault
-	}
-
-	return c.Args()[0], nil
-}
-
-// targetHostWithOffset returns a specific host name if one is indicated by the first CLI
 // arg, or the default host name if no host is specified. It ignores a number of arguments
 // equal to the value of `argOffset`.
-func targetHostWithOffset(c CommandLine, api libmachine.API, argOffset int) (string, error) {
+func targetHost(c CommandLine, api libmachine.API, argOffset int) (string, error) {
 	if len(c.Args()) == 0+argOffset {
 		defaultExists, err := api.Exists(defaultMachineName)
 		if err != nil {
@@ -123,7 +104,7 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 	// machine if it exists.  This allows short form commands such as
 	// 'docker-machine stop' for convenience.
 	if len(c.Args()) == 0 {
-		target, err := targetHost(c, api)
+		target, err := targetHost(c, api, 0)
 		if err != nil {
 			return err
 		}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -79,7 +79,7 @@ func (c *contextCommandLine) Application() *cli.App {
 // arg, or the default host name if no host is specified. It ignores a number of arguments
 // equal to the value of `argOffset`.
 func targetHost(c CommandLine, api libmachine.API, argOffset int) (string, error) {
-	if len(c.Args()) == 0+argOffset {
+	if len(c.Args()) == argOffset {
 		defaultExists, err := api.Exists(defaultMachineName)
 		if err != nil {
 			return "", fmt.Errorf("Error checking if host %q exists: %s", defaultMachineName, err)
@@ -92,7 +92,7 @@ func targetHost(c CommandLine, api libmachine.API, argOffset int) (string, error
 		return "", ErrNoDefault
 	}
 
-	return c.Args()[0+argOffset], nil
+	return c.Args()[argOffset], nil
 }
 
 func runAction(actionName string, c CommandLine, api libmachine.API) error {

--- a/commands/config.go
+++ b/commands/config.go
@@ -16,7 +16,7 @@ func cmdConfig(c CommandLine, api libmachine.API) error {
 	// being run (it is intended to be run in a subshell)
 	log.SetOutWriter(os.Stderr)
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return err
 	}

--- a/commands/env.go
+++ b/commands/env.go
@@ -74,7 +74,7 @@ func shellCfgSet(c CommandLine, api libmachine.API) (*ShellConfig, error) {
 		return nil, ErrExpectedOneMachine
 	}
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -26,7 +26,7 @@ func cmdInspect(c CommandLine, api libmachine.API) error {
 		return ErrExpectedOneMachine
 	}
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return err
 	}

--- a/commands/scp.go
+++ b/commands/scp.go
@@ -20,6 +20,7 @@ var (
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=quiet", // suppress "Warning: Permanently added '[localhost]:2022' (ECDSA) to the list of known hosts."
 	}
+	stdCommandRunner CommandRunner = &CommandRunnerWithStdIo{}
 )
 
 // HostInfo gives the mandatory information to connect to a host.
@@ -187,7 +188,16 @@ func generateLocationArg(hostInfo HostInfo, user, path string) (string, error) {
 	return location, nil
 }
 
-func runCmdWithStdIo(cmd exec.Cmd) error {
+func SetCommandRunner(cmdRunner CommandRunner) {
+	stdCommandRunner = cmdRunner
+}
+
+type CommandRunner interface {
+	run(cmd exec.Cmd) error
+}
+type CommandRunnerWithStdIo struct{}
+
+func (r *CommandRunnerWithStdIo) run(cmd exec.Cmd) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/commands/scp_test.go
+++ b/commands/scp_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -176,4 +177,21 @@ func TestGetScpCmdWithDelta(t *testing.T) {
 
 	assert.Equal(t, expectedCmd, cmd)
 	assert.NoError(t, err)
+}
+
+type cmdAssert func(exec.Cmd) bool
+type MockCommandRunner struct {
+	command   exec.Cmd
+	assertion cmdAssert
+}
+
+func (r *MockCommandRunner) run(cmd exec.Cmd) error {
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if r.assertion != nil {
+		r.assertion(cmd)
+	}
+
+	return nil
 }

--- a/commands/scp_unix.go
+++ b/commands/scp_unix.go
@@ -23,5 +23,5 @@ func cmdScp(c CommandLine, api libmachine.API) error {
 		return err
 	}
 
-	return runCmdWithStdIo(*cmd)
+	return stdCommandRunner.run(*cmd)
 }

--- a/commands/scp_windows.go
+++ b/commands/scp_windows.go
@@ -28,7 +28,13 @@ func cmdScp(c CommandLine, api libmachine.API) error {
 	// Default argument escaping is not valid for scp.exe with quoted arguments, so we do it ourselves
 	// see golang/go#15566
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.CmdLine = fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	cmd.SysProcAttr.CmdLine = fmt.Sprintf("%s %s", cmd.Path, strings.Join(tailArgs(cmd.Args), " "))
+	return stdCommandRunner.run(*cmd)
+}
 
-	return runCmdWithStdIo(*cmd)
+func tailArgs(a []string) []string {
+	if len(a) >= 2 {
+		return []string(a)[1:]
+	}
+	return []string{}
 }

--- a/commands/scp_windows.go
+++ b/commands/scp_windows.go
@@ -28,7 +28,7 @@ func cmdScp(c CommandLine, api libmachine.API) error {
 	// Default argument escaping is not valid for scp.exe with quoted arguments, so we do it ourselves
 	// see golang/go#15566
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.CmdLine = fmt.Sprintf("%s %s", cmd.Path, strings.Join(tailArgs(cmd.Args), " "))
+	cmd.SysProcAttr.CmdLine = fmt.Sprintf("\"%s\" %s", cmd.Path, strings.Join(tailArgs(cmd.Args), " "))
 	return stdCommandRunner.run(*cmd)
 }
 

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -23,7 +23,7 @@ func cmdSSH(c CommandLine, api libmachine.API) error {
 		return nil
 	}
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return err
 	}

--- a/commands/status.go
+++ b/commands/status.go
@@ -11,7 +11,7 @@ func cmdStatus(c CommandLine, api libmachine.API) error {
 		return ErrExpectedOneMachine
 	}
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return err
 	}

--- a/commands/url.go
+++ b/commands/url.go
@@ -11,7 +11,7 @@ func cmdURL(c CommandLine, api libmachine.API) error {
 		return ErrExpectedOneMachine
 	}
 
-	target, err := targetHost(c, api)
+	target, err := targetHost(c, api, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
 <!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description
Hi there,

I understand the status of the project, however, this PR addresses issues with the SCP command in Windows (#4444, #4498)

Also, it adds a new feature that allows to upload and trust CA Certificates as described in #1799
Test coverage is almost 100% on that.

Best regards

## Related issue(s)
- #4444
- #4498
- #1799
<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
