### PR TITLE
Fix for #2989

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -85,7 +85,7 @@ func isAdministrator() (bool, error) {
 }
 
 func isHypervAdministrator() bool {
-	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("S-1-5-32-578")`)
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(([System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-578")))`)
 	if err != nil {
 		log.Debug(err)
 		return false


### PR DESCRIPTION

## Description
A user member of "Hyper-V Administrators" group should be able to create a VM without also being member of "Administrators" group. 

For using an SID as parameter - which is better because of potential i18n issue with role name - "isInRole()" expect a "System.Security.Principal.SecurityIdentifier" object instead of a "String". 

That's because of this error that isHypervAdministrator() always return false and and consequently  "Administrator" role is requested.

## Related issue(s)

#2989
