### PR TITLE
Update region.go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.9
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /go/src/github.com/mqhub/machine
     steps:
       - checkout
 

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -30,6 +30,7 @@ var regionDetails map[string]*region = map[string]*region{
 	"us-west-1":       {"ami-264c4646"},
 	"us-west-2":       {"ami-78a22900"},
 	"us-gov-west-1":   {"ami-2561ea44"},
+	"us-gov-east-1":   {"ami-7609e007"}, // Note: this is 20200814
 	"custom-endpoint": {""},
 }
 


### PR DESCRIPTION
Add AWS region us-gov-east-1

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->

amazonec2 driver does not currently support aws region us-gov-east-1, it gives error "Invalid region specified". I added the region to the list to fix the problem.

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
