### PR TITLE
Fix shell detection for Powershell core

### DIFF
--- a/libmachine/shell/shell_windows.go
+++ b/libmachine/shell/shell_windows.go
@@ -56,7 +56,7 @@ func Detect() (string, error) {
 		if err != nil {
 			return "cmd", err // defaulting to cmd
 		}
-		if strings.Contains(strings.ToLower(shell), "powershell") {
+		if strings.Contains(strings.ToLower(shell), "powershell") || strings.Contains(strings.ToLower(shell), "pwsh") {
 			return "powershell", nil
 		} else if strings.Contains(strings.ToLower(shell), "cmd") {
 			return "cmd", nil
@@ -65,7 +65,7 @@ func Detect() (string, error) {
 			if err != nil {
 				return "cmd", err // defaulting to cmd
 			}
-			if strings.Contains(strings.ToLower(shell), "powershell") {
+			if strings.Contains(strings.ToLower(shell), "powershell") || strings.Contains(strings.ToLower(shell), "pwsh") {
 				return "powershell", nil
 			} else if strings.Contains(strings.ToLower(shell), "cmd") {
 				return "cmd", nil


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

This PR fixes shell detection for newer versions of powershell. The executable for Powershell Core is pwsh.exe as opposed to powershell.exe for previous versions.

## Related issue(s)

#4789 
