### PR TITLE
Ensure that for OSes that specify ID_LIKE=debian, the DebianProvisioner is indicated as compatible (for ex: Raspbian)

### DIFF
--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -33,6 +33,10 @@ func (provisioner *DebianProvisioner) String() string {
 	return "debian"
 }
 
+func (provisioner *DebianProvisioner) CompatibleWithHost() bool {
+	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID || provisioner.OsReleaseInfo.IDLike == provisioner.OsReleaseID
+}
+
 func (provisioner *DebianProvisioner) Package(name string, action pkgaction.PackageAction) error {
 	var packageAction string
 


### PR DESCRIPTION
For OSes that indicate ID_LIKE=debian (for example Raspbian), the DebianProvisioner would return false. This simple one line fix fixes that. This is taken directly from the arch provisioner that works correctly for all Arch-like distros.