### PR TITLE
Added eu-south-1 region (Milano)  in amazonec2 driver

### DIFF
--- a/drivers/amazonec2/amazonec2_test.go
+++ b/drivers/amazonec2/amazonec2_test.go
@@ -179,7 +179,7 @@ func TestConfigureSecurityGroupPermissionsWithSwarm(t *testing.T) {
 }
 
 func TestValidateAwsRegionValid(t *testing.T) {
-	regions := []string{"eu-west-1", "eu-central-1"}
+	regions := []string{"eu-west-1", "eu-central-1", "eu-south-1"}
 
 	for _, region := range regions {
 		validatedRegion, err := validateAwsRegion(region)

--- a/drivers/amazonec2/region.go
+++ b/drivers/amazonec2/region.go
@@ -21,6 +21,7 @@ var regionDetails map[string]*region = map[string]*region{
 	"cn-northwest-1":  {"ami-fd0e1a9f"}, // Note: this is 20180126
 	"eu-north-1":      {"ami-017ff17f"},
 	"eu-central-1":    {"ami-bc4925d3"},
+	"eu-south-1":      {"ami-bc4925d3"},
 	"eu-west-1":       {"ami-0b541372"},
 	"eu-west-2":       {"ami-ff46a298"},
 	"eu-west-3":       {"ami-9465d3e9"},


### PR DESCRIPTION


## Description

docker-machine did not support aws 'eu-south-1' region.
I simply added the ability to create a machine in this region using the same "ami" as in the eu-central-1 region.

