### PR TITLE
Restart after changing configuration

### DIFF
--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -185,7 +185,7 @@ func ConfigureAuth(p Provisioner) error {
 		return err
 	}
 
-	if err := p.Service("docker", serviceaction.Start); err != nil {
+	if err := p.Service("docker", serviceaction.Restart); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

After docker-machine installs Docker engine to OS using systemd, Docker is automatically started, so after changing configuration (adding 10-machine.conf) starting service which is already started has no sense, it needs to be restarted.
