### PR TITLE
Rackspace driver fix

### DIFF
--- a/drivers/rackspace/client.go
+++ b/drivers/rackspace/client.go
@@ -53,16 +53,6 @@ func (c *Client) Authenticate(d *openstack.Driver) error {
 	return nil
 }
 
-// StartInstance is unfortunately not supported on Rackspace at this time.
-func (c *Client) StartInstance(d *openstack.Driver) error {
-	return unsupportedOpErr("start")
-}
-
-// StopInstance is unfortunately not support on Rackspace at this time.
-func (c *Client) StopInstance(d *openstack.Driver) error {
-	return unsupportedOpErr("stop")
-}
-
 // GetInstanceIPAddresses can be short-circuited with the server's AccessIPv4Addr on Rackspace.
 func (c *Client) GetInstanceIPAddresses(d *openstack.Driver) ([]openstack.IPAddress, error) {
 	server, err := c.GetServerDetail(d)

--- a/drivers/rackspace/rackspace.go
+++ b/drivers/rackspace/rackspace.go
@@ -57,7 +57,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "OS_IMAGE_ID",
 			Name:   "rackspace-image-id",
-			Usage:  "Rackspace image ID. Default: Ubuntu 16.04 LTS (Xenial Xerus) (PVHVM)",
+			Usage:  "Rackspace image ID. Default: Ubuntu 18.04 LTS (Bionic Beaver) (Cloud)",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "OS_FLAVOR_ID",
@@ -144,10 +144,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 
 	if d.ImageId == "" {
-		// Default to the Ubuntu 16.04 image.
+		// Default to the Ubuntu 18.04 image.
 		// This is done here, rather than in the option registration, to keep the default value
 		// from making "machine create --help" ugly.
-		d.ImageId = "821ba5f4-712d-4ec8-9c65-a3fa4bc500f9"
+		d.ImageId = "498bfa38-d288-4e37-b975-a4acb77f8557"
 	}
 
 	if d.EndpointType != "publicURL" && d.EndpointType != "adminURL" && d.EndpointType != "internalURL" {


### PR DESCRIPTION
Rackspace has deprecated the previously used default image ID which causes Docker Machine's created by default to fail. Switch to a supported image ID based on Ubuntu 18.04 to resolve this. Removed code which blocked the start/stop action on Rackspace's Public Cloud as these actions work fine.