### PR TITLE
Update amazonec2.go to support IO1, IO2, and GP3 volume types. Update…

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.4.10"
+  version = "1.36.3"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
… version of AWS SDK. Signed-off-by: Chris Pollard <chris.pollard@rocketmail.com>

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

There are a number of AWS EBS volume types that support changes to IOPs and now throughput. This allows us to set them from docker machine configurations. 

## Related issue(s)
 
