### PR TITLE
Ensure that OSes that use ID_LIKE=coreos, the CoreOSProvisioneer is indicated as compatible.

### DIFF
--- a/libmachine/provision/coreos.go
+++ b/libmachine/provision/coreos.go
@@ -43,6 +43,10 @@ func (provisioner *CoreOSProvisioner) String() string {
 	return "coreOS"
 }
 
+func (provisioner *CoreOSProvisioner) CompatibleWithHost() bool {
+	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID || provisioner.OsReleaseInfo.IDLike == provisioner.OsReleaseID
+}
+
 func (provisioner *CoreOSProvisioner) SetHostname(hostname string) error {
 	log.Debugf("SetHostname: %s", hostname)
 


### PR DESCRIPTION
## Description

For OSes that indicate ID_LIKE=coreos (for example [flatcar](https://github.com/flatcar-linux/Flatcar)), the CoreOSProvisioner would return false. This simple one line fix fixes that. 
This is inspired by the intended raspian fix #4790 