### PR TITLE
Fix executable name duplicated in arguments

### DIFF
--- a/commands/scp_windows.go
+++ b/commands/scp_windows.go
@@ -28,7 +28,7 @@ func cmdScp(c CommandLine, api libmachine.API) error {
 	// Default argument escaping is not valid for scp.exe with quoted arguments, so we do it ourselves
 	// see golang/go#15566
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.CmdLine = fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	cmd.SysProcAttr.CmdLine = fmt.Sprintf("\"%s\" %s", cmd.Path, strings.Join(cmd.Args[1:], " "))
 
 	return runCmdWithStdIo(*cmd)
 }


### PR DESCRIPTION
Signed-off-by: Alexandre V <alex@vautier.biz>

## Description

Remove the executable path from the arguments

## Related issue(s)

https://github.com/docker/machine/issues/4444
