### PR TITLE
Update golang 1.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0
+FROM golang:1.12.9
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
                 openssh-client \


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

## Description

For macOS Catalina we have to compile `docker-machine` with a newer version of Golang to codesign and notarize all binaries.

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
