### PR TITLE
Correctly detect powershell when ssh to windows machine.

### DIFF
--- a/libmachine/shell/shell_windows.go
+++ b/libmachine/shell/shell_windows.go
@@ -80,5 +80,7 @@ func Detect() (string, error) {
 		return "fish", nil
 	}
 
+	shell = strings.TrimSuffix(shell, filepath.Ext(shell))
+
 	return filepath.Base(shell), nil
 }

--- a/libmachine/shell/shell_windows_test.go
+++ b/libmachine/shell/shell_windows_test.go
@@ -17,6 +17,16 @@ func TestDetect(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDetectOnSSH(t *testing.T) {
+	defer func(shell string) { os.Setenv("SHELL", shell) }(os.Getenv("SHELL"))
+	os.Setenv("SHELL", "c:\\windows\\system32\\windowspowershell\\v1.0\\powershell.exe")
+
+	shell, err := Detect()
+
+	assert.Equal(t, "powershell", shell)
+	assert.NoError(t, err)
+}
+
 func TestGetNameAndItsPpidOfCurrent(t *testing.T) {
 	shell, shellppid, err := getNameAndItsPpid(os.Getpid())
 


### PR DESCRIPTION
## Description
When ssh to a windows machine, the `Detect()` will return *powershell.exe* rather than *powershell*. It is due to the fact that the `os.getenv()` returns the absolute path to powershell rather then an empty string, which causes this issue.
```
fmt.Printf("%v\n",os.Getenv("SHELL"))
c:\windows\system32\windowspowershell\v1.0\powershell.exe
```

## Related issue(s)

- https://github.com/kubernetes/minikube/issues/10626
- https://github.com/kubernetes/minikube/issues/10627

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->