### PR TITLE
set storage driver to overlay2 for archlinux

### DIFF
--- a/libmachine/provision/arch.go
+++ b/libmachine/provision/arch.go
@@ -94,7 +94,7 @@ func (provisioner *ArchProvisioner) Provision(swarmOptions swarm.Options, authOp
 	provisioner.EngineOptions = engineOptions
 	swarmOptions.Env = engineOptions.Env
 
-	storageDriver, err := decideStorageDriver(provisioner, "overlay", engineOptions.StorageDriver)
+	storageDriver, err := decideStorageDriver(provisioner, "overlay2", engineOptions.StorageDriver)
 	if err != nil {
 		return err
 	}

--- a/libmachine/provision/arch_test.go
+++ b/libmachine/provision/arch_test.go
@@ -14,7 +14,7 @@ func TestArchDefaultStorageDriver(t *testing.T) {
 	p := NewArchProvisioner(&fakedriver.Driver{}).(*ArchProvisioner)
 	p.SSHCommander = provisiontest.NewFakeSSHCommander(provisiontest.FakeSSHCommanderOptions{})
 	p.Provision(swarm.Options{}, auth.Options{}, engine.Options{})
-	if p.EngineOptions.StorageDriver != "overlay" {
-		t.Fatal("Default storage driver should be overlay")
+	if p.EngineOptions.StorageDriver != "overlay2" {
+		t.Fatal("Default storage driver should be overlay2")
 	}
 }


### PR DESCRIPTION
## Description
set default storage driver to overlay2 for archlinux provisioner
