### PR TITLE
Fix 'docker-machine upgrade' for Debian 9 and Debian 10

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -51,7 +51,7 @@ func (provisioner *DebianProvisioner) Package(name string, action pkgaction.Pack
 
 	switch name {
 	case "docker":
-		name = "docker-engine"
+		name = "docker-ce"
 	}
 
 	if updateMetadata {


### PR DESCRIPTION
## Description

On Debian 9, the Docker package name changed from `docker-engine` to `docker-ce`.  `docker-machine upgrade` fails on machines running Debian 9 or higher because `apt-get` doesn't find `docker-engine`:

```
am@localhost:~$ docker-machine upgrade my-docker-machine
Waiting for SSH to be available...
Detecting the provisioner...
Upgrading docker...
Error running "DEBIAN_FRONTEND=noninteractive sudo -E apt-get install -y  docker-engine": ssh command error:
command : DEBIAN_FRONTEND=noninteractive sudo -E apt-get install -y  docker-engine
err     : exit status 100
output  : Reading package lists...
Building dependency tree...
Reading state information...
Package docker-engine is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  docker-ce

E: Package 'docker-engine' has no installation candidate
```

This commit simply replaces `docker-engine` with `docker-ce` on `debian.go`. This breaks compatibility for Debian 8, but that's probably not a problem because Debian 8 is EOL since 30th june 2020.
