### PR TITLE
Add Github Actions workflow to automatically build on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+on:
+  release:
+    types: [edited, published]
+    branches:
+      - main
+      - master
+      - feature-*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        uses: textbook/git-checkout-submodule-action@master
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      
+      - name: Build
+        env:
+          USE_CONTAINER: true
+        run: |
+          make build
+        
+      - name: Publish binaries  
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: 'bin/docker-machine'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,11 @@ jobs:
           USE_CONTAINER: true
         run: |
           make build
+          zip docker-machine.zip bin/docker-machine
         
       - name: Publish binaries  
         uses: skx/github-action-publish-binaries@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: 'bin/docker-machine'
+          args: 'docker-machine.zip'

--- a/libmachine/provision/debian.go
+++ b/libmachine/provision/debian.go
@@ -33,6 +33,10 @@ func (provisioner *DebianProvisioner) String() string {
 	return "debian"
 }
 
+func (provisioner *DebianProvisioner) CompatibleWithHost() bool {
+	return provisioner.OsReleaseInfo.ID == provisioner.OsReleaseID || provisioner.OsReleaseInfo.IDLike == provisioner.OsReleaseID
+}
+
 func (provisioner *DebianProvisioner) Package(name string, action pkgaction.PackageAction) error {
 	var packageAction string
 


### PR DESCRIPTION
release.yml automatically builds docker-machine and attaches it to any release when created or edited. This actions runs on master, main and any feature branches.