### PR TITLE
OpenStack driver: define multiple networks and select floating point network

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,6 @@ before_script:
     expire_in: 1 week
   tags:
   - docker
-  - privileged
 
 .build_validate: &build_validate
   <<: *build_base

--- a/drivers/openstack/openstack_test.go
+++ b/drivers/openstack/openstack_test.go
@@ -27,3 +27,95 @@ func TestSetConfigFromFlags(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, checkFlags.InvalidFlags)
 }
+
+func TestSetSingleNetworkId(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"openstack-auth-url":  "http://url",
+			"openstack-username":  "user",
+			"openstack-password":  "pwd",
+			"openstack-tenant-id": "ID",
+			"openstack-flavor-id": "ID",
+			"openstack-image-id":  "ID",
+			"openstack-net-id":    "ID",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+}
+
+func TestSetSingleNetworkName(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"openstack-auth-url":  "http://url",
+			"openstack-username":  "user",
+			"openstack-password":  "pwd",
+			"openstack-tenant-id": "ID",
+			"openstack-flavor-id": "ID",
+			"openstack-image-id":  "ID",
+			"openstack-net-name":  "ID",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+}
+
+func TestSetMultipleNetworkIds(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"openstack-auth-url":  "http://url",
+			"openstack-username":  "user",
+			"openstack-password":  "pwd",
+			"openstack-tenant-id": "ID",
+			"openstack-flavor-id": "ID",
+			"openstack-image-id":  "ID",
+			//TODO: multivalue test
+			//"openstack-net-id":    "ID",
+			"openstack-net-id": "ID2",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+}
+
+func TestSetMultipleNetworkNames(t *testing.T) {
+	driver := NewDriver("default", "path")
+
+	checkFlags := &drivers.CheckDriverOptions{
+		FlagsValues: map[string]interface{}{
+			"openstack-auth-url":  "http://url",
+			"openstack-username":  "user",
+			"openstack-password":  "pwd",
+			"openstack-tenant-id": "ID",
+			"openstack-flavor-id": "ID",
+			"openstack-image-id":  "ID",
+			"openstack-net-name":  "ID",
+			//TODO: multivalue test
+			//"openstack-net-name":  "ID2",
+		},
+		CreateFlags: driver.GetCreateFlags(),
+	}
+
+	err := driver.SetConfigFromFlags(checkFlags)
+
+	assert.NoError(t, err)
+	assert.Empty(t, checkFlags.InvalidFlags)
+}

--- a/drivers/openstack/openstack_test.go
+++ b/drivers/openstack/openstack_test.go
@@ -77,15 +77,14 @@ func TestSetMultipleNetworkIds(t *testing.T) {
 
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
-			"openstack-auth-url":  "http://url",
-			"openstack-username":  "user",
-			"openstack-password":  "pwd",
-			"openstack-tenant-id": "ID",
-			"openstack-flavor-id": "ID",
-			"openstack-image-id":  "ID",
-			//TODO: multivalue test
-			//"openstack-net-id":    "ID",
-			"openstack-net-id": "ID2",
+			"openstack-auth-url":          "http://url",
+			"openstack-username":          "user",
+			"openstack-password":          "pwd",
+			"openstack-tenant-id":         "ID",
+			"openstack-flavor-id":         "ID",
+			"openstack-image-id":          "ID",
+			"openstack-net-id":            []string{"ID", "ID2"},
+			"openstack-floatingip-net-id": "ID2",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}
@@ -101,15 +100,14 @@ func TestSetMultipleNetworkNames(t *testing.T) {
 
 	checkFlags := &drivers.CheckDriverOptions{
 		FlagsValues: map[string]interface{}{
-			"openstack-auth-url":  "http://url",
-			"openstack-username":  "user",
-			"openstack-password":  "pwd",
-			"openstack-tenant-id": "ID",
-			"openstack-flavor-id": "ID",
-			"openstack-image-id":  "ID",
-			"openstack-net-name":  "ID",
-			//TODO: multivalue test
-			//"openstack-net-name":  "ID2",
+			"openstack-auth-url":            "http://url",
+			"openstack-username":            "user",
+			"openstack-password":            "pwd",
+			"openstack-tenant-id":           "ID",
+			"openstack-flavor-id":           "ID",
+			"openstack-image-id":            "ID",
+			"openstack-net-name":            []string{"ID", "ID2"},
+			"openstack-floatingip-net-name": "ID2",
 		},
 		CreateFlags: driver.GetCreateFlags(),
 	}


### PR DESCRIPTION
## Description

This PR adds support for OpenStack environment where access to multiple networks is required. Our use case is to use Docker Machine to auto scale GitLab runners in environment where runners are controlled from internal network and runner VM has access to other network(s).

## Related issue(s)
