### PR TITLE
SUSE: remove outdated firewall config

### DIFF
--- a/libmachine/provision/suse.go
+++ b/libmachine/provision/suse.go
@@ -158,14 +158,6 @@ func (provisioner *SUSEProvisioner) Provision(swarmOptions swarm.Options, authOp
 		return err
 	}
 
-	// Is yast2 firewall installed?
-	if _, installed := provisioner.SSHCommand("rpm -q yast2-firewall"); installed == nil {
-		// Open the firewall port required by docker
-		if _, err := provisioner.SSHCommand("sudo -E /sbin/yast2 firewall services add ipprotocol=tcp tcpport=2376 zone=EXT"); err != nil {
-			return err
-		}
-	}
-
 	log.Debug("Starting systemd docker service")
 	if err := provisioner.Service("docker", serviceaction.Start); err != nil {
 		return err


### PR DESCRIPTION
The latest versions of yast-firewall cannot be used from command-line, moreover firewall configuration isn't supported by other provisioners. It looks safer to delete this part of the code than fix it for new SUSE releases

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->
