### PR TITLE
Fix Powershell spawned from Command Prompt being mis-detected

### DIFF
--- a/libmachine/shell/shell_windows.go
+++ b/libmachine/shell/shell_windows.go
@@ -51,7 +51,9 @@ func getNameAndItsPpid(pid int) (exefile string, parentid int, err error) {
 func Detect() (string, error) {
 	shell := os.Getenv("SHELL")
 
-	if shell == "" {
+	// if you spawn a Powershell instance from CMD, sometimes the SHELL environment variable still points to CMD in the Powershell instance
+	// so if SHELL is pointing to CMD, let's do extra work to get the correct shell
+	if shell == "" || filepath.Base(shell) == "cmd.exe" {
 		shell, shellppid, err := getNameAndItsPpid(os.Getppid())
 		if err != nil {
 			return "cmd", err // defaulting to cmd


### PR DESCRIPTION
## Description

Fixes #4891

Issue:
> For CI testing Windows in minikube we SSH into a Windows machine, which starts us in Command Prompt. We then run powershell to change the terminal to Powershell. However, within the Powershell terminal the SHELL environment variable is still pointing to Command Prompt (c:\windows\system32\cmd.exe). So when running the exported function shell.Detect here it returns cmd instead of the expected powershell.

If `cmd` is detected via `SHELL` environment variable, do the the more in-depth shell detection.

## Related issue(s)

#4891
