### PR TITLE
Detect PowerShell Core

### DIFF
--- a/libmachine/shell/shell_windows.go
+++ b/libmachine/shell/shell_windows.go
@@ -56,7 +56,7 @@ func Detect() (string, error) {
 		if err != nil {
 			return "cmd", err // defaulting to cmd
 		}
-		if strings.Contains(strings.ToLower(shell), "powershell") {
+		if strings.Contains(strings.ToLower(shell), "powershell") || strings.Contains(strings.ToLower(shell), "pwsh") {
 			return "powershell", nil
 		} else if strings.Contains(strings.ToLower(shell), "cmd") {
 			return "cmd", nil
@@ -65,7 +65,7 @@ func Detect() (string, error) {
 			if err != nil {
 				return "cmd", err // defaulting to cmd
 			}
-			if strings.Contains(strings.ToLower(shell), "powershell") {
+			if strings.Contains(strings.ToLower(shell), "powershell") || strings.Contains(strings.ToLower(shell), "pwsh") {
 				return "powershell", nil
 			} else if strings.Contains(strings.ToLower(shell), "cmd") {
 				return "cmd", nil


### PR DESCRIPTION
## Description

Fixes shell detection (for the `env` command) not detecting PowerShell Core.

## Related issue(s)

Fixes #4826